### PR TITLE
docs: generalize example docs and improve E2E seeding patterns

### DIFF
--- a/docs/example-prd.md
+++ b/docs/example-prd.md
@@ -1,179 +1,169 @@
-# PRD — Example CRM
+# PRD — Resource Management Platform (Example)
+
+> **Note:** This is an example PRD included with the template. Replace the content with your own product requirements when starting a new project. The structure and sections below illustrate what a good PRD looks like.
 
 ## 1. Context
 
-InmoAutos currently operates with multiple disconnected tools:
-
-- **WhatsApp** — conversations
-- **WordPress / Houzez** — website
-- **Spreadsheets & Google Drive** — tracking
-- **Human memory**
-
-This generates disorder, loss of context, and missed commercial opportunities.
+The team currently manages resources (products, documents, assets) across disconnected spreadsheets, email threads, and shared drives. There is no single source of truth, and information gets lost as the team grows.
 
 ## 2. Problem
 
-The main problem is not a lack of leads, but a lack of **structured follow-up**.
+The core problem is not a lack of tools, but a lack of **structured organization**.
 
-Today, leads:
+Today, resources:
 
-- Enter through multiple channels
-- Lose continuity
-- Have no traceability
-- Are not correctly linked to properties
+- Are tracked in multiple places with no synchronization
+- Have no clear ownership or status tracking
+- Cannot be searched or filtered efficiently
+- Lack audit trails for changes
 
 This directly impacts:
 
-- Fewer closings
-- More operational time
-- Low team efficiency
+- Time wasted searching for information
+- Duplicate or outdated records
+- Poor visibility for managers
 
 ## 3. Objective
 
-Build a platform that enables:
+Build a multi-tenant platform that enables:
 
-- Centralizing leads and conversations
-- Structuring commercial follow-up
-- Linking contacts with properties
-- Automating tasks and actions
-- Preventing loss of context
+- Centralizing resource management in one place
+- Tracking resource status through a clear lifecycle
+- Assigning ownership and audit trails
+- Filtering and searching across the catalog
 
 ## 4. Value Proposition
 
-**Never lose a lead or commercial context**, organizing the entire operation in a single system connected to WhatsApp.
+**One place to manage all resources**, with clear status, ownership, and history — accessible to the entire team.
 
 ## 5. Users
 
 | Role | Responsibilities |
 |------|-----------------|
-| **Owner** | Global business vision, metrics and control |
-| **Admin** | System maintenance, data loading and control |
-| **Seller** | Lead follow-up, daily system usage |
+| **Owner** | Global visibility, metrics, system configuration |
+| **Admin** | Resource management, user administration |
+| **Member** | Read-only access, day-to-day usage |
 
-> **Primary user: Seller**
+> **Primary user: Admin** — manages resources daily.
 
 ## 6. MVP Scope
 
 ### Included
 
-- WhatsApp integration (capture)
-- Automatic contact creation
-- Commercial pipeline (kanban)
-- Basic inventory
-- AI agent (summary + suggestions)
+- Resource CRUD (create, read, update, archive)
+- Resource types and statuses
+- Multi-tenant isolation (each organization sees only its data)
+- Role-based access control
+- Basic filtering and pagination
 
 ### Not Included
 
-- WhatsApp-like chat inside the CRM
-- Complex automations
-- Advanced reporting
-- Financial modules
+- File attachments or uploads
+- Notifications or alerts
+- Reporting dashboards
+- API integrations with third-party tools
 
 ## 7. User Journey
 
-### Entry
+### Onboarding
 
-1. Lead arrives via WhatsApp
-2. System captures the message
-3. Contact is created or linked
+1. User signs up and creates an organization
+2. System provisions a tenant workspace
+3. User lands on the dashboard
 
-### Conversion
+### Daily Usage
 
-1. Opportunity is created
-2. Property is linked
-3. Responsible person is assigned
+1. Admin navigates to Resources
+2. Creates or updates a resource
+3. Filters by type or status to find what they need
 
-### Follow-up
+### Administration
 
-1. Agent suggests actions
-2. Tasks are created
-3. Pipeline advances
+1. Owner reviews system usage
+2. Manages team members and roles
+3. Archives outdated resources
 
 ## 8. Core Features
 
-### 8.1 WhatsApp (Entry)
+### 8.1 Resource Management
 
-- Automatic message capture
-- Contact identification
+- Create, edit, and archive resources
+- Assign type (product, service, asset, document, other)
+- Track status (active, draft, archived, suspended)
 
-### 8.2 AI Agent
+### 8.2 Filtering & Search
 
-- Conversation summary
-- Data extraction
-- Action suggestions
+- Filter by type, status
+- Paginated list view
+- Detail view per resource
 
-### 8.3 Kanban
+### 8.3 Role-Based Access
 
