### PR TITLE
feat: add resources reference module with full CRUD, RLS, and E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,8 @@ jobs:
     env:
       # Supabase local dev defaults (deterministic keys from `supabase start`)
       # These are NOT secrets — they are the same for every local Supabase instance.
-      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54331
+      # Ports must match supabase/config.toml (55331+)
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:55331
       NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -59,7 +60,7 @@ jobs:
         run: |
           echo "Waiting for Supabase..."
           for i in $(seq 1 30); do
-            if curl -s http://127.0.0.1:54331/auth/v1/health > /dev/null 2>&1; then
+            if curl -s http://127.0.0.1:55331/auth/v1/health > /dev/null 2>&1; then
               echo "Supabase Auth is ready!"
               break
             fi

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ This starts a full Supabase stack in Docker (Postgres, Auth, Storage, Studio), a
 
 | Service | URL |
 |---------|-----|
-| API | http://127.0.0.1:54331 |
-| Studio (DB admin) | http://127.0.0.1:54333 |
-| Inbucket (email capture) | http://127.0.0.1:54334 |
-| Postgres | `postgresql://postgres:postgres@127.0.0.1:54332/postgres` |
+| API | http://127.0.0.1:55331 |
+| Studio (DB admin) | http://127.0.0.1:55333 |
+| Inbucket (email capture) | http://127.0.0.1:55334 |
+| Postgres | `postgresql://postgres:postgres@127.0.0.1:55332/postgres` |
 
 Test user credentials (from seed):
 - Email: `admin@enterprise.dev`

--- a/docs/example-prd.md
+++ b/docs/example-prd.md
@@ -1,0 +1,179 @@
+# PRD — Example CRM
+
+## 1. Context
+
+InmoAutos currently operates with multiple disconnected tools:
+
+- **WhatsApp** — conversations
+- **WordPress / Houzez** — website
+- **Spreadsheets & Google Drive** — tracking
+- **Human memory**
+
+This generates disorder, loss of context, and missed commercial opportunities.
+
+## 2. Problem
+
+The main problem is not a lack of leads, but a lack of **structured follow-up**.
+
+Today, leads:
+
+- Enter through multiple channels
+- Lose continuity
+- Have no traceability
+- Are not correctly linked to properties
+
+This directly impacts:
+
+- Fewer closings
+- More operational time
+- Low team efficiency
+
+## 3. Objective
+
+Build a platform that enables:
+
+- Centralizing leads and conversations
+- Structuring commercial follow-up
+- Linking contacts with properties
+- Automating tasks and actions
+- Preventing loss of context
+
+## 4. Value Proposition
+
+**Never lose a lead or commercial context**, organizing the entire operation in a single system connected to WhatsApp.
+
+## 5. Users
+
+| Role | Responsibilities |
+|------|-----------------|
+| **Owner** | Global business vision, metrics and control |
+| **Admin** | System maintenance, data loading and control |
+| **Seller** | Lead follow-up, daily system usage |
+
+> **Primary user: Seller**
+
+## 6. MVP Scope
+
+### Included
+
+- WhatsApp integration (capture)
+- Automatic contact creation
+- Commercial pipeline (kanban)
+- Basic inventory
+- AI agent (summary + suggestions)
+
+### Not Included
+
+- WhatsApp-like chat inside the CRM
+- Complex automations
+- Advanced reporting
+- Financial modules
+
+## 7. User Journey
+
+### Entry
+
+1. Lead arrives via WhatsApp
+2. System captures the message
+3. Contact is created or linked
+
+### Conversion
+
+1. Opportunity is created
+2. Property is linked
+3. Responsible person is assigned
+
+### Follow-up
+
+1. Agent suggests actions
+2. Tasks are created
+3. Pipeline advances
+
+## 8. Core Features
+
+### 8.1 WhatsApp (Entry)
+
+- Automatic message capture
+- Contact identification
+
+### 8.2 AI Agent
+
+- Conversation summary
+- Data extraction
+- Action suggestions
+
+### 8.3 Kanban
+
+- Opportunity visualization
+- Fixed commercial stages
+
+### 8.4 Inventory
+
+- Property management
+- Commercial statuses
+
+### 8.5 Tasks
+
+- Manual and automatic follow-up
+
+## 9. Non-Functional Requirements
+
+- **Multi-tenant** (per company)
+- **Realtime**
+- **Mobile-first**
+- **Low effort to use**
+- **Integration with existing tools**
+
+## 10. Success Metrics
+
+### Business
+
+- Fewer lost leads
+- More property visits
+- More closings
+
+### Product
+
+- Kanban usage
+- Completed tasks
+- System adoption
+
+## 11. Roadmap
+
+### MVP (1 week)
+
+- WhatsApp capture
+- Contacts
+- Kanban
+- Basic inventory
+- Simple agent
+
+### V2
+
+- Automations
+- Dashboard
+
+### V3
+
+- Full SaaS
+- Billing
+
+## 12. Risks
+
+- Attempting to replace WhatsApp
+- Over-building
+- Low adoption
+- Inconsistent data
+
+## 13. Definition of Success
+
+The product will be successful if:
+
+- The team uses it **by choice**
+- It improves follow-up
+- It reduces lead loss
+- It simplifies daily operations
+
+## 14. In One Sentence
+
+> InmoAutos is a CRM that transforms conversations into opportunities and structured follow-up, without replacing WhatsApp, but leveraging it intelligently.

--- a/docs/example-rfc.md
+++ b/docs/example-rfc.md
@@ -1,0 +1,235 @@
+# RFC — Example CRM Architecture
+
+## 1. Summary
+
+This document defines how the InmoAutos CRM system will be built from a technical perspective.
+
+The system is based on a modern, modular, and scalable architecture, focused on:
+
+- WhatsApp integration
+- AI agent processing
+- Centralized database
+- Realtime experience
+
+## 2. Technical Objective
+
+Design an architecture that enables:
+
+- Capturing messages from WhatsApp
+- Structuring commercial context
+- Managing opportunities
+- Administering inventory
+- Automating follow-up
+- Scaling to multiple companies (SaaS)
+
+## 3. General Architecture
+
+### Main Flow
+
+```
+WhatsApp → Webhook → Backend → AI Agent → Database → Frontend
+```
+
+```
+┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ WhatsApp │───▶│ Webhook  │───▶│ Backend  │───▶│ AI Agent │
+│ (YCloud) │    │ Endpoint │    │ (API)    │    │ Service  │
+└──────────┘    └──────────┘    └──────────┘    └────┬─────┘
+                                                     │
+                                                     ▼
+┌──────────┐    ┌──────────┐    ┌──────────────────────────┐
+│ Frontend │◀───│ Realtime │◀───│   Supabase (PostgreSQL)  │
+│ (Next.js)│    │ Updates  │    │   Multi-tenant DB        │
+└──────────┘    └──────────┘    └──────────────────────────┘
+```
+
+## 4. Components
+
+### Frontend
+
+- **Next.js** (App Router)
+- Mobile-first design
+- Realtime data consumption
+- shadcn/ui component library
+
+### Backend
+
+- Lightweight API (Node.js / Next.js Server Actions)
+- Webhook handling
+- Business logic in service layer
+
+### Database
+
+- **Supabase** (PostgreSQL)
+- Multi-tenant by workspace
+- Realtime subscriptions
+- Row Level Security (RLS)
+
+### AI Agent
+
+- Independent service
+- Message processing
+- Context generation
+
+### WhatsApp Integration
+
+- **YCloud** as WhatsApp Business API provider
+- Event reception via webhooks
+
+## 5. Data Flow
+
+### Incoming Message
+
+1. WhatsApp sends webhook event
+2. Backend receives event
+3. Contact is identified (or created)
+4. Context is constructed
+5. Message is sent to AI agent
+6. Agent processes and generates summary
+7. Result is saved to database
+8. Frontend updates in realtime
+
+## 6. Data Model
+
+### Core Entities
+
+| Entity | Description |
+|--------|-------------|
+| `workspaces` | Tenant isolation unit (one per company) |
+| `users` | System users with roles (owner, admin, seller) |
+| `contacts` | Leads and clients captured from WhatsApp |
+| `opportunities` | Commercial deals linked to contacts and properties |
+| `properties` | Real estate inventory items |
+| `conversation_summaries` | AI-generated summaries of WhatsApp conversations |
+| `tasks` | Follow-up actions (manual and automated) |
+
+> **Central entity: `opportunities`** — everything connects through deals.
+
+### Entity Relationships
+
+```
+workspaces
+  ├── users
+  ├── contacts
+  │     └── opportunities
+  │           ├── properties (linked)
+  │           ├── tasks
+  │           └── conversation_summaries
+  └── properties
+```
+
+## 7. Multi-Tenant Strategy
+
+- Each company has its own **workspace**
+- All data is isolated by `workspace_id`
+- Access controlled by **roles** (owner, admin, seller)
+- RLS policies enforce tenant isolation at the database level
+
+## 8. Realtime
+
+Used for:
+
+- **Kanban board** — opportunity stage changes
+- **Tasks** — creation and status updates
+- **Activity feed** — recent actions
+
+Technology: **Supabase Realtime** (PostgreSQL changes broadcast)
+
+## 9. AI Agent
+
+### Functions
+
+- Summarize conversations
+- Extract structured data (name, intent, property interest)
+- Classify lead intention
+- Suggest next actions
+
+### Boundaries
+
+- Does NOT replace WhatsApp
+- Does NOT make critical decisions without human control
+- Operates as a **suggestion engine**, not an autonomous actor
+
+## 10. Integrations
+
+### Critical (MVP)
+
+| Integration | Provider | Purpose |
+|-------------|----------|---------|
+| WhatsApp | YCloud | Message capture and webhook events |
+
+### Future
+
+| Integration | Purpose |
+|-------------|---------|
+| Google Drive | Property list import |
+| Google Calendar | Visit scheduling |
+
+> **Note:** WordPress/Houzez integration is explicitly excluded — WordPress will be deprecated.
+
+## 11. Technical Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Monorepo | Shared types, contracts, and UI across packages |
+| Supabase as primary backend | PostgreSQL + Auth + Realtime + RLS in one platform |
+| AI agent as separate service | Decoupled processing, independent scaling |
+| No WhatsApp rebuild | CRM augments WhatsApp, does not replace it |
+| Next.js App Router | Server Components, Server Actions, streaming |
+| Mobile-first | Primary users (sellers) work from phones |
+
+## 12. Trade-offs
+
+### Prioritized
+
+- Speed of delivery
+- Simplicity
+- Focus on core value
+
+### Sacrificed
+
+- Advanced initial features
+- Complex customization
+- Comprehensive reporting (deferred to V2)
+
+## 13. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Poor WhatsApp integration | Use proven provider (YCloud), test webhook flow early |
+| AI agent errors | Agent suggests only, human confirms actions |
+| Inconsistent data | Strong validation at contracts layer, RLS enforcement |
+| Low adoption | Mobile-first, minimal friction, augment existing workflow |
+
+## 14. Scalability
+
+- Multi-tenant architecture prepared from day one
+- Modular architecture (packages isolate concerns)
+- AI agent decoupled (can scale independently)
+- Supabase handles connection pooling and realtime at scale
+
+## 15. Implementation Plan
+
+### Phase 1 — MVP
+
+- [ ] WhatsApp webhook integration (YCloud)
+- [ ] Contact management (auto-creation from messages)
+- [ ] Opportunity pipeline (kanban)
+- [ ] Basic property inventory
+- [ ] Simple AI agent (summarize + suggest)
+
+### Phase 2
+
+- [ ] Automations (task creation, reminders)
+- [ ] AI improvements (better classification, richer context)
+- [ ] Dashboard with metrics
+
+### Phase 3
+
+- [ ] Full SaaS (onboarding, self-service)
+- [ ] Billing and subscription management
+- [ ] Advanced reporting
+
+## 16. In One Sentence
+
+> The RFC defines how to build a system that converts WhatsApp messages into structured commercial context through AI and centralizes it in an operational, scalable CRM.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -98,7 +98,7 @@ npx supabase db push
 supabase start
 
 # Use local URL in .env.local
-NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:55331
 # Anon key from `supabase status`
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 ```
@@ -110,7 +110,7 @@ Use this setup to run deterministic auth unit/E2E tests locally.
 ### Required local services
 
 - Supabase local stack (`supabase start`)
-- Inbucket email capture (`http://localhost:54334` from `supabase/config.toml`)
+- Inbucket email capture (`http://localhost:55334` from `supabase/config.toml`)
 
 ### Local auth assumptions
 
@@ -133,10 +133,10 @@ Auth reset tests use:
 - `DELETE /api/v1/mailbox/{mailbox}`
 
 Default base URL:
-- `http://localhost:54334`
+- `http://localhost:55334`
 
 Override with:
 
 ```bash
-INBUCKET_URL=http://localhost:54334
+INBUCKET_URL=http://localhost:55334
 ```

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -87,7 +87,7 @@ sequenceDiagram
   - Confirm users exist in Auth and `profiles` rows have expected roles.
 
 - **Password reset E2E times out waiting for email**
-  - Verify Inbucket is running on `http://localhost:54334`.
+  - Verify Inbucket is running on `http://localhost:55334`.
   - Optionally set `INBUCKET_URL` when using a non-default local endpoint.
   - Ensure mailbox is not rate-limited; tests rotate between `reset@enterprise.dev` and `reset2@enterprise.dev` on retries.
 

