### PR TITLE
fix(release): restore parseable release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release v${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
@@ -19,7 +18,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
-      "component": ""
+      "component": "enterprise-platform"
     }
   }
 }


### PR DESCRIPTION
Closes #8

## Summary
- remove the custom release PR title pattern that prevented release-please from reparsing merged release PRs
- keep the root component explicit so manifest releases stay aligned with the package identity
- pair this config fix with the manually backfilled `v1.1.0` GitHub release so future release runs are unblocked

## Changes
| File | Change |
|------|--------|
| `release-please-config.json` | Removed invalid custom group PR title pattern and kept explicit root component alignment |

## Test Plan
- [x] Verified PR #5 had been merged but no `v1.1.0` tag/release existed
- [x] Backfilled GitHub release `v1.1.0` on merge commit `5734a89968a79c4852d9cfcb68f9749db6b35557`
- [x] Confirmed `gh release list` now shows `v1.1.0`
- [x] Re-ran the release workflow and confirmed the remaining blocker is config/PR parsing, which this change addresses on `main`

## Notes
- The repository was in a half-released state: `main` already said `1.1.0`, but GitHub had no tag/release.
- This PR fixes the configuration side; the historical missing release has already been backfilled manually.