-- Opportunity visualization
-- Fixed commercial stages
-
-### 8.4 Inventory
-
-- Property management
-- Commercial statuses
-
-### 8.5 Tasks
-
-- Manual and automatic follow-up
+- Owners and admins can create, edit, and archive
+- Members have read-only access
+- All data is tenant-isolated via RLS
 
 ## 9. Non-Functional Requirements
 
-- **Multi-tenant** (per company)
-- **Realtime**
-- **Mobile-first**
-- **Low effort to use**
-- **Integration with existing tools**
+- **Multi-tenant** — data isolated per organization
+- **Responsive** — works on desktop and mobile
+- **Secure** — RLS at database level, role-based UI guards
+- **Fast** — server-side rendered pages, minimal client JS
+- **Auditable** — CUD operations logged
 
 ## 10. Success Metrics
 
-### Business
-
-- Fewer lost leads
-- More property visits
-- More closings
-
 ### Product
 
-- Kanban usage
-- Completed tasks
-- System adoption
+- Resources created per tenant
+- Daily active users
+- Average time to find a resource
+
+### Technical
+
+- Zero RLS bypass incidents
+- Test coverage above thresholds
+- Page load under 2 seconds
 
 ## 11. Roadmap
 
-### MVP (1 week)
+### MVP
 
-- WhatsApp capture
-- Contacts
-- Kanban
-- Basic inventory
-- Simple agent
+- Resource CRUD with types and statuses
+- Multi-tenant with RLS
+- Role-based access
+- Basic filtering
 
 ### V2
 
-- Automations
-- Dashboard
+- File attachments
+- Activity feed
+- Dashboard with metrics
 
 ### V3
 
-- Full SaaS
-- Billing
+- API integrations
+- Notifications
+- Advanced search (full-text)
 
 ## 12. Risks
 
-- Attempting to replace WhatsApp
-- Over-building
-- Low adoption
-- Inconsistent data
+| Risk | Mitigation |
+|------|------------|
+| Low adoption | Keep UI simple, minimize required fields |
+| Data inconsistency | Zod validation on all inputs, RLS enforcement |
+| Over-engineering | Start with MVP scope, defer advanced features |
+| Security gaps | RLS by default, role checks in UI and server |
 
 ## 13. Definition of Success
 
 The product will be successful if:
 
-- The team uses it **by choice**
-- It improves follow-up
-- It reduces lead loss
-- It simplifies daily operations
+- The team uses it as their **primary resource catalog**
+- It reduces time spent searching for information
+- Admins manage resources without needing technical help
+- The system scales to multiple tenants without code changes
 
 ## 14. In One Sentence
 
-> InmoAutos is a CRM that transforms conversations into opportunities and structured follow-up, without replacing WhatsApp, but leveraging it intelligently.
+> A multi-tenant platform for managing resources with clear status tracking, role-based access, and tenant isolation — built to be extended for any domain.

--- a/docs/example-rfc.md
+++ b/docs/example-rfc.md
@@ -1,235 +1,182 @@
-# RFC — Example CRM Architecture
+# RFC — Resource Management Platform Architecture (Example)
+
+> **Note:** This is an example RFC included with the template. Replace the content with your own technical architecture when starting a new project. The structure and sections below illustrate what a good RFC looks like.
 
 ## 1. Summary
 
-This document defines how the InmoAutos CRM system will be built from a technical perspective.
+This document defines how the Resource Management Platform will be built from a technical perspective.
 
-The system is based on a modern, modular, and scalable architecture, focused on:
+The system uses a modern, modular architecture focused on:
 
-- WhatsApp integration
-- AI agent processing
-- Centralized database
-- Realtime experience
+- Multi-tenant data isolation
+- Server-side rendering with selective client interactivity
+- Type-safe contracts shared across the stack
+- Row Level Security at the database level
 
 ## 2. Technical Objective
 
 Design an architecture that enables:
 
-- Capturing messages from WhatsApp
-- Structuring commercial context
-- Managing opportunities
-- Administering inventory
-- Automating follow-up
-- Scaling to multiple companies (SaaS)
+- Managing resources with full CRUD operations
+- Isolating data per tenant using RLS
+- Enforcing role-based access (owner, admin, member)
+- Scaling to multiple organizations without code changes
 
 ## 3. General Architecture
 
 ### Main Flow
 
 ```
-WhatsApp → Webhook → Backend → AI Agent → Database → Frontend
+Browser → Next.js (Server Components / Actions) → Service Layer → Supabase (RLS) → PostgreSQL
 ```
 
 ```
-┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
-│ WhatsApp │───▶│ Webhook  │───▶│ Backend  │───▶│ AI Agent │
-│ (YCloud) │    │ Endpoint │    │ (API)    │    │ Service  │
-└──────────┘    └──────────┘    └──────────┘    └────┬─────┘
-                                                     │
-                                                     ▼
-┌──────────┐    ┌──────────┐    ┌──────────────────────────┐
-│ Frontend │◀───│ Realtime │◀───│   Supabase (PostgreSQL)  │
-│ (Next.js)│    │ Updates  │    │   Multi-tenant DB        │
-└──────────┘    └──────────┘    └──────────────────────────┘
+┌──────────┐    ┌──────────────┐    ┌──────────────┐    ┌──────────────────────────┐
+│ Browser  │───▶│ Next.js App  │───▶│ Service      │───▶│   Supabase (PostgreSQL)  │
+│          │    │ Server/Client│    │ Layer        │    │   Multi-tenant + RLS     │
+└──────────┘    └──────────────┘    └──────────────┘    └──────────────────────────┘
 ```
 
 ## 4. Components
 
 ### Frontend
 
