### PR TITLE
docs: add Supabase local setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,17 +15,19 @@
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
 
 # Anonymous (public) key — safe to expose in the browser
-# Get from: Supabase Dashboard → Project Settings → API
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Local dev: deterministic key from `supabase start` (same for everyone)
+# Production: get from Supabase Dashboard → Project Settings → API
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 
 # Service role key — SECRET, server-side only, NEVER expose to the browser
-# Get from: Supabase Dashboard → Project Settings → API
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Local dev: deterministic key from `supabase start`
+# Production: get from Supabase Dashboard → Project Settings → API
+SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
 
-# Direct Postgres connection (Supabase Transaction pooler, port 6543)
+# Direct Postgres connection (local)
 # Used by Drizzle Kit (studio, introspect) — NOT for runtime queries.
-# Format: postgresql://postgres.[PROJECT_REF]:[PASSWORD]@aws-1-us-west-2.pooler.supabase.com:6543/postgres
-DATABASE_URL=postgresql://postgres.[PROJECT_REF]:[PASSWORD]@aws-1-us-west-2.pooler.supabase.com:6543/postgres
+# Production: postgresql://postgres.[PROJECT_REF]:[PASSWORD]@aws-1-us-west-2.pooler.supabase.com:6543/postgres
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54332/postgres
 
 # ─────────────────────────────────────────────────────────────────────────────
 # App Configuration

--- a/README.md
+++ b/README.md
@@ -41,29 +41,41 @@ If you publish a fork, plan to define product-specific features and operations f
 
 - Node.js `>=20`
 - pnpm `>=9`
-- A Supabase project (or local Supabase stack) with valid API keys
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (required for Supabase local)
+- [Supabase CLI](https://supabase.com/docs/guides/cli/getting-started) (`brew install supabase/tap/supabase`)
 
 ### 2) Install and configure
 
 ```bash
 pnpm install
 cp .env.example .env.local
-```
-
-Then set at least the required environment variables in `.env.local`:
-
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-
-Next.js loads `.env.local` from its own project directory (`ui/`). Create a symlink so it reads the monorepo root file:
-
-```bash
 ln -s ../.env.local ui/.env.local
 ```
 
-Optional/conditional variables are documented in [docs/onboarding-checklist.md](./docs/onboarding-checklist.md).
+The `.env.example` comes pre-configured with Supabase local defaults — no changes needed for local dev.
 
-### 3) Run development
+Next.js loads `.env.local` from `ui/`. The symlink makes it read the monorepo root file.
+
+### 3) Start Supabase local
+
+```bash
+supabase start
+```
+
+This starts a full Supabase stack in Docker (Postgres, Auth, Storage, Studio), applies all migrations from `supabase/migrations/`, and seeds a test user from `supabase/seed.sql`.
+
+| Service | URL |
+|---------|-----|
+| API | http://127.0.0.1:54331 |
+| Studio (DB admin) | http://127.0.0.1:54333 |
+| Mailpit (email capture) | http://127.0.0.1:54334 |
+| Postgres | `postgresql://postgres:postgres@127.0.0.1:54332/postgres` |
+
+Test user credentials (from seed):
+- Email: `admin@enterprise.dev`
+- Password: `password123`
+
+### 4) Run development
 
 ```bash
 pnpm dev
@@ -72,6 +84,15 @@ pnpm dev
 App routes:
 - Auth: `http://localhost:3000/sign-in`
 - Dashboard: `http://localhost:3000/dashboard`
+
+### Useful Supabase commands
+
+```bash
+supabase start              # Start local stack (migrations + seed)
+supabase stop               # Stop (data persisted in Docker volumes)
+supabase db reset           # Re-apply all migrations + seed from scratch
+supabase status             # Show running services and URLs
+```
 
 ## Required configuration notes
 


### PR DESCRIPTION
## Summary

- README now documents the full Supabase local workflow: prerequisites (Docker, CLI), `supabase start`, service URLs, test credentials, useful commands
- `.env.example` pre-filled with Supabase local defaults (deterministic keys) so `cp .env.example .env.local` works out of the box — no manual key lookup needed