### PR TITLE
test(web): add auth callback middleware coverage

### DIFF
--- a/ui/middleware.test.ts
+++ b/ui/middleware.test.ts
@@ -46,6 +46,12 @@ describe("middleware auth flow", () => {
     expect(result.headers.get("location")).toBeNull();
   });
 
+  it("keeps auth callback route accessible for authenticated users", async () => {
+    const result = await middleware(createRequest("/auth/callback"));
+
+    expect(result.headers.get("location")).toBeNull();
+  });
+
   it("still redirects authenticated users away from sign-in", async () => {
     const result = await middleware(createRequest("/sign-in"));
     const redirectLocation = result.headers.get("location");

--- a/ui/middleware.test.ts
+++ b/ui/middleware.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetUser, mockSingle, mockUpdateSession } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),


### PR DESCRIPTION
Closes #1

## Summary
- add middleware regression coverage for authenticated /auth/callback access
- keep auth completion route exemptions aligned with /reset-password behavior
- strengthen the published starter against auth callback regressions

## Changes
| File | Change |
|------|--------|
| \ | Added authenticated /auth/callback no-redirect assertion |

## Test Plan
- [x] Manually verified the patch matches the local hardening change
- [x] Change is intentionally scoped to middleware regression coverage
- [x] No unrelated product scope added