-- **Next.js** (App Router)
-- Mobile-first design
-- Realtime data consumption
-- shadcn/ui component library
+- **Next.js 15+** (App Router)
+- Server Components by default, Client Components for interactivity
+- **shadcn/ui** component library
+- **Tailwind CSS 4** for styling
 
-### Backend
+### Service Layer
 
-- Lightweight API (Node.js / Next.js Server Actions)
-- Webhook handling
-- Business logic in service layer
+- Function-based services in `packages/core/src/services/`
+- Receives `SupabaseClient` as first argument (dependency injection)
+- Returns `ServiceResult<T>` — never throws for expected failures
+- No framework-specific code (no `"use server"`, no `revalidatePath`)
+
+### Server Actions
+
+- Thin wrappers in `ui/features/{module}/actions.ts`
+- Pattern: Zod validate → get auth client → call service → revalidate → return `ActionResult<T>`
 
 ### Database
 
 - **Supabase** (PostgreSQL)
-- Multi-tenant by workspace
-- Realtime subscriptions
-- Row Level Security (RLS)
+- Multi-tenant via `tenant_id` column + RLS policies
+- Auth via Supabase Auth with JWT claims in `app_metadata`
+- Schema defined with **Drizzle ORM**
 
-### AI Agent
+### Contracts
 
-- Independent service
-- Message processing
-- Context generation
+- **Zod schemas** in `packages/contracts/`
+- Single source of truth for all DTOs and validation
+- TypeScript types derived from schemas via `z.infer<>`
 
-### WhatsApp Integration
-
-- **YCloud** as WhatsApp Business API provider
-- Event reception via webhooks
-
-## 5. Data Flow
-
-### Incoming Message
-
-1. WhatsApp sends webhook event
-2. Backend receives event
-3. Contact is identified (or created)
-4. Context is constructed
-5. Message is sent to AI agent
-6. Agent processes and generates summary
-7. Result is saved to database
-8. Frontend updates in realtime
-
-## 6. Data Model
+## 5. Data Model
 
 ### Core Entities
 
 | Entity | Description |
 |--------|-------------|
-| `workspaces` | Tenant isolation unit (one per company) |
-| `users` | System users with roles (owner, admin, seller) |
-| `contacts` | Leads and clients captured from WhatsApp |
-| `opportunities` | Commercial deals linked to contacts and properties |
-| `properties` | Real estate inventory items |
-| `conversation_summaries` | AI-generated summaries of WhatsApp conversations |
-| `tasks` | Follow-up actions (manual and automated) |
-
-> **Central entity: `opportunities`** — everything connects through deals.
+| `tenants` | Organization isolation unit |
+| `profiles` | User profiles linked to Supabase Auth |
+| `user_roles` | Role assignments per tenant |
+| `resources` | Domain entities managed by the platform |
+| `audit_log` | CUD operation audit trail |
 
 ### Entity Relationships
 
 ```
-workspaces
-  ├── users
-  ├── contacts
-  │     └── opportunities
-  │           ├── properties (linked)
-  │           ├── tasks
-  │           └── conversation_summaries
-  └── properties
+tenants
+  ├── profiles (users belong to a tenant)
+  ├── user_roles (role assignments)
+  ├── resources (domain data, tenant-scoped)
+  └── audit_log (action history)
 ```
 
-## 7. Multi-Tenant Strategy
+## 6. Multi-Tenant Strategy
 
-- Each company has its own **workspace**
-- All data is isolated by `workspace_id`
-- Access controlled by **roles** (owner, admin, seller)
-- RLS policies enforce tenant isolation at the database level
+- Each organization has its own **tenant**
+- All data is isolated by `tenant_id`
+- `tenant_id` and `role` are stored in JWT `app_metadata`
+- RLS policies enforce isolation at the database level
+- No tenant bypass in frontend code
 
-## 8. Realtime
+## 7. Security Model
 
-Used for:
+### Authentication
 