--- a/packages/contracts/src/__tests__/resources.test.ts
+++ b/packages/contracts/src/__tests__/resources.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  createResourceSchema,
+  resourceQuerySchema,
+  updateResourceSchema,
+} from "../schemas/resources";
+
+describe("createResourceSchema", () => {
+  const validComplete = {
+    title: "Payroll document",
+    type: "document",
+    status: "active",
+    description: "Monthly payroll summary",
+    metadata: { owner: "finance", pii: false },
+    imageUrls: ["https://example.com/doc-1.png", "https://example.com/doc-2.png"],
+  } as const;
+
+  it("accepts a valid complete payload", () => {
+    const result = createResourceSchema.safeParse(validComplete);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a minimal payload (only required fields)", () => {
+    const result = createResourceSchema.safeParse({ title: "Basic resource", type: "product" });
+    expect(result.success).toBe(true);
+  });
+
+  it("applies default status = active when not provided", () => {
+    const result = createResourceSchema.parse({ title: "No status", type: "asset" });
+    expect(result.status).toBe("active");
+  });
+
+  it("rejects payload with missing title", () => {
+    const result = createResourceSchema.safeParse({ type: "service" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects payload with empty title", () => {
+    const result = createResourceSchema.safeParse({ title: "", type: "service" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid enum value for type", () => {
+    const result = createResourceSchema.safeParse({ title: "Invalid", type: "license" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid enum value for status", () => {
+    const result = createResourceSchema.safeParse({
+      title: "Invalid",
+      type: "service",
+      status: "deleted",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts metadata object", () => {
+    const result = createResourceSchema.safeParse({
+      title: "With metadata",
+      type: "other",
+      metadata: { nested: { foo: "bar" }, quantity: 2 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid image URL", () => {
+    const result = createResourceSchema.safeParse({
+      title: "Bad URL",
+      type: "document",
+      imageUrls: ["https://valid.com/img.png", "invalid-url"],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateResourceSchema", () => {
+  it("accepts empty object", () => {
+    const result = updateResourceSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts partial update", () => {
+    const result = updateResourceSchema.safeParse({ title: "Updated" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid partial type", () => {
+    const result = updateResourceSchema.safeParse({ type: "machine" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("resourceQuerySchema", () => {
+  it("applies default limit and offset", () => {
+    const result = resourceQuerySchema.parse({});
+    expect(result.limit).toBe(20);
+    expect(result.offset).toBe(0);
+  });
+
+  it("accepts custom pagination", () => {
+    const result = resourceQuerySchema.parse({ limit: 30, offset: 10 });
+    expect(result.limit).toBe(30);
+    expect(result.offset).toBe(10);
+  });
+
+  it("rejects invalid pagination", () => {
+    expect(resourceQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(resourceQuerySchema.safeParse({ offset: -1 }).success).toBe(false);
+  });
+
+  it("accepts valid filters", () => {
+    const result = resourceQuerySchema.safeParse({ type: "asset", status: "draft" });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/dto/resources.ts
+++ b/packages/contracts/src/dto/resources.ts
@@ -1,0 +1,10 @@
+import type { z } from "zod";
+import type {
+  createResourceSchema,
+  resourceQuerySchema,
+  updateResourceSchema,
+} from "../schemas/resources";
+
+export type CreateResourceDto = z.infer<typeof createResourceSchema>;
+export type UpdateResourceDto = z.infer<typeof updateResourceSchema>;
+export type ResourceQueryDto = z.infer<typeof resourceQuerySchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,7 +5,7 @@
 export { z } from "zod";
 // DTOs
 export * from "./dto/platform";
-
+export * from "./dto/resources";
 export type {
   InvitationMetadata,
   PaginationParams,
@@ -37,5 +37,8 @@ export {
   userRoleSchema,
   uuidSchema,
 } from "./schemas/platform";
+// Resources domain — schemas, DTOs, and types
+export * from "./schemas/resources";
 // Types
 export * from "./types/platform";
+export * from "./types/resources";

--- a/packages/contracts/src/schemas/resources.ts
+++ b/packages/contracts/src/schemas/resources.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const resourceTypeSchema = z.enum(["product", "service", "asset", "document", "other"]);
+
+export const resourceStatusSchema = z.enum(["active", "draft", "archived", "suspended"]);
+
+export const createResourceSchema = z.object({
+  title: z.string().min(1).max(500),
+  type: resourceTypeSchema,
+  status: resourceStatusSchema.default("active"),
+  description: z.string().max(5000).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  imageUrls: z.array(z.string().url()).optional(),
+});
+
+export const updateResourceSchema = createResourceSchema.partial();
+
+export const resourceQuerySchema = z.object({
+  type: resourceTypeSchema.optional(),
+  status: resourceStatusSchema.optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});

--- a/packages/contracts/src/types/resources.ts
+++ b/packages/contracts/src/types/resources.ts
@@ -1,0 +1,32 @@
+export const RESOURCE_TYPE = {
+  PRODUCT: "product",
+  SERVICE: "service",
+  ASSET: "asset",
+  DOCUMENT: "document",
+  OTHER: "other",
+} as const;
+
+export type ResourceType = (typeof RESOURCE_TYPE)[keyof typeof RESOURCE_TYPE];
+
+export const RESOURCE_STATUS = {
+  ACTIVE: "active",
+  DRAFT: "draft",
+  ARCHIVED: "archived",
+  SUSPENDED: "suspended",
+} as const;
+
+export type ResourceStatus = (typeof RESOURCE_STATUS)[keyof typeof RESOURCE_STATUS];
+
+export interface ResourceEntity {
+  id: string;
+  tenantId: string;
+  title: string;
+  type: ResourceType;
+  status: ResourceStatus;
+  description: string | null;
+  metadata: string | null;
+  imageUrls: string | null;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/packages/core/src/services/__tests__/resource-service.test.ts
+++ b/packages/core/src/services/__tests__/resource-service.test.ts
@@ -1,0 +1,196 @@
+import type { CreateResourceDto, ResourceQueryDto, UpdateResourceDto } from "@enterprise/contracts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createResource,
+  deleteResource,
+  getResourceById,
+  listResources,
+  updateResource,
+} from "../resource-service";
+
+function makeQueryChain(result: { data: unknown; error: unknown; count?: number | null }) {
+  const chain = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    neq: vi.fn(),
+    range: vi.fn(),
+    single: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+  };
+
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.neq.mockReturnValue(chain);
+  chain.range.mockResolvedValue(result);
+  chain.single.mockResolvedValue(result);
+  chain.update.mockReturnValue(chain);
+  chain.insert.mockReturnValue(chain);
+
+  return chain;
+}
+
+function createMockClient(queryResult: { data: unknown; error: unknown; count?: number | null }) {
+  const chain = makeQueryChain(queryResult);
+
+  const client = {
+    from: vi.fn(() => chain),
+    __chain: chain,
+  } as unknown as SupabaseClient & { __chain: ReturnType<typeof makeQueryChain> };
+
+  return client;
+}
+
+const TENANT_ID = "tenant-uuid-1234";
+const USER_ID = "user-uuid-5678";
+const RESOURCE_ID = "resource-uuid-9012";
+
+const mockResource = {
+  id: RESOURCE_ID,
+  tenant_id: TENANT_ID,
+  title: "Corporate Handbook",
+  type: "document",
+  status: "active",
+  description: "Company policy handbook",
+  metadata: '{"department":"operations"}',
+  image_urls: '["https://example.com/cover.jpg"]',
+  created_by: USER_ID,
+  created_at: new Date("2026-01-01"),
+  updated_at: new Date("2026-01-02"),
+};
+
+describe("listResources", () => {
+  it("no filters: returns items + total and excludes archived by default", async () => {
+    const client = createMockClient({ data: [mockResource], error: null, count: 1 });
+
+    const result = await listResources(client);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items).toHaveLength(1);
+      expect(result.data.total).toBe(1);
+    }
+
+    expect(client.__chain.neq).toHaveBeenCalledWith("status", "archived");
+  });
+
+  it("filters: applies eq for type and status when provided", async () => {
+    const client = createMockClient({ data: [mockResource], error: null, count: 1 });
+    const filters: ResourceQueryDto = {
+      type: "document",
+      status: "active",
+      limit: 20,
+      offset: 0,
+    };
+
+    await listResources(client, filters);
+
+    expect(client.__chain.eq).toHaveBeenCalledWith("type", "document");
+    expect(client.__chain.eq).toHaveBeenCalledWith("status", "active");
+    expect(client.__chain.neq).not.toHaveBeenCalledWith("status", "archived");
+  });
+
+  it("pagination: calls range with correct offset + limit - 1", async () => {
+    const client = createMockClient({ data: [], error: null, count: 0 });
+    const filters: ResourceQueryDto = { limit: 10, offset: 20 };
+
+    await listResources(client, filters);
+
+    expect(client.__chain.range).toHaveBeenCalledWith(20, 29);
+  });
+
+  it("DB error: returns failure ServiceResult", async () => {
+    const client = createMockClient({ data: null, error: { message: "DB error" }, count: null });
+
+    const result = await listResources(client);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("getResourceById", () => {
+  it("found: returns resource data", async () => {
+    const client = createMockClient({ data: mockResource, error: null });
+
+    const result = await getResourceById(client, RESOURCE_ID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(RESOURCE_ID);
+    }
+    expect(client.__chain.eq).toHaveBeenCalledWith("id", RESOURCE_ID);
+  });
+
+  it("not found (null data): returns not_found error", async () => {
+    const client = createMockClient({ data: null, error: null });
+
+    const result = await getResourceById(client, RESOURCE_ID);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("not_found");
+    }
+  });
+});
+
+describe("createResource", () => {
+  const createInput: CreateResourceDto = {
+    title: "Corporate Handbook",
+    type: "document",
+    status: "active",
+    description: "Company policy handbook",
+    metadata: { department: "operations" },
+    imageUrls: ["https://example.com/cover.jpg"],
+  };
+
+  it("success: inserts record and returns it", async () => {
+    const client = createMockClient({ data: mockResource, error: null });
+
+    const result = await createResource(client, TENANT_ID, USER_ID, createInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(RESOURCE_ID);
+    }
+    expect(client.from).toHaveBeenCalledWith("resources");
+    expect(client.__chain.insert).toHaveBeenCalled();
+  });
+});
+
+describe("updateResource", () => {
+  const updateInput: UpdateResourceDto = {
+    title: "Updated Handbook",
+  };
+
+  it("success: updates record and returns it", async () => {
+    const updatedResource = { ...mockResource, title: "Updated Handbook" };
+    const client = createMockClient({ data: updatedResource, error: null });
+
+    const result = await updateResource(client, RESOURCE_ID, updateInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.title).toBe("Updated Handbook");
+    }
+    expect(client.__chain.update).toHaveBeenCalled();
+    expect(client.__chain.eq).toHaveBeenCalledWith("id", RESOURCE_ID);
+  });
+});
+
+describe("deleteResource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls .update({ status: 'archived' }) — NOT .delete()", async () => {
+    const client = createMockClient({ data: { id: RESOURCE_ID }, error: null });
+
+    const result = await deleteResource(client, RESOURCE_ID);
+
+    expect(client.__chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "archived" }),
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/core/src/services/resource-service.ts
+++ b/packages/core/src/services/resource-service.ts
@@ -1,0 +1,201 @@
+import type {
+  CreateResourceDto,
+  ResourceEntity,
+  ResourceQueryDto,
+  UpdateResourceDto,
+} from "@enterprise/contracts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ServiceResult } from "./auth-service";
+
+function mapRow(row: Record<string, unknown>): ResourceEntity {
+  return {
+    id: row["id"] as string,
+    tenantId: row["tenant_id"] as string,
+    title: row["title"] as string,
+    type: row["type"] as ResourceEntity["type"],
+    status: row["status"] as ResourceEntity["status"],
+    description: (row["description"] as string | null) ?? null,
+    metadata: (row["metadata"] as string | null) ?? null,
+    imageUrls: (row["image_urls"] as string | null) ?? null,
+    createdBy: row["created_by"] as string,
+    createdAt: row["created_at"] as Date,
+    updatedAt: row["updated_at"] as Date,
+  };
+}
+
+async function writeAuditLog(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  action: "create" | "update" | "delete",
+  resourceId: string,
+): Promise<void> {
+  const { error } = await client.from("audit_log").insert({
+    tenant_id: tenantId,
+    user_id: userId,
+    action,
+    resource: "resources",
+    resource_id: resourceId,
+    metadata: null,
+    ip_address: null,
+    user_agent: null,
+  });
+
+  if (error) {
+    console.error(`Failed to write audit log [${action}:resources:${resourceId}]:`, error);
+  }
+}
+
+export async function listResources(
+  client: SupabaseClient,
+  filters?: ResourceQueryDto,
+): Promise<ServiceResult<{ items: ResourceEntity[]; total: number }>> {
+  const limit = filters?.limit ?? 20;
+  const offset = filters?.offset ?? 0;
+
+  let query = client.from("resources").select("*", { count: "exact" });
+
+  if (filters?.type) {
+    query = query.eq("type", filters.type);
+  }
+
+  if (filters?.status) {
+    query = query.eq("status", filters.status);
+  } else {
+    query = query.neq("status", "archived");
+  }
+
+  const { data, error, count } = await query.range(offset, offset + limit - 1);
+
+  if (error) {
+    return { success: false, error: error.message, code: "LIST_FAILED" };
+  }
+
+  const items = (data ?? []).map((row) => mapRow(row as Record<string, unknown>));
+
+  return { success: true, data: { items, total: count ?? 0 } };
+}
+
+export async function getResourceById(
+  client: SupabaseClient,
+  id: string,
+): Promise<ServiceResult<ResourceEntity>> {
+  const { data, error } = await client.from("resources").select("*").eq("id", id).single();
+
+  if (error) {
+    return { success: false, error: error.message, code: "FETCH_FAILED" };
+  }
+
+  if (!data) {
+    return { success: false, error: "Resource not found", code: "not_found" };
+  }
+
+  return { success: true, data: mapRow(data as Record<string, unknown>) };
+}
+
+export async function createResource(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  input: CreateResourceDto,
+): Promise<ServiceResult<ResourceEntity>> {
+  const { imageUrls, metadata, ...rest } = input;
+
+  const insertPayload = {
+    tenant_id: tenantId,
+    created_by: userId,
+    title: rest.title,
+    type: rest.type,
+    status: rest.status ?? "active",
+    description: rest.description ?? null,
+    metadata: metadata ? JSON.stringify(metadata) : null,
+    image_urls: imageUrls ? JSON.stringify(imageUrls) : null,
+  };
+
+  const { data, error } = await client.from("resources").insert(insertPayload).select().single();
+
+  if (error) {
+    return { success: false, error: error.message, code: "CREATE_FAILED" };
+  }
+
+  if (!data) {
+    return { success: false, error: "Resource was not created", code: "CREATE_FAILED" };
+  }
+
+  const entity = mapRow(data as Record<string, unknown>);
+
+  void writeAuditLog(client, tenantId, userId, "create", entity.id).catch(console.error);
+
+  return { success: true, data: entity };
+}
+
+export async function updateResource(
+  client: SupabaseClient,
+  id: string,
+  input: UpdateResourceDto,
+): Promise<ServiceResult<ResourceEntity>> {
+  const updatePayload: Record<string, unknown> = {};
+
+  if (input.title !== undefined) updatePayload["title"] = input.title;
+  if (input.type !== undefined) updatePayload["type"] = input.type;
+  if (input.status !== undefined) updatePayload["status"] = input.status;
+  if (input.description !== undefined) updatePayload["description"] = input.description;
+  if (input.metadata !== undefined) {
+    updatePayload["metadata"] = input.metadata ? JSON.stringify(input.metadata) : null;
+  }
+  if (input.imageUrls !== undefined) {
+    updatePayload["image_urls"] = input.imageUrls ? JSON.stringify(input.imageUrls) : null;
+  }
+
+  const { data, error } = await client
+    .from("resources")
+    .update(updatePayload)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error: error.message, code: "UPDATE_FAILED" };
+  }
+
+  if (!data) {
+    return { success: false, error: "Resource not found after update", code: "not_found" };
+  }
+
+  const entity = mapRow(data as Record<string, unknown>);
+
+  void writeAuditLog(client, entity.tenantId, entity.createdBy, "update", entity.id).catch(
+    console.error,
+  );
+
+  return { success: true, data: entity };
+}
+
+export async function deleteResource(
+  client: SupabaseClient,
+  id: string,
+): Promise<ServiceResult<null>> {
+  const { data, error } = await client
+    .from("resources")
+    .update({ status: "archived" })
+    .eq("id", id)
+    .select("id, tenant_id, created_by")
+    .single();
+
+  if (error) {
+    return { success: false, error: error.message, code: "DELETE_FAILED" };
+  }
+
+  if (data) {
+    const row = data as Record<string, unknown>;
+    void writeAuditLog(
+      client,
+      row["tenant_id"] as string,
+      row["created_by"] as string,
+      "delete",
+      id,
+    ).catch(console.error);
+  }
+
+  return { success: true, data: null };
+}

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "drizzle-kit";
 const { DATABASE_URL } = process.env;
 
 export default defineConfig({
-  schema: "./src/schema/platform.ts",
+  schema: "./src/schema/*.ts",
   out: "../../supabase/migrations",
   dialect: "postgresql",
   dbCredentials: {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,5 +4,5 @@
 export type { PgTable } from "drizzle-orm/pg-core";
 // Re-export drizzle utilities
 export { drizzle } from "drizzle-orm/postgres-js";
-
 export * from "./schema/platform.js";
+export * from "./schema/resources.js";

--- a/packages/db/src/schema/resources.ts
+++ b/packages/db/src/schema/resources.ts
@@ -1,0 +1,80 @@
+// Resources domain schema — generic reference entities with RLS
+
+import { sql } from "drizzle-orm";
+import { index, pgEnum, pgPolicy, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { authenticatedRole } from "drizzle-orm/supabase";
+
+/** Resource type enum */
+export const resourceTypeEnum = pgEnum("resource_type", [
+  "product",
+  "service",
+  "asset",
+  "document",
+  "other",
+]);
+
+/** Resource status enum */
+export const resourceStatusEnum = pgEnum("resource_status", [
+  "active",
+  "draft",
+  "archived",
+  "suspended",
+]);
+
+/** Matches the tenant_id column against the JWT app_metadata tenant_id claim */
+const tenantClaim = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+
+/** Restricts mutations to owner and admin roles */
+const adminClaim = sql`(auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))`;
+
+/** Resources — generic reference entities per tenant */
+export const resources = pgTable(
+  "resources",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id").notNull(),
+    title: text("title").notNull(),
+    type: resourceTypeEnum("type").notNull(),
+    status: resourceStatusEnum("status").notNull().default("active"),
+    description: text("description"),
+    metadata: text("metadata"), // JSON-stringified object for custom fields
+    imageUrls: text("image_urls"), // JSON-stringified array of URLs
+    createdBy: uuid("created_by").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("resources_tenant_idx").on(table.tenantId),
+    index("resources_status_idx").on(table.status),
+    index("resources_type_idx").on(table.type),
+    index("resources_created_by_idx").on(table.createdBy),
+    pgPolicy("resources_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: tenantClaim,
+    }),
+    pgPolicy("resources_insert", {
+      as: "permissive",
+      for: "insert",
+      to: authenticatedRole,
+      withCheck: sql`(${tenantClaim} AND ${adminClaim})`,
+    }),
+    pgPolicy("resources_update", {
+      as: "permissive",
+      for: "update",
+      to: authenticatedRole,
+      using: sql`(${tenantClaim} AND ${adminClaim})`,
+      withCheck: sql`(${tenantClaim} AND ${adminClaim})`,
+    }),
+    pgPolicy("resources_delete", {
+      as: "permissive",
+      for: "delete",
+      to: authenticatedRole,
+      using: sql`(${tenantClaim} AND ${adminClaim})`,
+    }),
+  ],
+).enableRLS();
+
+export type Resource = typeof resources.$inferSelect;
+export type NewResource = typeof resources.$inferInsert;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,11 +1,11 @@
 # For detailed configuration reference documentation, visit:
 # https://supabase.com/docs/guides/local-development/cli/config
-project_id = "enterprise-platform-template"
+project_id = "enterprise-platform-template-local"
 
 [api]
 enabled = true
 # Port to use for the API URL.
-port = 54331
+port = 55331
 # Schemas to expose in your API.
 schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
@@ -16,14 +16,14 @@ enabled = false
 
 [db]
 # Port to use for the local database URL.
-port = 54332
-shadow_port = 54330
+port = 55332
+shadow_port = 55330
 health_timeout = "2m"
 major_version = 17
 
 [db.pooler]
 enabled = false
-port = 54339
+port = 55339
 pool_mode = "transaction"
 default_pool_size = 20
 max_client_conn = 100
@@ -46,14 +46,14 @@ enabled = true
 
 [studio]
 enabled = true
-port = 54333
+port = 55333
 api_url = "http://127.0.0.1"
 openai_api_key = "env(OPENAI_API_KEY)"
 
 # Email testing server — emails are captured locally, not sent.
 [inbucket]
 enabled = true
-port = 54334
+port = 55334
 
 [storage]
 enabled = true
@@ -175,7 +175,7 @@ deno_version = 2
 
 [analytics]
 enabled = true
-port = 54337
+port = 55337
 backend = "postgres"
 
 [experimental]

--- a/supabase/migrations/20260422000003_resources_schema.sql
+++ b/supabase/migrations/20260422000003_resources_schema.sql
@@ -1,0 +1,29 @@
+CREATE TYPE "public"."resource_type" AS ENUM('product', 'service', 'asset', 'document', 'other');--> statement-breakpoint
+CREATE TYPE "public"."resource_status" AS ENUM('active', 'draft', 'archived', 'suspended');--> statement-breakpoint
+CREATE TABLE "resources" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"title" text NOT NULL,
+	"type" "resource_type" NOT NULL,
+	"status" "resource_status" DEFAULT 'active' NOT NULL,
+	"description" text,
+	"metadata" text,
+	"image_urls" text,
+	"created_by" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "resources" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE INDEX "resources_tenant_idx" ON "resources" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "resources_status_idx" ON "resources" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "resources_type_idx" ON "resources" USING btree ("type");--> statement-breakpoint
+CREATE INDEX "resources_created_by_idx" ON "resources" USING btree ("created_by");--> statement-breakpoint
+CREATE POLICY "resources_select" ON "resources" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id));--> statement-breakpoint
+CREATE POLICY "resources_insert" ON "resources" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ((((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))));--> statement-breakpoint
+CREATE POLICY "resources_update" ON "resources" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ((((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))) WITH CHECK ((((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))));--> statement-breakpoint
+CREATE POLICY "resources_delete" ON "resources" AS PERMISSIVE FOR DELETE TO "authenticated" USING ((((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))));--> statement-breakpoint
+CREATE TRIGGER resources_updated_at
+  BEFORE UPDATE ON resources
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/meta/0000_snapshot.json
+++ b/supabase/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "386de942-7709-4ac3-b1df-bef96cc7b456",
+  "id": "bd7e8b72-8351-4d34-be92-fb5b66d77b75",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -505,6 +505,190 @@
       },
       "checkConstraints": {},
       "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_tenant_idx": {
+          "name": "resources_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_status_idx": {
+          "name": "resources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_type_idx": {
+          "name": "resources_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_created_by_idx": {
+          "name": "resources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "resources_select": {
+          "name": "resources_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "resources_insert": {
+          "name": "resources_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_update": {
+          "name": "resources_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_delete": {
+          "name": "resources_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
     }
   },
   "enums": {
@@ -538,6 +722,27 @@
         "admin",
         "member",
         "guest"
+      ]
+    },
+    "public.resource_status": {
+      "name": "resource_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "draft",
+        "archived",
+        "suspended"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "service",
+        "asset",
+        "document",
+        "other"
       ]
     }
   },

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1776699512508,
+      "when": 1776909061381,
       "tag": "0000_late_scorpion",
       "breakpoints": true
     }

--- a/ui/app/(dashboard)/dashboard/resources/[id]/edit/page.tsx
+++ b/ui/app/(dashboard)/dashboard/resources/[id]/edit/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/features/auth/queries";
+import { ResourceForm } from "@/features/resources/components/resource-form";
+import { getResourceById } from "@/features/resources/queries";
+
+export const metadata = { title: "Edit Resource" };
+
+interface EditResourcePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditResourcePage({ params }: EditResourcePageProps) {
+  const user = await requireAuth();
+  const { id } = await params;
+
+  const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+  if (!isAdminOrOwner) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-muted-foreground">You do not have permission to edit resources.</p>
+      </div>
+    );
+  }
+
+  const resource = await getResourceById(id);
+
+  if (!resource) {
+    notFound();
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <nav className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/dashboard/resources" className="hover:text-foreground hover:underline">
+          Resources
+        </Link>
+        <span>/</span>
+        <Link href={`/dashboard/resources/${id}`} className="hover:text-foreground hover:underline">
+          {resource.title}
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">Edit</span>
+      </nav>
+
+      <div>
+        <h1 className="font-headline text-2xl font-bold">Edit Resource</h1>
+        <p className="text-muted-foreground">Update the details for {resource.title}</p>
+      </div>
+
+      <div className="max-w-3xl">
+        <ResourceForm defaultValues={resource} />
+      </div>
+    </div>
+  );
+}

--- a/ui/app/(dashboard)/dashboard/resources/[id]/page.tsx
+++ b/ui/app/(dashboard)/dashboard/resources/[id]/page.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@enterprise/ui/components/button";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/features/auth/queries";
+import { DeleteResourceButton } from "@/features/resources/components/delete-resource-button";
+import { ResourceDetail } from "@/features/resources/components/resource-detail";
+import { getResourceById } from "@/features/resources/queries";
+
+export const metadata = { title: "Resource Detail" };
+
+interface ResourcePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ResourcePage({ params }: ResourcePageProps) {
+  const user = await requireAuth();
+  const { id } = await params;
+
+  const resource = await getResourceById(id);
+
+  if (!resource) {
+    notFound();
+  }
+
+  const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <nav className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/dashboard/resources" className="hover:text-foreground hover:underline">
+          Resources
+        </Link>
+        <span>/</span>
+        <span className="truncate text-foreground">{resource.title}</span>
+      </nav>
+
+      {isAdminOrOwner && (
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/dashboard/resources/${id}/edit`}>Edit</Link>
+          </Button>
+          <DeleteResourceButton id={id} />
+        </div>
+      )}
+
+      <ResourceDetail resource={resource} />
+    </div>
+  );
+}

--- a/ui/app/(dashboard)/dashboard/resources/new/page.tsx
+++ b/ui/app/(dashboard)/dashboard/resources/new/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { requireAuth } from "@/features/auth/queries";
+import { ResourceForm } from "@/features/resources/components/resource-form";
+
+export const metadata = { title: "New Resource" };
+
+export default async function NewResourcePage() {
+  const user = await requireAuth();
+  const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+
+  if (!isAdminOrOwner) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-muted-foreground">You do not have permission to create resources.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <nav className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/dashboard/resources" className="hover:text-foreground hover:underline">
+          Resources
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">New Resource</span>
+      </nav>
+
+      <div>
+        <h1 className="font-headline text-2xl font-bold">New Resource</h1>
+        <p className="text-muted-foreground">Add a new resource to your workspace</p>
+      </div>
+
+      <div className="max-w-3xl">
+        <ResourceForm />
+      </div>
+    </div>
+  );
+}

--- a/ui/app/(dashboard)/dashboard/resources/page.tsx
+++ b/ui/app/(dashboard)/dashboard/resources/page.tsx
@@ -1,0 +1,97 @@
+import type { ResourceQueryDto } from "@enterprise/contracts";
+import { Button } from "@enterprise/ui/components/button";
+import Link from "next/link";
+import { requireAuth } from "@/features/auth/queries";
+import { ResourceFilters } from "@/features/resources/components/resource-filters";
+import { ResourceTable } from "@/features/resources/components/resource-table";
+import { getResources } from "@/features/resources/queries";
+
+export const metadata = { title: "Resources" };
+
+const ITEMS_PER_PAGE = 20;
+
+interface ResourcesPageProps {
+  searchParams?: Promise<Record<string, string | string[]>>;
+}
+
+export default async function ResourcesPage({ searchParams }: ResourcesPageProps) {
+  const user = await requireAuth();
+  const params = (await searchParams) ?? {};
+
+  const typeParam = typeof params["type"] === "string" ? params["type"] : undefined;
+  const statusParam = typeof params["status"] === "string" ? params["status"] : undefined;
+  const offsetParam =
+    typeof params["offset"] === "string" ? Number.parseInt(params["offset"], 10) : 0;
+
+  const filters: Partial<ResourceQueryDto> = {
+    limit: ITEMS_PER_PAGE,
+    offset: Number.isNaN(offsetParam) ? 0 : offsetParam,
+  };
+
+  if (typeParam) filters.type = typeParam as ResourceQueryDto["type"];
+  if (statusParam) filters.status = statusParam as ResourceQueryDto["status"];
+
+  const { items, total } = await getResources(filters as ResourceQueryDto);
+
+  const currentOffset = filters.offset ?? 0;
+  const canGoBack = currentOffset > 0;
+  const canGoForward = currentOffset + ITEMS_PER_PAGE < total;
+
+  const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-headline text-2xl font-bold">Resources</h1>
+          <p className="text-muted-foreground">Browse and manage your resource catalog</p>
+        </div>
+        {isAdminOrOwner && (
+          <Button asChild>
+            <Link href="/dashboard/resources/new">New Resource</Link>
+          </Button>
+        )}
+      </div>
+
+      <ResourceFilters />
+
+      <ResourceTable items={items} total={total} />
+
+      {total > ITEMS_PER_PAGE && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {currentOffset + 1}–{Math.min(currentOffset + ITEMS_PER_PAGE, total)} of {total}
+          </p>
+          <div className="flex gap-2">
+            {canGoBack && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={`/dashboard/resources?${new URLSearchParams({
+                    ...(typeParam ? { type: typeParam } : {}),
+                    ...(statusParam ? { status: statusParam } : {}),
+                    offset: String(currentOffset - ITEMS_PER_PAGE),
+                  }).toString()}`}
+                >
+                  Previous
+                </Link>
+              </Button>
+            )}
+            {canGoForward && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={`/dashboard/resources?${new URLSearchParams({
+                    ...(typeParam ? { type: typeParam } : {}),
+                    ...(statusParam ? { status: statusParam } : {}),
+                    offset: String(currentOffset + ITEMS_PER_PAGE),
+                  }).toString()}`}
+                >
+                  Next
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/components/layout/sidebar.tsx
+++ b/ui/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import type { UserRole } from "@enterprise/contracts";
 import { cn } from "@enterprise/ui/lib/utils";
 import type { LucideIcon } from "lucide-react";
-import { LayoutDashboard, Settings } from "lucide-react";
+import { LayoutDashboard, Package, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -16,6 +16,7 @@ interface NavItem {
 
 export const NAV_ITEMS: NavItem[] = [
   { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Resources", href: "/dashboard/resources", icon: Package },
   { label: "Settings", href: "/dashboard/settings", icon: Settings },
 ];
 

--- a/ui/e2e/auth/auth-page.ts
+++ b/ui/e2e/auth/auth-page.ts
@@ -3,6 +3,45 @@ import { expect, type Page } from "@playwright/test";
 export class AuthPage {
   constructor(private readonly page: Page) {}
 
+  private async waitForHydratedForm(submitLabel: string): Promise<void> {
+    const submitButton = this.page.getByRole("button", { name: submitLabel });
+
+    await this.page.locator("form").first().waitFor({ state: "visible", timeout: 15_000 });
+    await submitButton.waitFor({
+      state: "visible",
+      timeout: 15_000,
+    });
+
+    await submitButton.evaluate((button) => {
+      return new Promise<void>((resolve, reject) => {
+        const deadline = Date.now() + 15_000;
+
+        const isHydrated = () => {
+          const keys = Object.keys(button as object);
+          return keys.some(
+            (key) => key.startsWith("__reactProps$") || key.startsWith("__reactFiber$"),
+          );
+        };
+
+        const check = () => {
+          if (isHydrated()) {
+            resolve();
+            return;
+          }
+
+          if (Date.now() > deadline) {
+            reject(new Error("Auth form did not hydrate within timeout"));
+            return;
+          }
+
+          requestAnimationFrame(check);
+        };
+
+        check();
+      });
+    });
+  }
+
   async gotoSignIn(redirectTo?: string): Promise<void> {
     const suffix = redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : "";
     await this.page.goto(`/sign-in${suffix}`);
@@ -17,9 +56,23 @@ export class AuthPage {
   }
 
   async signIn(email: string, password: string): Promise<void> {
-    await this.page.getByLabel("Email").fill(email);
-    await this.page.getByLabel("Password").fill(password);
-    await this.page.getByRole("button", { name: "Sign In" }).click();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await this.waitForHydratedForm("Sign In");
+
+      await this.page.getByLabel("Email").fill(email);
+      await this.page.getByLabel("Password").fill(password);
+      await this.page.getByRole("button", { name: "Sign In" }).click();
+
+      try {
+        await this.page.waitForURL(/\/dashboard/, { timeout: 4_000 });
+        return;
+      } catch {
+        // Retry if the page is still on sign-in (native submit race before hydration).
+        if (!this.page.url().includes("/sign-in")) {
+          return;
+        }
+      }
+    }
   }
 
   async signUp(name: string, email: string, password: string): Promise<void> {

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -55,7 +55,9 @@ export default async function globalSetup() {
     }
   }
 
-  const inbucketBaseUrl = process.env["INBUCKET_URL"] ?? "http://localhost:54334";
+  // Default matches the inbucket port in supabase/config.toml (55334).
+  // Override with INBUCKET_URL env var if using a different port.
+  const inbucketBaseUrl = process.env["INBUCKET_URL"] ?? "http://localhost:55334";
   await waitForHttp(inbucketBaseUrl, {
     timeoutMs: 30_000,
     intervalMs: 1_000,

--- a/ui/e2e/helpers/auth.ts
+++ b/ui/e2e/helpers/auth.ts
@@ -19,15 +19,56 @@ export async function login(
 ) {
   await page.goto("/sign-in");
 
-  // Wait for the form to be interactive (React hydration complete)
-  await page
-    .getByRole("button", { name: "Sign In" })
-    .waitFor({ state: "visible", timeout: 15_000 });
+  const signInForm = page.locator("form").first();
+  const submitButton = page.getByRole("button", { name: "Sign In" });
 
-  await page.getByLabel("Email").fill(email);
-  await page.getByLabel("Password").fill(password);
-  await page.getByRole("button", { name: "Sign In" }).click();
+  // Wait for hydration: clicking too early can trigger native action="" submit.
+  await signInForm.waitFor({ state: "visible", timeout: 15_000 });
+  await submitButton.waitFor({ state: "visible", timeout: 15_000 });
+  await submitButton.evaluate((button) => {
+    return new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 15_000;
 
-  // Wait for redirect — generous timeout for Server Action roundtrip
-  await page.waitForURL(/\/dashboard/, { timeout: 30_000 });
+      const isHydrated = () => {
+        const keys = Object.keys(button as object);
+        return keys.some(
+          (key) => key.startsWith("__reactProps$") || key.startsWith("__reactFiber$"),
+        );
+      };
+
+      const check = () => {
+        if (isHydrated()) {
+          resolve();
+          return;
+        }
+
+        if (Date.now() > deadline) {
+          reject(new Error("Sign-in form did not hydrate within timeout"));
+          return;
+        }
+
+        requestAnimationFrame(check);
+      };
+
+      check();
+    });
+  });
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(password);
+    await submitButton.click();
+
+    try {
+      // Keep strict behavior: auth must redirect into dashboard route.
+      await page.waitForURL(/\/dashboard/, { timeout: 10_000 });
+      return;
+    } catch {
+      if (!page.url().includes("/sign-in")) {
+        throw new Error("Login did not reach dashboard route after submit");
+      }
+    }
+  }
+
+  throw new Error("Login failed after hydration retries");
 }

--- a/ui/e2e/helpers/inbucket.ts
+++ b/ui/e2e/helpers/inbucket.ts
@@ -1,4 +1,5 @@
-const DEFAULT_INBUCKET_BASE_URL = process.env["INBUCKET_URL"] ?? "http://localhost:54334";
+// Default matches the inbucket port in supabase/config.toml (55334).
+const DEFAULT_INBUCKET_BASE_URL = process.env["INBUCKET_URL"] ?? "http://localhost:55334";
 
 const INBUCKET_POLLING = {
   DEFAULT_TIMEOUT_MS: 10_000,

--- a/ui/e2e/resources/resources-page.ts
+++ b/ui/e2e/resources/resources-page.ts
@@ -1,0 +1,97 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface ResourceFormData {
+  title?: string;
+  type?: string;
+  status?: string;
+  description?: string;
+  metadata?: string;
+  imageUrls?: string;
+}
+
+export class ResourcesPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoList(): Promise<void> {
+    await this.page.goto("/dashboard/resources");
+    await this.page.waitForURL(/\/dashboard\/resources/);
+  }
+
+  async gotoNew(): Promise<void> {
+    await this.page.goto("/dashboard/resources/new");
+    await this.page.waitForURL(/\/dashboard\/resources\/new/);
+  }
+
+  async fillForm(data: ResourceFormData): Promise<void> {
+    if (data.title !== undefined) {
+      await this.page.getByLabel("Title").fill(data.title);
+    }
+
+    if (data.type !== undefined) {
+      await this.page.getByLabel("Type").click();
+      await this.page.getByRole("option", { name: data.type, exact: true }).click();
+    }
+
+    if (data.status !== undefined) {
+      await this.page.getByLabel("Status").click();
+      await this.page.getByRole("option", { name: data.status, exact: true }).click();
+    }
+
+    if (data.description !== undefined) {
+      await this.page.getByLabel("Description").fill(data.description);
+    }
+
+    if (data.metadata !== undefined) {
+      await this.page.getByLabel("Metadata (JSON)").fill(data.metadata);
+    }
+
+    if (data.imageUrls !== undefined) {
+      await this.page.getByLabel("Image URLs").fill(data.imageUrls);
+    }
+  }
+
+  async submitForm(): Promise<void> {
+    await this.page.getByRole("button", { name: /create resource|update resource/i }).click();
+  }
+
+  async expectResourceInTable(title: string): Promise<void> {
+    await expect(this.page.getByRole("cell", { name: title })).toBeVisible();
+  }
+
+  async expectResourceNotInTable(title: string): Promise<void> {
+    await expect(this.page.getByRole("cell", { name: title })).toHaveCount(0);
+  }
+
+  async clickViewResource(title: string): Promise<void> {
+    const row = this.page.getByRole("row").filter({ hasText: title });
+    await row.getByRole("link", { name: "View" }).click();
+  }
+
+  async clickEditResource(title: string): Promise<void> {
+    const row = this.page.getByRole("row").filter({ hasText: title });
+    await row.getByRole("link", { name: "Edit" }).click();
+  }
+
+  async deleteResource(title: string): Promise<void> {
+    await this.clickViewResource(title);
+    await this.page.getByRole("button", { name: "Archive" }).click();
+    await this.page.getByRole("button", { name: "Archive Resource" }).click();
+    await this.page.waitForURL(/\/dashboard\/resources(?!\/)/, { timeout: 15_000 });
+  }
+
+  async filterByType(type: string): Promise<void> {
+    await this.page.getByLabel("Type").click();
+    await this.page.getByRole("option", { name: type, exact: true }).click();
+    await this.page.waitForURL(/\/dashboard\/resources/);
+  }
+
+  async filterByStatus(status: string): Promise<void> {
+    await this.page.getByLabel("Status").click();
+    await this.page.getByRole("option", { name: status, exact: true }).click();
+    await this.page.waitForURL(/\/dashboard\/resources/);
+  }
+
+  async expectRedirectedToSignIn(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/sign-in/);
+  }
+}

--- a/ui/e2e/resources/resources.spec.ts
+++ b/ui/e2e/resources/resources.spec.ts
@@ -85,7 +85,9 @@ test.describe("Resources", () => {
 
       await firstRow.getByRole("link", { name: "View" }).click();
       await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+$/);
-      await expect(page.getByText(title)).toBeVisible();
+      // Use heading role to avoid strict mode violation — title appears in both
+      // the detail card heading and the table/breadcrumb, so getByText matches 2 elements.
+      await expect(page.getByRole("heading", { name: title })).toBeVisible();
     });
 
     test("edit resource: change title and save → updated title appears in list", async ({

--- a/ui/e2e/resources/resources.spec.ts
+++ b/ui/e2e/resources/resources.spec.ts
@@ -85,9 +85,9 @@ test.describe("Resources", () => {
 
       await firstRow.getByRole("link", { name: "View" }).click();
       await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+$/);
-      // Use heading role to avoid strict mode violation — title appears in both
-      // the detail card heading and the table/breadcrumb, so getByText matches 2 elements.
-      await expect(page.getByRole("heading", { name: title })).toBeVisible();
+      // CardTitle renders a <div>, not a semantic heading, so use getByText
+      // with .first() to avoid strict mode violation (title also appears in breadcrumb).
+      await expect(page.getByText(title).first()).toBeVisible();
     });
 
     test("edit resource: change title and save → updated title appears in list", async ({

--- a/ui/e2e/resources/resources.spec.ts
+++ b/ui/e2e/resources/resources.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@playwright/test";
+import { login } from "../helpers/auth";
+import { ResourcesPage } from "./resources-page";
+
+test.describe("Resources", () => {
+  test("unauthenticated request to /dashboard/resources redirects to sign-in", async ({ page }) => {
+    const resourcesPage = new ResourcesPage(page);
+
+    await page.goto("/dashboard/resources");
+
+    await resourcesPage.expectRedirectedToSignIn();
+  });
+
+  test("unauthenticated request to /dashboard/resources/new redirects to sign-in", async ({
+    page,
+  }) => {
+    const resourcesPage = new ResourcesPage(page);
+
+    await page.goto("/dashboard/resources/new");
+
+    await resourcesPage.expectRedirectedToSignIn();
+  });
+
+  test.describe("authenticated flows (require running app + seeded DB)", () => {
+    const uniqueTitle = `E2E Resource ${Date.now()}`;
+
+    test("create resource happy path: fill form → submit → resource appears in list", async ({
+      page,
+    }) => {
+      const resourcesPage = new ResourcesPage(page);
+
+      await login(page);
+      await resourcesPage.gotoNew();
+
+      await resourcesPage.fillForm({
+        title: uniqueTitle,
+        type: "Document",
+        status: "Active",
+        description: "Resource created from E2E test",
+      });
+
+      await resourcesPage.submitForm();
+
+      await resourcesPage.gotoList();
+      await resourcesPage.expectResourceInTable(uniqueTitle);
+    });
+
+    test("list with type filter: applying 'Document' sets type query param", async ({ page }) => {
+      const resourcesPage = new ResourcesPage(page);
+
+      await login(page);
+      await resourcesPage.gotoList();
+      await resourcesPage.filterByType("Document");
+
+      await expect(page).toHaveURL(/type=document/);
+    });
+
+    test("list with status filter: applying 'Active' sets status query param", async ({ page }) => {
+      const resourcesPage = new ResourcesPage(page);
+
+      await login(page);
+      await resourcesPage.gotoList();
+      await resourcesPage.filterByStatus("Active");
+
+      await expect(page).toHaveURL(/status=active/);
+    });
+
+    test("view resource detail: clicking View opens detail page", async ({ page }) => {
+      const resourcesPage = new ResourcesPage(page);
+
+      await login(page);
+      await resourcesPage.gotoList();
+
+      const rows = page.getByRole("row");
+      const rowCount = await rows.count();
+
+      if (rowCount <= 1) {
+        test.skip();
+        return;
+      }
+
+      const firstRow = rows.nth(1);
+      const titleCell = firstRow.getByRole("cell").nth(0);
+      const title = (await titleCell.textContent()) ?? "";
+
+      await firstRow.getByRole("link", { name: "View" }).click();
+      await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+$/);
+      await expect(page.getByText(title)).toBeVisible();
+    });
+
+    test("edit resource: change title and save → updated title appears in list", async ({
+      page,
+    }) => {
+      const resourcesPage = new ResourcesPage(page);
+      const editedTitle = `Edited Resource ${Date.now()}`;
+
+      await login(page);
+      await resourcesPage.gotoList();
+
+      const rows = page.getByRole("row");
+      const rowCount = await rows.count();
+
+      if (rowCount <= 1) {
+        test.skip();
+        return;
+      }
+
+      const firstRow = rows.nth(1);
+      await firstRow.getByRole("link", { name: "Edit" }).click();
+      await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+\/edit/);
+
+      await page.getByLabel("Title").fill(editedTitle);
+      await resourcesPage.submitForm();
+
+      await resourcesPage.gotoList();
+      await resourcesPage.expectResourceInTable(editedTitle);
+    });
+
+    test("delete resource (soft delete): resource disappears from default list", async ({
+      page,
+    }) => {
+      const resourcesPage = new ResourcesPage(page);
+      const deleteTitle = `Delete Resource ${Date.now()}`;
+
+      await login(page);
+
+      await resourcesPage.gotoNew();
+      await resourcesPage.fillForm({
+        title: deleteTitle,
+        type: "Other",
+        status: "Active",
+      });
+      await resourcesPage.submitForm();
+
+      await resourcesPage.gotoList();
+      await resourcesPage.expectResourceInTable(deleteTitle);
+
+      await resourcesPage.deleteResource(deleteTitle);
+      await resourcesPage.expectResourceNotInTable(deleteTitle);
+    });
+  });
+});

--- a/ui/features/resources/actions.ts
+++ b/ui/features/resources/actions.ts
@@ -1,0 +1,155 @@
+"use server";
+
+import {
+  type ActionResult,
+  type CreateResourceDto,
+  createResourceSchema,
+  type ResourceEntity,
+  updateResourceSchema,
+} from "@enterprise/contracts";
+import {
+  createResource,
+  deleteResource,
+  getResourceById,
+  updateResource,
+} from "@enterprise/core/services/resource-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { revalidatePath } from "next/cache";
+
+const RESOURCES_PATH = "/dashboard/resources";
+
+async function getAuthContext(supabase: Awaited<ReturnType<typeof getServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  // tenantId is read from app_metadata (matches RLS claim source)
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+
+  return { userId: user.id, tenantId };
+}
+
+export async function createResourceAction(
+  input: Record<string, unknown>,
+): Promise<ActionResult<ResourceEntity>> {
+  const parsed = createResourceSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  const result = await createResource(
+    supabase,
+    auth.tenantId,
+    auth.userId,
+    parsed.data as CreateResourceDto,
+  );
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: { code: result.code ?? "CREATE_FAILED", message: result.error },
+    };
+  }
+
+  revalidatePath(RESOURCES_PATH);
+
+  return { success: true, data: result.data };
+}
+
+export async function updateResourceAction(
+  id: string,
+  input: Record<string, unknown>,
+): Promise<ActionResult<ResourceEntity>> {
+  const parsed = updateResourceSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  const result = await updateResource(supabase, id, parsed.data);
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: { code: result.code ?? "UPDATE_FAILED", message: result.error },
+    };
+  }
+
+  revalidatePath(RESOURCES_PATH);
+  revalidatePath(`${RESOURCES_PATH}/${id}`);
+
+  return { success: true, data: result.data };
+}
+
+export async function deleteResourceAction(id: string): Promise<ActionResult<null>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  const existsResult = await getResourceById(supabase, id);
+
+  if (!existsResult.success) {
+    return {
+      success: false,
+      error: { code: existsResult.code ?? "NOT_FOUND", message: existsResult.error },
+    };
+  }
+
+  const result = await deleteResource(supabase, id);
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: { code: result.code ?? "DELETE_FAILED", message: result.error },
+    };
+  }
+
+  revalidatePath(RESOURCES_PATH);
+
+  return { success: true, data: null };
+}

--- a/ui/features/resources/components/delete-resource-button.tsx
+++ b/ui/features/resources/components/delete-resource-button.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@enterprise/ui/components/dialog";
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { deleteResourceAction } from "@/features/resources/actions";
+
+interface DeleteResourceButtonProps {
+  id: string;
+}
+
+export function DeleteResourceButton({ id }: DeleteResourceButtonProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleConfirm() {
+    setError(null);
+
+    startTransition(async () => {
+      const result = await deleteResourceAction(id);
+
+      if (!result.success) {
+        setError(result.error?.message ?? "Failed to archive resource. Please try again.");
+        return;
+      }
+
+      setOpen(false);
+      router.push("/dashboard/resources");
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="size-4" />
+          Archive
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive Resource</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to archive this resource? This action performs a soft delete by
+            setting the resource status to archived.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+        )}
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button variant="destructive" disabled={isPending} onClick={handleConfirm}>
+            {isPending ? "Archiving…" : "Archive Resource"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/features/resources/components/resource-detail.tsx
+++ b/ui/features/resources/components/resource-detail.tsx
@@ -1,0 +1,179 @@
+import type { ResourceEntity, ResourceStatus, ResourceType } from "@enterprise/contracts";
+import { Badge } from "@enterprise/ui/components/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@enterprise/ui/components/card";
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+interface ResourceDetailProps {
+  resource: ResourceEntity;
+}
+
+const TYPE_LABELS: Record<ResourceType, string> = {
+  product: "Product",
+  service: "Service",
+  asset: "Asset",
+  document: "Document",
+  other: "Other",
+};
+
+const STATUS_VARIANTS: Record<ResourceStatus, "default" | "secondary" | "destructive" | "outline"> =
+  {
+    active: "default",
+    draft: "secondary",
+    archived: "outline",
+    suspended: "destructive",
+  };
+
+const STATUS_LABELS: Record<ResourceStatus, string> = {
+  active: "Active",
+  draft: "Draft",
+  archived: "Archived",
+  suspended: "Suspended",
+};
+
+function parseImageUrls(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((value): value is string => typeof value === "string");
+    }
+  } catch {
+    return [];
+  }
+  return [];
+}
+
+function prettyMetadata(raw: string | null): string {
+  if (!raw) return "—";
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+interface FieldProps {
+  label: string;
+  value: ReactNode;
+}
+
+function Field({ label, value }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="text-sm">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+export function ResourceDetail({ resource }: ResourceDetailProps) {
+  const imageUrls = parseImageUrls(resource.imageUrls);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <CardTitle className="text-xl">{resource.title}</CardTitle>
+              <CardDescription>{TYPE_LABELS[resource.type]}</CardDescription>
+            </div>
+            <Badge variant={STATUS_VARIANTS[resource.status]}>
+              {STATUS_LABELS[resource.status]}
+            </Badge>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Resource Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 sm:grid-cols-2">
+            <Field label="Type" value={TYPE_LABELS[resource.type]} />
+            <Field label="Status" value={STATUS_LABELS[resource.status]} />
+            <Field label="Description" value={resource.description} />
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Metadata (JSON)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+            {prettyMetadata(resource.metadata)}
+          </pre>
+        </CardContent>
+      </Card>
+
+      {imageUrls.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Images</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+              {imageUrls.map((url) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="overflow-hidden rounded-md border"
+                >
+                  <Image
+                    src={url}
+                    alt="Resource preview"
+                    width={400}
+                    height={225}
+                    unoptimized
+                    className="aspect-video w-full object-cover"
+                  />
+                </a>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Metadata</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid gap-4 sm:grid-cols-2">
+            <Field label="Resource ID" value={<code className="text-xs">{resource.id}</code>} />
+            <Field label="Tenant ID" value={<code className="text-xs">{resource.tenantId}</code>} />
+            <Field
+              label="Created"
+              value={new Date(resource.createdAt).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            />
+            <Field
+              label="Last Updated"
+              value={new Date(resource.updatedAt).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            />
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/features/resources/components/resource-filters.tsx
+++ b/ui/features/resources/components/resource-filters.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  RESOURCE_STATUS,
+  RESOURCE_TYPE,
+  type ResourceStatus,
+  type ResourceType,
+} from "@enterprise/contracts";
+import { Label } from "@enterprise/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@enterprise/ui/components/select";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const RESOURCE_TYPE_LABELS: Record<ResourceType, string> = {
+  product: "Product",
+  service: "Service",
+  asset: "Asset",
+  document: "Document",
+  other: "Other",
+};
+
+const RESOURCE_STATUS_LABELS: Record<ResourceStatus, string> = {
+  active: "Active",
+  draft: "Draft",
+  archived: "Archived",
+  suspended: "Suspended",
+};
+
+export function ResourceFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  function updateFilter(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (value && value !== "all") {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+
+    params.delete("offset");
+
+    router.push(`/dashboard/resources?${params.toString()}`);
+  }
+
+  const currentType = searchParams.get("type") ?? "";
+  const currentStatus = searchParams.get("status") ?? "";
+
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-type" className="text-sm">
+          Type
+        </Label>
+        <Select value={currentType || "all"} onValueChange={(value) => updateFilter("type", value)}>
+          <SelectTrigger id="filter-type" className="w-40">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            {Object.entries(RESOURCE_TYPE).map(([, value]) => (
+              <SelectItem key={value} value={value}>
+                {RESOURCE_TYPE_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-status" className="text-sm">
+          Status
+        </Label>
+        <Select
+          value={currentStatus || "all"}
+          onValueChange={(value) => updateFilter("status", value)}
+        >
+          <SelectTrigger id="filter-status" className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {Object.entries(RESOURCE_STATUS).map(([, value]) => (
+              <SelectItem key={value} value={value}>
+                {RESOURCE_STATUS_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/ui/features/resources/components/resource-form.tsx
+++ b/ui/features/resources/components/resource-form.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import type {
+  ActionResult,
+  ResourceEntity,
+  ResourceStatus,
+  ResourceType,
+} from "@enterprise/contracts";
+import { RESOURCE_STATUS, RESOURCE_TYPE } from "@enterprise/contracts";
+import { Button } from "@enterprise/ui/components/button";
+import { Input } from "@enterprise/ui/components/input";
+import { Label } from "@enterprise/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@enterprise/ui/components/select";
+import { Textarea } from "@enterprise/ui/components/textarea";
+import { useActionState } from "react";
+import { createResourceAction, updateResourceAction } from "@/features/resources/actions";
+
+interface ResourceFormProps {
+  defaultValues?: Partial<ResourceEntity>;
+}
+
+const RESOURCE_TYPE_LABELS: Record<ResourceType, string> = {
+  product: "Product",
+  service: "Service",
+  asset: "Asset",
+  document: "Document",
+  other: "Other",
+};
+
+const RESOURCE_STATUS_LABELS: Record<ResourceStatus, string> = {
+  active: "Active",
+  draft: "Draft",
+  archived: "Archived",
+  suspended: "Suspended",
+};
+
+function getFieldError(
+  result: ActionResult<ResourceEntity> | null,
+  field: string,
+): string | undefined {
+  if (!result || result.success) return undefined;
+  const details = result.error?.details as Record<string, string[]> | undefined;
+  return details?.[field]?.[0];
+}
+
+function parseJsonString(value: string | null): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function ResourceForm({ defaultValues }: ResourceFormProps) {
+  const isEdit = Boolean(defaultValues?.id);
+
+  async function boundAction(
+    _prevState: ActionResult<ResourceEntity> | null,
+    formData: FormData,
+  ): Promise<ActionResult<ResourceEntity>> {
+    const imageUrlsRaw = (formData.get("imageUrlsText") as string | null) ?? "";
+    const imageUrlsList = imageUrlsRaw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    const metadataText = (formData.get("metadataText") as string | null) ?? "";
+    const parsedMetadata = parseJsonString(metadataText.trim() || null);
+
+    const input: Record<string, unknown> = {
+      title: formData.get("title") ?? undefined,
+      type: formData.get("type") ?? undefined,
+      status: formData.get("status") ?? undefined,
+      description: formData.get("description") ?? undefined,
+      metadata: parsedMetadata,
+      imageUrls: imageUrlsList.length > 0 ? imageUrlsList : undefined,
+    };
+
+    if (isEdit && defaultValues?.id) {
+      return updateResourceAction(defaultValues.id, input);
+    }
+
+    return createResourceAction(input);
+  }
+
+  const [state, formAction, isPending] = useActionState(boundAction, null);
+
+  const existingImageUrlsText = (() => {
+    if (!defaultValues?.imageUrls) return "";
+    try {
+      const parsed: unknown = JSON.parse(defaultValues.imageUrls);
+      if (Array.isArray(parsed)) return parsed.join(", ");
+    } catch {
+      return defaultValues.imageUrls;
+    }
+    return defaultValues.imageUrls;
+  })();
+
+  const existingMetadataText = (() => {
+    if (!defaultValues?.metadata) return "";
+    try {
+      const parsed: unknown = JSON.parse(defaultValues.metadata);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return defaultValues.metadata;
+    }
+  })();
+
+  return (
+    <form action={formAction} className="flex flex-col gap-6">
+      {state && !state.success && !state.error?.details && (
+        <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {state.error?.message ?? "An error occurred. Please try again."}
+        </p>
+      )}
+
+      {state?.success && !isEdit && (
+        <p className="rounded-md bg-green-100 px-3 py-2 text-sm text-green-800">
+          Resource created successfully.
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <Label htmlFor="title">
+            Title <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="title"
+            name="title"
+            required
+            defaultValue={defaultValues?.title ?? ""}
+            placeholder="Resource title"
+          />
+          {getFieldError(state, "title") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "title")}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="type">
+            Type <span className="text-destructive">*</span>
+          </Label>
+          <Select name="type" defaultValue={defaultValues?.type ?? RESOURCE_TYPE.PRODUCT} required>
+            <SelectTrigger id="type">
+              <SelectValue placeholder="Select type" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(RESOURCE_TYPE).map(([, value]) => (
+                <SelectItem key={value} value={value}>
+                  {RESOURCE_TYPE_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {getFieldError(state, "type") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "type")}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="status">
+            Status <span className="text-destructive">*</span>
+          </Label>
+          <Select
+            name="status"
+            defaultValue={defaultValues?.status ?? RESOURCE_STATUS.ACTIVE}
+            required
+          >
+            <SelectTrigger id="status">
+              <SelectValue placeholder="Select status" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(RESOURCE_STATUS).map(([, value]) => (
+                <SelectItem key={value} value={value}>
+                  {RESOURCE_STATUS_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {getFieldError(state, "status") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "status")}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            name="description"
+            defaultValue={defaultValues?.description ?? ""}
+            placeholder="Resource description"
+            rows={4}
+          />
+          {getFieldError(state, "description") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "description")}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <Label htmlFor="metadataText">Metadata (JSON)</Label>
+          <Textarea
+            id="metadataText"
+            name="metadataText"
+            defaultValue={existingMetadataText}
+            placeholder='{"owner":"operations","tags":["internal"]}'
+            rows={5}
+          />
+          <p className="text-xs text-muted-foreground">Use a valid JSON object.</p>
+          {getFieldError(state, "metadata") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "metadata")}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5 sm:col-span-2">
+          <Label htmlFor="imageUrlsText">Image URLs</Label>
+          <Textarea
+            id="imageUrlsText"
+            name="imageUrlsText"
+            defaultValue={existingImageUrlsText}
+            placeholder="Comma-separated image URLs"
+            rows={2}
+          />
+          <p className="text-xs text-muted-foreground">Separate multiple URLs with commas.</p>
+          {getFieldError(state, "imageUrls") && (
+            <p className="text-xs text-destructive">{getFieldError(state, "imageUrls")}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-3">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? "Saving…" : isEdit ? "Update Resource" : "Create Resource"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/ui/features/resources/components/resource-table.tsx
+++ b/ui/features/resources/components/resource-table.tsx
@@ -1,0 +1,108 @@
+import type { ResourceEntity, ResourceStatus, ResourceType } from "@enterprise/contracts";
+import { Badge } from "@enterprise/ui/components/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@enterprise/ui/components/table";
+import Link from "next/link";
+
+interface ResourceTableProps {
+  items: ResourceEntity[];
+  total: number;
+}
+
+const TYPE_LABELS: Record<ResourceType, string> = {
+  product: "Product",
+  service: "Service",
+  asset: "Asset",
+  document: "Document",
+  other: "Other",
+};
+
+const STATUS_VARIANTS: Record<ResourceStatus, "default" | "secondary" | "destructive" | "outline"> =
+  {
+    active: "default",
+    draft: "secondary",
+    archived: "outline",
+    suspended: "destructive",
+  };
+
+const STATUS_LABELS: Record<ResourceStatus, string> = {
+  active: "Active",
+  draft: "Draft",
+  archived: "Archived",
+  suspended: "Suspended",
+};
+
+function truncate(value: string | null, max = 80): string {
+  if (!value) return "—";
+  return value.length <= max ? value : `${value.slice(0, max)}…`;
+}
+
+export function ResourceTable({ items, total }: ResourceTableProps) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border py-16 text-center">
+        <p className="text-muted-foreground">No resources found.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Add a resource to get started, or adjust your filters.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-muted-foreground">
+        {total} {total === 1 ? "resource" : "resources"} found
+      </p>
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Title</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((resource) => (
+              <TableRow key={resource.id}>
+                <TableCell className="font-medium">{resource.title}</TableCell>
+                <TableCell>{TYPE_LABELS[resource.type]}</TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_VARIANTS[resource.status]}>
+                    {STATUS_LABELS[resource.status]}
+                  </Badge>
+                </TableCell>
+                <TableCell>{truncate(resource.description)}</TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end gap-2">
+                    <Link
+                      href={`/dashboard/resources/${resource.id}`}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      View
+                    </Link>
+                    <Link
+                      href={`/dashboard/resources/${resource.id}/edit`}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      Edit
+                    </Link>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/ui/features/resources/queries.ts
+++ b/ui/features/resources/queries.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import type { ResourceEntity, ResourceQueryDto } from "@enterprise/contracts";
+import {
+  getResourceById as getResourceByIdService,
+  listResources,
+} from "@enterprise/core/services/resource-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+
+export async function getResources(
+  filters?: ResourceQueryDto,
+): Promise<{ items: ResourceEntity[]; total: number }> {
+  const supabase = await getServerClient();
+  const result = await listResources(supabase, filters);
+
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}
+
+export async function getResourceById(id: string): Promise<ResourceEntity | null> {
+  const supabase = await getServerClient();
+  const result = await getResourceByIdService(supabase, id);
+
+  if (!result.success) {
+    if (result.code === "not_found") {
+      return null;
+    }
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}

--- a/ui/test-utils/inbucket.test.ts
+++ b/ui/test-utils/inbucket.test.ts
@@ -29,7 +29,7 @@ describe("inbucket helper", () => {
 
     await getMailboxMessages("reset@enterprise.dev");
 
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:54334/api/v1/mailbox/reset");
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:55334/api/v1/mailbox/reset");
   });
 
   it("clearMailbox issues DELETE request to mailbox endpoint", async () => {
@@ -39,7 +39,7 @@ describe("inbucket helper", () => {
 
     await clearMailbox("reset@enterprise.dev");
 
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:54334/api/v1/mailbox/reset", {
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:55334/api/v1/mailbox/reset", {
       method: "DELETE",
     });
   });
@@ -80,7 +80,7 @@ describe("inbucket helper", () => {
       );
 
     const message = await getLatestEmail("reset@enterprise.dev", {
-      baseUrl: "http://localhost:54334",
+      baseUrl: "http://localhost:55334",
       timeoutMs: 2_000,
       pollIntervalMs: 10,
     });
@@ -88,7 +88,7 @@ describe("inbucket helper", () => {
     expect(message.id).toBe("newer-message");
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "http://localhost:54334/api/v1/mailbox/reset/newer-message",
+      "http://localhost:55334/api/v1/mailbox/reset/newer-message",
     );
   });
 


### PR DESCRIPTION
## Summary

- Add a generic **resources** feature module as a reference implementation showing the full template patterns end-to-end
- Fix RLS policies to use `app_metadata` JWT claims, isolate local Supabase with dedicated ports, and harden Playwright login helper

## What this PR includes

### Resources reference module (new feature)
A complete vertical slice demonstrating every template pattern:

| Layer | Files | What it covers |
|-------|-------|----------------|
| **DB Schema** | `packages/db/src/schema/resources.ts` | Drizzle table, pgEnums (`resource_type`, `resource_status`), 4 RLS policies, 4 indexes, `.enableRLS()` |
| **Migration** | `supabase/migrations/20260422000003_resources_schema.sql` | Consolidated migration with table + enums + RLS + trigger |
| **Contracts** | `packages/contracts/src/schemas/resources.ts`, `dto/resources.ts`, `types/resources.ts` | Zod schemas, DTOs, const maps, `ResourceEntity` interface |
| **Service** | `packages/core/src/services/resource-service.ts` | 5 CRUD functions, soft-delete (→ archived), fire-and-forget audit |
| **Actions** | `ui/features/resources/actions.ts` | 3 thin Server Action wrappers |
| **Queries** | `ui/features/resources/queries.ts` | Server-only data fetchers |
| **UI Components** | `ui/features/resources/components/` | Filters, table, form, detail, delete button (5 components) |
| **Pages** | `ui/app/(dashboard)/dashboard/resources/` | List, new, detail, edit (4 Server Component pages) |
| **Sidebar** | `ui/components/layout/sidebar.tsx` | "Resources" nav entry with Package icon |
| **Unit Tests** | `resource-service.test.ts`, `resources.test.ts` | Service + contract Zod schema tests |
| **E2E Tests** | `ui/e2e/resources/` | Page Object Model + Playwright specs |

### Bugfixes

| Fix | Details |
|-----|---------|
| **RLS claims** | Policies now use `auth.jwt()->'app_metadata'->>'tenant_id'` and `->>'role'` instead of top-level claims |
| **Supabase local isolation** | `supabase/config.toml` uses `project_id = enterprise-platform-template-local` with ports `55331+` to avoid conflicts with other local projects |
| **Playwright login** | `ui/e2e/helpers/auth.ts` now waits for React hydration before submitting the sign-in form |
| **Drizzle multi-schema** | `drizzle.config.ts` uses glob `./src/schema/*.ts` for automatic schema discovery |

### Docs

| File | What |
|------|------|
| `docs/example-prd.md` | Example PRD document (reference for new projects) |
| `docs/example-rfc.md` | Example RFC/architecture document (reference for new projects) |

## Resource model (generic)

| Field | Type | Notes |
|-------|------|-------|
| `type` | enum | `product`, `service`, `asset`, `document`, `other` |
| `status` | enum | `active`, `draft`, `archived`, `suspended` |
| `description` | text | Optional |
| `metadata` | text (JSON) | Flexible key-value store for domain-specific fields |
| `imageUrls` | text (JSON array) | Optional image URLs |

## Test plan

- [x] `pnpm typecheck` — 5/5 packages pass
- [x] `pnpm lint` — 128 files, 0 errors
- [x] `pnpm test` — 169 tests pass (73 contracts + 46 core + 50 web)
- [x] E2E tests compile and list correctly (`pnpm e2e --list`)
- [ ] Full E2E run (requires `supabase db reset` with new ports)

## How to use after cloning

1. `supabase start && supabase db reset`
2. Verify `supabase status` shows ports `55331+`
3. `pnpm dev` → navigate to `/dashboard/resources`
4. To adapt: rename "resources" to your domain entity, change enums/fields, keep the patterns