### PR TITLE
fix(ci): grant issues write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Closes #11

## Summary
- add the missing `issues: write` permission to the Release workflow
- allow Release Please to manage `autorelease:*` labels on release PRs
- prevent future half-released states where release PRs merge but remain stuck in `autorelease: pending`

## Changes
| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Added `issues: write` to the workflow permissions alongside `contents: write` and `pull-requests: write` |

## Why this is the likely root cause
The official `release-please-action` examples include `issues: write` because release lifecycle labels are managed through the Issues API. In this repository, the repeated failure mode was:
- release PR merges
- version/changelog files update
- GitHub release/tag is not finalized automatically
- PR remains labeled `autorelease: pending`

That behavior is consistent with insufficient permission to update labels.

## Test Plan
- [x] Confirmed repeated operational failure on `v1.1.0` and `v1.1.1`
- [x] Recovered both releases manually by creating the release and switching labels to `autorelease: tagged`
- [x] Verified current release workflow config lacked `issues: write`
- [x] Updated workflow to match the documented permission set for Release Please

## Notes
- This PR fixes the workflow permissions permanently.
- It does not modify application code.