-- **Kanban board** — opportunity stage changes
-- **Tasks** — creation and status updates
-- **Activity feed** — recent actions
+- Supabase Auth with email/password
+- JWT tokens with `tenant_id` and `role` in `app_metadata`
+- `getUser()` (not `getSession()`) for server-side auth checks
 
-Technology: **Supabase Realtime** (PostgreSQL changes broadcast)
+### Authorization
 
-## 9. AI Agent
+- RLS policies on every table
+- SELECT: all authenticated tenant members
+- INSERT/UPDATE/DELETE: restricted to `owner` and `admin` roles
+- UI guards hide mutation controls from unauthorized roles
 
-### Functions
+### Audit
 
-- Summarize conversations
-- Extract structured data (name, intent, property interest)
-- Classify lead intention
-- Suggest next actions
+- CUD operations logged via `AuditService.log()` (fire-and-forget)
+- No PII in audit metadata
 
-### Boundaries
-
-- Does NOT replace WhatsApp
-- Does NOT make critical decisions without human control
-- Operates as a **suggestion engine**, not an autonomous actor
-
-## 10. Integrations
-
-### Critical (MVP)
-
-| Integration | Provider | Purpose |
-|-------------|----------|---------|
-| WhatsApp | YCloud | Message capture and webhook events |
-
-### Future
-
-| Integration | Purpose |
-|-------------|---------|
-| Google Drive | Property list import |
-| Google Calendar | Visit scheduling |
-
-> **Note:** WordPress/Houzez integration is explicitly excluded — WordPress will be deprecated.
-
-## 11. Technical Decisions
+## 8. Technical Decisions
 
 | Decision | Rationale |
 |----------|-----------|
-| Monorepo | Shared types, contracts, and UI across packages |
-| Supabase as primary backend | PostgreSQL + Auth + Realtime + RLS in one platform |
-| AI agent as separate service | Decoupled processing, independent scaling |
-| No WhatsApp rebuild | CRM augments WhatsApp, does not replace it |
-| Next.js App Router | Server Components, Server Actions, streaming |
-| Mobile-first | Primary users (sellers) work from phones |
+| Monorepo (pnpm + Turborepo) | Shared types, contracts, and UI across packages |
+| Supabase | PostgreSQL + Auth + RLS + Realtime in one platform |
+| Drizzle ORM | Type-safe schema definition, migration generation |
+| Function-based services | Testable, composable, no class overhead |
+| Server Components default | Minimal client JS, better performance |
+| Zod contracts package | Single source of truth for validation and types |
 
-## 12. Trade-offs
+## 9. Trade-offs
 
 ### Prioritized
 
-- Speed of delivery
-- Simplicity
-- Focus on core value
+- Simplicity and clarity
+- Type safety across the stack
+- Convention over configuration
 
 ### Sacrificed
 
-- Advanced initial features
-- Complex customization
-- Comprehensive reporting (deferred to V2)
+- Advanced features in MVP (deferred to V2+)
+- Complex state management (Zustand only where needed)
+- Realtime subscriptions (not needed for resource CRUD)
 
-## 13. Risks
+## 10. Risks
 
 | Risk | Mitigation |
 |------|------------|
-| Poor WhatsApp integration | Use proven provider (YCloud), test webhook flow early |
-| AI agent errors | Agent suggests only, human confirms actions |
-| Inconsistent data | Strong validation at contracts layer, RLS enforcement |
-| Low adoption | Mobile-first, minimal friction, augment existing workflow |
+| RLS misconfiguration | Use `app_metadata` claims (not user-editable), test policies |
+| Drizzle migration drift | Review generated SQL, use `db:generate` workflow |
+| Over-engineering | Strict MVP scope, defer features explicitly |
+| Multi-tenant data leak | RLS enforced at DB level, never bypass in app code |
 
-## 14. Scalability
-
-- Multi-tenant architecture prepared from day one
-- Modular architecture (packages isolate concerns)
-- AI agent decoupled (can scale independently)
-- Supabase handles connection pooling and realtime at scale
-
-## 15. Implementation Plan
+## 11. Implementation Plan
 
 ### Phase 1 — MVP
 
-- [ ] WhatsApp webhook integration (YCloud)
-- [ ] Contact management (auto-creation from messages)
-- [ ] Opportunity pipeline (kanban)
-- [ ] Basic property inventory
-- [ ] Simple AI agent (summarize + suggest)
+- [x] Multi-tenant foundation (tenants, profiles, RLS)
+- [x] Auth flows (sign-in, sign-up, password reset)
+- [x] Resource CRUD (create, list, detail, edit, archive)
+- [x] Role-based access control
+- [x] Unit and E2E test coverage
 
 ### Phase 2
 
-- [ ] Automations (task creation, reminders)
-- [ ] AI improvements (better classification, richer context)
+- [ ] File attachments (Supabase Storage)
+- [ ] Activity feed (Supabase Realtime)
 - [ ] Dashboard with metrics
 
 ### Phase 3
 
-- [ ] Full SaaS (onboarding, self-service)
-- [ ] Billing and subscription management
-- [ ] Advanced reporting
+- [ ] API integrations
+- [ ] Notification system
+- [ ] Advanced search and reporting
 
-## 16. In One Sentence
+## 12. In One Sentence
 
-> The RFC defines how to build a system that converts WhatsApp messages into structured commercial context through AI and centralizes it in an operational, scalable CRM.
+> The RFC defines a multi-tenant, RLS-secured platform architecture using Next.js, Supabase, and Drizzle ORM — designed to be cloned and adapted for any domain.

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -80,6 +80,28 @@ sequenceDiagram
 5. Run browser tests:
    - `pnpm e2e`
 
+## E2E Anti-Patterns
+
+### Don't test skeleton/loading states
+
+Skeleton components are transient — they appear briefly during SSR streaming and disappear
+when the real content loads. Testing for skeleton visibility is inherently flaky because:
+
+- In fast environments (CI with warm cache), skeletons may never render visibly
+- In slow environments, they may persist longer than expected
+- Race conditions between assertion and render completion are common
+
+**Instead**: Test the end state after navigation completes. Assert on the real content,
+not the loading placeholder.
+
+```diff
+- // BAD: testing transient state
+- await expect(page.locator('.skeleton')).toBeVisible();
+- await expect(page.locator('.skeleton')).not.toBeVisible();
++ // GOOD: test the end state directly
++ await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+```
+
 ## Troubleshooting
 
 - **Cannot sign in with seeded users**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,13 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        // Deny all device permissions by default.
+        // Features that need camera/mic/location should create a separate project
+        // with explicit grants (e.g., for QR scanner tests).
+        permissions: [],
+      },
     },
   ],
   webServer: {

--- a/ui/e2e/helpers/supabase-rest.ts
+++ b/ui/e2e/helpers/supabase-rest.ts
@@ -1,0 +1,120 @@
+interface SupabaseRestOptions {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: Record<string, unknown> | Record<string, unknown>[];
+  headers?: Record<string, string>;
+  /** PostgREST query params like select, order, limit */
+  params?: Record<string, string>;
+}
+
+function getRequiredEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "SUPABASE_SERVICE_ROLE_KEY"): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable for E2E Supabase REST helper: ${name}`);
+  }
+
+  return value;
+}
+
+function buildSupabaseRestUrl(table: string, params?: Record<string, string>): URL {
+  const supabaseUrl = getRequiredEnv("NEXT_PUBLIC_SUPABASE_URL");
+  const normalizedBaseUrl = supabaseUrl.endsWith("/") ? supabaseUrl.slice(0, -1) : supabaseUrl;
+  const requestUrl = new URL(`${normalizedBaseUrl}/rest/v1/${table}`);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      requestUrl.searchParams.set(key, value);
+    }
+  }
+
+  return requestUrl;
+}
+
+/**
+ * Makes authenticated requests to the Supabase PostgREST API using the service-role key.
+ * Used for E2E test data seed/teardown — NOT for production code.
+ *
+ * Reads NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from environment.
+ */
+export async function supabaseRequest<T = unknown>(
+  table: string,
+  options?: SupabaseRestOptions,
+): Promise<T> {
+  const method = options?.method ?? "GET";
+  const serviceRoleKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const requestUrl = buildSupabaseRestUrl(table, options?.params);
+
+  const requestHeaders: Record<string, string> = {
+    apikey: serviceRoleKey,
+    Authorization: `Bearer ${serviceRoleKey}`,
+    ...options?.headers,
+  };
+
+  if (method === "POST" && !requestHeaders["Prefer"]) {
+    requestHeaders["Prefer"] = "return=representation";
+  }
+
+  if (options?.body) {
+    requestHeaders["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(requestUrl, {
+    method,
+    headers: requestHeaders,
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Supabase REST request failed (${method} ${requestUrl.pathname}): ${response.status} ${response.statusText} ${errorBody}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const rawBody = await response.text();
+
+  if (!rawBody) {
+    return undefined as T;
+  }
+
+  return JSON.parse(rawBody) as T;
+}
+
+export async function seedRow(
+  table: string,
+  data: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const rows = await supabaseRequest<Record<string, unknown>[]>(table, {
+    method: "POST",
+    body: data,
+  });
+
+  const [createdRow] = rows;
+
+  if (!createdRow) {
+    throw new Error(`Supabase REST seedRow did not return created row for table: ${table}`);
+  }
+
+  return createdRow;
+}
+
+export async function seedRows(
+  table: string,
+  data: Record<string, unknown>[],
+): Promise<Record<string, unknown>[]> {
+  return supabaseRequest<Record<string, unknown>[]>(table, {
+    method: "POST",
+    body: data,
+  });
+}
+
+export async function deleteRows(table: string, filters: Record<string, string>): Promise<void> {
+  await supabaseRequest(table, {
+    method: "DELETE",
+    params: filters,
+  });
+}

--- a/ui/e2e/resources/resources-page.ts
+++ b/ui/e2e/resources/resources-page.ts
@@ -13,13 +13,24 @@ export class ResourcesPage {
   constructor(private readonly page: Page) {}
 
   async gotoList(): Promise<void> {
+    // Use page.waitForURL() for App Router SPA navigation.
+    // NEVER use page.waitForFunction(() => window.location...) — it's unreliable
+    // with Next.js prefetching in production builds.
     await this.page.goto("/dashboard/resources");
     await this.page.waitForURL(/\/dashboard\/resources/);
   }
 
   async gotoNew(): Promise<void> {
+    // Use page.waitForURL() for App Router SPA navigation.
+    // NEVER use page.waitForFunction(() => window.location...) — it's unreliable
+    // with Next.js prefetching in production builds.
     await this.page.goto("/dashboard/resources/new");
     await this.page.waitForURL(/\/dashboard\/resources\/new/);
+  }
+
+  async navigateToList(): Promise<void> {
+    await this.page.getByRole("link", { name: "Resources" }).click();
+    await this.page.waitForURL(/\/dashboard\/resources/, { timeout: 10_000 });
   }
 
   async fillForm(data: ResourceFormData): Promise<void> {

--- a/ui/e2e/resources/resources-seed.ts
+++ b/ui/e2e/resources/resources-seed.ts
@@ -1,0 +1,127 @@
+import { deleteRows, seedRows, supabaseRequest } from "../helpers/supabase-rest";
+
+const SEED_PREFIX = "e2e-resource";
+
+interface AdminProfileSeedContext {
+  id: string;
+  tenantId: string;
+}
+
+export interface SeededResource {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+}
+
+export async function getAdminTenantId(): Promise<string> {
+  const profiles = await supabaseRequest<Array<{ tenant_id: string }>>("profiles", {
+    params: { email: "eq.admin@enterprise.dev", select: "tenant_id" },
+  });
+
+  const [adminProfile] = profiles;
+
+  if (!adminProfile?.tenant_id) {
+    throw new Error("Unable to resolve tenant_id for admin@enterprise.dev from profiles table");
+  }
+
+  return adminProfile.tenant_id;
+}
+
+async function getAdminProfileContext(): Promise<AdminProfileSeedContext> {
+  const profiles = await supabaseRequest<Array<{ id: string; tenant_id: string }>>("profiles", {
+    params: {
+      email: "eq.admin@enterprise.dev",
+      select: "id,tenant_id",
+      limit: "1",
+    },
+  });
+
+  const [adminProfile] = profiles;
+
+  if (!adminProfile?.id || !adminProfile?.tenant_id) {
+    throw new Error("Unable to resolve admin profile context from profiles table");
+  }
+
+  return {
+    id: adminProfile.id,
+    tenantId: adminProfile.tenant_id,
+  };
+}
+
+/**
+ * Seeds test resources into the database.
+ * Call in beforeAll() hook.
+ * Returns the created records for use in test assertions.
+ */
+export async function seedResources(tenantId: string): Promise<SeededResource[]> {
+  const adminProfile = await getAdminProfileContext();
+  const safeTenantId = tenantId || adminProfile.tenantId;
+  const suffix = Date.now();
+
+  const seededRows = await seedRows("resources", [
+    {
+      tenant_id: safeTenantId,
+      created_by: adminProfile.id,
+      title: `${SEED_PREFIX}-${suffix}-document-active`,
+      type: "document",
+      status: "active",
+      description: "E2E seeded resource for filter and detail tests",
+    },
+    {
+      tenant_id: safeTenantId,
+      created_by: adminProfile.id,
+      title: `${SEED_PREFIX}-${suffix}-asset-draft`,
+      type: "asset",
+      status: "draft",
+      description: "E2E seeded resource draft entry",
+    },
+    {
+      tenant_id: safeTenantId,
+      created_by: adminProfile.id,
+      title: `${SEED_PREFIX}-${suffix}-service-suspended`,
+      type: "service",
+      status: "suspended",
+      description: "E2E seeded resource suspended entry",
+    },
+    {
+      tenant_id: safeTenantId,
+      created_by: adminProfile.id,
+      title: `${SEED_PREFIX}-${suffix}-other-archived`,
+      type: "other",
+      status: "archived",
+      description: "E2E seeded resource archived entry",
+    },
+  ]);
+
+  return seededRows.map((row) => {
+    const id = row["id"];
+    const title = row["title"];
+    const type = row["type"];
+    const status = row["status"];
+
+    if (
+      typeof id !== "string" ||
+      typeof title !== "string" ||
+      typeof type !== "string" ||
+      typeof status !== "string"
+    ) {
+      throw new Error("Supabase REST seedResources returned an unexpected row shape");
+    }
+
+    return {
+      id,
+      title,
+      type,
+      status,
+    };
+  });
+}
+
+/**
+ * Cleans up seeded resources.
+ * Call in afterAll() hook.
+ */
+export async function teardownResources(): Promise<void> {
+  await deleteRows("resources", { title: `like.${SEED_PREFIX}-%` });
+}

--- a/ui/e2e/resources/resources.spec.ts
+++ b/ui/e2e/resources/resources.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "@playwright/test";
 import { login } from "../helpers/auth";
 import { ResourcesPage } from "./resources-page";
+import {
+  getAdminTenantId,
+  type SeededResource,
+  seedResources,
+  teardownResources,
+} from "./resources-seed";
 
 test.describe("Resources", () => {
   test("unauthenticated request to /dashboard/resources redirects to sign-in", async ({ page }) => {
@@ -22,18 +28,28 @@ test.describe("Resources", () => {
   });
 
   test.describe("authenticated flows (require running app + seeded DB)", () => {
-    const uniqueTitle = `E2E Resource ${Date.now()}`;
+    let seededResources: SeededResource[] = [];
+
+    test.beforeAll(async () => {
+      const tenantId = await getAdminTenantId();
+      seededResources = await seedResources(tenantId);
+    });
+
+    test.afterAll(async () => {
+      await teardownResources();
+    });
 
     test("create resource happy path: fill form → submit → resource appears in list", async ({
       page,
     }) => {
       const resourcesPage = new ResourcesPage(page);
+      const createdTitle = `E2E UI Resource ${Date.now()}`;
 
       await login(page);
       await resourcesPage.gotoNew();
 
       await resourcesPage.fillForm({
-        title: uniqueTitle,
+        title: createdTitle,
         type: "Document",
         status: "Active",
         description: "Resource created from E2E test",
@@ -42,73 +58,81 @@ test.describe("Resources", () => {
       await resourcesPage.submitForm();
 
       await resourcesPage.gotoList();
-      await resourcesPage.expectResourceInTable(uniqueTitle);
+      await resourcesPage.expectResourceInTable(createdTitle);
     });
 
     test("list with type filter: applying 'Document' sets type query param", async ({ page }) => {
       const resourcesPage = new ResourcesPage(page);
+      const seededDocument = seededResources.find((resource) => resource.type === "document");
+
+      if (!seededDocument) {
+        test.skip();
+        return;
+      }
 
       await login(page);
       await resourcesPage.gotoList();
       await resourcesPage.filterByType("Document");
 
       await expect(page).toHaveURL(/type=document/);
+      await resourcesPage.expectResourceInTable(seededDocument.title);
     });
 
     test("list with status filter: applying 'Active' sets status query param", async ({ page }) => {
       const resourcesPage = new ResourcesPage(page);
+      const activeResource = seededResources.find((resource) => resource.status === "active");
+
+      if (!activeResource) {
+        test.skip();
+        return;
+      }
 
       await login(page);
       await resourcesPage.gotoList();
       await resourcesPage.filterByStatus("Active");
 
       await expect(page).toHaveURL(/status=active/);
+      await resourcesPage.expectResourceInTable(activeResource.title);
     });
 
     test("view resource detail: clicking View opens detail page", async ({ page }) => {
       const resourcesPage = new ResourcesPage(page);
+      const targetResource = seededResources[0];
 
-      await login(page);
-      await resourcesPage.gotoList();
-
-      const rows = page.getByRole("row");
-      const rowCount = await rows.count();
-
-      if (rowCount <= 1) {
+      if (!targetResource) {
         test.skip();
         return;
       }
 
-      const firstRow = rows.nth(1);
-      const titleCell = firstRow.getByRole("cell").nth(0);
-      const title = (await titleCell.textContent()) ?? "";
+      await login(page);
+      await resourcesPage.gotoList();
 
-      await firstRow.getByRole("link", { name: "View" }).click();
+      await resourcesPage.expectResourceInTable(targetResource.title);
+      await resourcesPage.clickViewResource(targetResource.title);
       await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+$/);
       // CardTitle renders a <div>, not a semantic heading, so use getByText
       // with .first() to avoid strict mode violation (title also appears in breadcrumb).
-      await expect(page.getByText(title).first()).toBeVisible();
+      await expect(page.getByText(targetResource.title).first()).toBeVisible();
     });
 
     test("edit resource: change title and save → updated title appears in list", async ({
       page,
     }) => {
       const resourcesPage = new ResourcesPage(page);
-      const editedTitle = `Edited Resource ${Date.now()}`;
+      const resourceToEdit = seededResources[1];
 
-      await login(page);
-      await resourcesPage.gotoList();
-
-      const rows = page.getByRole("row");
-      const rowCount = await rows.count();
-
-      if (rowCount <= 1) {
+      if (!resourceToEdit) {
         test.skip();
         return;
       }
 
-      const firstRow = rows.nth(1);
-      await firstRow.getByRole("link", { name: "Edit" }).click();
+      const editedTitle = `${resourceToEdit.title}-edited`;
+
+      await login(page);
+      await resourcesPage.gotoList();
+
+      await resourcesPage.expectResourceInTable(resourceToEdit.title);
+      await resourcesPage.clickEditResource(resourceToEdit.title);
       await expect(page).toHaveURL(/\/dashboard\/resources\/[0-9a-f-]+\/edit/);
 
       await page.getByLabel("Title").fill(editedTitle);
@@ -122,7 +146,7 @@ test.describe("Resources", () => {
       page,
     }) => {
       const resourcesPage = new ResourcesPage(page);
-      const deleteTitle = `Delete Resource ${Date.now()}`;
+      const deleteTitle = `E2E UI Resource Delete ${Date.now()}`;
 
       await login(page);
 

--- a/ui/e2e/settings/settings-page.ts
+++ b/ui/e2e/settings/settings-page.ts
@@ -1,0 +1,24 @@
+import { expect, type Page } from "@playwright/test";
+
+export class SettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoSettings(): Promise<void> {
+    await this.page.goto("/dashboard/settings");
+    await this.page.waitForURL(/\/dashboard\/settings(?:\?.*)?$/, { timeout: 10_000 });
+  }
+
+  async expectSettingsHeading(): Promise<void> {
+    await expect(
+      this.page.getByRole("main").getByRole("heading", { name: "Settings" }),
+    ).toBeVisible();
+  }
+
+  async expectAccountCard(): Promise<void> {
+    await expect(this.page.getByText("Account", { exact: true })).toBeVisible();
+  }
+
+  async expectWorkspaceCard(): Promise<void> {
+    await expect(this.page.getByText("Workspace", { exact: true })).toBeVisible();
+  }
+}

--- a/ui/e2e/settings/settings.spec.ts
+++ b/ui/e2e/settings/settings.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { login } from "../helpers/auth";
+import { SettingsPage } from "./settings-page";
+
+test.describe("Settings", () => {
+  test("unauthenticated request to /dashboard/settings redirects to sign-in", async ({ page }) => {
+    await page.goto("/dashboard/settings");
+
+    await expect(page).toHaveURL(/\/sign-in\?redirectTo=%2Fdashboard%2Fsettings/);
+  });
+
+  test("authenticated request to /dashboard/settings shows Settings heading", async ({ page }) => {
+    const settingsPage = new SettingsPage(page);
+
+    await login(page);
+    await settingsPage.gotoSettings();
+
+    await settingsPage.expectSettingsHeading();
+  });
+
+  test("authenticated settings page shows Account and Workspace cards", async ({ page }) => {
+    const settingsPage = new SettingsPage(page);
+
+    await login(page);
+    await settingsPage.gotoSettings();
+
+    await settingsPage.expectAccountCard();
+    await settingsPage.expectWorkspaceCard();
+  });
+
+  test("navigate from dashboard via sidebar to settings", async ({ page }) => {
+    const settingsPage = new SettingsPage(page);
+
+    await login(page);
+    await page.getByRole("link", { name: "Settings" }).click();
+    await expect(page).toHaveURL(/\/dashboard\/settings(?:\?.*)?$/);
+
+    await settingsPage.expectSettingsHeading();
+  });
+});


### PR DESCRIPTION
## Summary

- rewrite the example PRD/RFC so they serve as generic template references instead of InmoAutos-specific docs
- add E2E infrastructure improvements inspired by SalaTicket, including programmatic Supabase seeding and expanded Page Object coverage

## What changed

### Example docs
- Rewrote `docs/example-prd.md` as a generic PRD example
- Rewrote `docs/example-rfc.md` as a generic RFC example
- Removed domain-specific references and narrowed the examples to template-oriented structure

### E2E improvements
- Added `ui/e2e/helpers/supabase-rest.ts` for programmatic seed/teardown via PostgREST
- Added `ui/e2e/resources/resources-seed.ts` with per-feature seeded setup/cleanup
- Refactored `ui/e2e/resources/resources.spec.ts` to rely on seeded data instead of UI-created dependencies
- Added `ui/e2e/settings/settings-page.ts` and `ui/e2e/settings/settings.spec.ts`
- Documented the anti-skeleton test pattern in `docs/testing-architecture.md`
- Updated `playwright.config.ts` with empty default permissions for future device-permission features

## Why

PR #16 was already merged before these follow-up changes were added to the branch. This PR cleanly reapplies only the two commits that were not part of `main`.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`