### PR TITLE
refactor: normalize RLS claims to app_metadata and redesign documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,156 +1,175 @@
-# Enterprise Platform Starter Template
+# 🚀 Enterprise Platform Template
 
-Multi-tenant enterprise starter/template built with Next.js, Supabase, and a strict monorepo architecture.
+**A production-ready multi-tenant starter for building secure enterprise applications.**  
+Built with Next.js 15, React 19, TypeScript 5.7, Supabase, Drizzle ORM, Tailwind CSS 4, and Turborepo.
 
-This repository is a **starter foundation**, not a finished SaaS product.
+![TypeScript](https://img.shields.io/badge/TypeScript-5.7+-3178C6?logo=typescript&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-15+-000000?logo=next.js&logoColor=white)
+![React](https://img.shields.io/badge/React-19-149ECA?logo=react&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-06B6D4?logo=tailwind-css&logoColor=white)
+![Turborepo](https://img.shields.io/badge/Turborepo-2.9+-EF4444?logo=turborepo&logoColor=white)
+![pnpm](https://img.shields.io/badge/pnpm-9+-F69220?logo=pnpm&logoColor=white)
+![Supabase](https://img.shields.io/badge/Supabase-latest-3ECF8E?logo=supabase&logoColor=white)
+![Drizzle ORM](https://img.shields.io/badge/Drizzle_ORM-1-111827)
+![Biome](https://img.shields.io/badge/Biome-2-60A5FA)
+![Playwright](https://img.shields.io/badge/Playwright-latest-2EAD33?logo=playwright&logoColor=white)
+![Vitest](https://img.shields.io/badge/Vitest-3-6E9F18?logo=vitest&logoColor=white)
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 
-## What this template includes (current state)
+---
 
-- Monorepo with package boundaries:
-  - `@enterprise/contracts` (Zod schemas + DTOs)
-  - `@enterprise/db` (Drizzle schema)
-  - `@enterprise/core` (Supabase clients, auth/service utilities)
-  - `@enterprise/ui` (shared UI primitives/tokens)
-  - `@enterprise/web` (Next.js App Router app)
-- Auth starter surface:
-  - `/sign-in`
-  - `/sign-up`
-  - `/forgot-password`
-  - `/reset-password`
-  - `/auth/callback` route for OTP/link flows
-  - `/login` compatibility redirect to `/sign-in`
-- Protected dashboard shell with starter pages:
-  - `/dashboard`
-  - `/dashboard/settings`
-- Starter dashboard data pulled from real Supabase tables (`tenants`, `profiles`) in server components
-- Testing baseline:
-  - Unit tests via Vitest (contracts/core/web coverage projects)
-  - Smoke E2E via Playwright (`ui/e2e/smoke`)
+## ✨ Features
 
-## What this template does NOT include
+- 🏗️ **Monorepo Architecture** — Turborepo + pnpm with 5 packages
+- 🏢 **Multi-Tenant** — RLS-based tenant isolation, ready for SaaS
+- 🔐 **Auth System** — Sign in, sign up, password reset, role-based access
+- 📊 **Dashboard Shell** — Protected pages with sidebar navigation
+- 🧩 **Reference Module** — Full CRUD example (Resources) showing every pattern
+- 🗄️ **Drizzle ORM** — Type-safe PostgreSQL schema with RLS policies
+- 📦 **Shared Contracts** — Zod schemas as single source of truth
+- 🎨 **shadcn/ui** — Component library with design tokens
+- 🧪 **Testing** — Vitest unit tests + Playwright E2E with Page Objects
+- 🤖 **AI Agent Skills** — 20+ curated skills for AI-assisted development
+- 📝 **Architecture Docs** — Comprehensive docs for onboarding
 
-- Completed business modules (billing, subscriptions, CRM, analytics, etc.)
-- Production-ready onboarding, admin panel, or role workflows beyond starter auth scaffolding
-- Fully automated tenant provisioning workflows for your specific product domain
+> This repository is a template starter, not a finished product. Use it as a strong foundation for your own SaaS domain.
 
-If you publish a fork, plan to define product-specific features and operations for your own product domain.
+## 📦 Tech Stack
 
-## Quick start
+| Category | Technology | Version | Purpose |
+|----------|-----------|---------|---------|
+| Framework | Next.js | 15+ | App Router, Server Actions, SSR |
+| UI Library | React | 19 | Server Components, React Compiler |
+| Language | TypeScript | 5.7+ | Strict mode everywhere |
+| Styling | Tailwind CSS | 4 | Utility-first with theme tokens |
+| Components | shadcn/ui | latest | Radix + CVA primitives |
+| State | Zustand | 5 | Client state (selective) |
+| Validation | Zod | 3 | Runtime schema validation |
+| Database | Drizzle ORM | 1 | Type-safe PostgreSQL schema |
+| Backend | Supabase | latest | Auth + DB + RLS + Storage + Realtime |
+| Monorepo | Turborepo | 2.9+ | Build orchestration + caching |
+| Lint/Format | Biome | 2 | Single tool (replaces ESLint + Prettier) |
+| Unit Tests | Vitest | 3 | Fast unit testing |
+| E2E Tests | Playwright | latest | Browser automation + Page Objects |
+| Package Manager | pnpm | 9+ | Fast, disk-efficient |
 
-### 1) Prerequisites
-
-- Node.js `>=20`
-- pnpm `>=9`
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (required for Supabase local)
-- [Supabase CLI](https://supabase.com/docs/guides/cli/getting-started) (`brew install supabase/tap/supabase`)
-
-### 2) Install and configure
-
-```bash
-pnpm install
-cp .env.example .env.local
-ln -s ../.env.local ui/.env.local
-```
-
-The `.env.example` comes pre-configured with Supabase local defaults — no changes needed for local dev.
-
-Next.js loads `.env.local` from `ui/`. The symlink makes it read the monorepo root file.
-
-### 3) Start Supabase local
-
-```bash
-supabase start
-```
-
-This starts a full Supabase stack in Docker (Postgres, Auth, Storage, Studio), applies all migrations from `supabase/migrations/`, and seeds a test user from `supabase/seed.sql`.
-
-| Service | URL |
-|---------|-----|
-| API | http://127.0.0.1:55331 |
-| Studio (DB admin) | http://127.0.0.1:55333 |
-| Inbucket (email capture) | http://127.0.0.1:55334 |
-| Postgres | `postgresql://postgres:postgres@127.0.0.1:55332/postgres` |
-
-Test user credentials (from seed):
-- Email: `admin@enterprise.dev`
-- Password: `password123`
-- Additional seeded users: `member@enterprise.dev`, `guest@enterprise.dev`, `reset@enterprise.dev`, `reset2@enterprise.dev` (all with `password123`)
-
-### 4) Run development
-
-```bash
-pnpm dev
-```
-
-App routes:
-- Auth: `http://localhost:3000/sign-in`
-- Dashboard: `http://localhost:3000/dashboard`
-
-### Useful Supabase commands
-
-```bash
-supabase start              # Start local stack (migrations + seed)
-supabase stop               # Stop (data persisted in Docker volumes)
-supabase db reset           # Re-apply all migrations + seed from scratch
-supabase status             # Show running services and URLs
-```
-
-## Required configuration notes
-
-- `NEXT_PUBLIC_APP_URL` is strongly recommended and used for auth redirect URLs
-- In production, a canonical app URL is required (`NEXT_PUBLIC_APP_URL`, fallback `NEXT_PUBLIC_SITE_URL` or `APP_URL`)
-- `SUPABASE_SERVICE_ROLE_KEY` is server-only and must never be exposed in client code
-- Drizzle uses `DATABASE_URL` for migration tooling
-
-See:
-- [Supabase setup](./docs/supabase-setup.md)
-- [Onboarding checklist](./docs/onboarding-checklist.md)
-
-## AI Skills Setup
-
-This template ships repo-local skills in `skills/`, but AI runtimes discover them through runtime-specific directories such as `.agents/skills/`.
-
-Use the setup script to wire the repo skills into your editor/runtime:
-
-```bash
-# OpenCode runtime only
-pnpm skills:setup
-
-# Configure all supported runtimes (Claude, OpenCode, Gemini, Codex, Copilot)
-pnpm skills:setup:all
-
-# Regenerate AGENTS auto-invoke tables from skill metadata
-pnpm skills:sync
-```
-
-What the setup script does:
-- creates `.agents/skills -> skills/` for OpenCode
-- can also create `.claude/skills`, `.gemini/skills`, and `.codex/skills`
-- copies `AGENTS.md` into runtime-specific instruction files where needed
-
-If you add or modify a local skill:
-1. edit `skills/{name}/SKILL.md`
-2. add/update `metadata.scope` and `metadata.auto_invoke`
-3. run `pnpm skills:sync`
-4. rerun `pnpm skills:setup` for your runtime if needed
-
-## Architecture summary
+## 🏛️ Architecture
 
 ```text
-@enterprise/web -> @enterprise/contracts, @enterprise/core, @enterprise/db, @enterprise/ui
-@enterprise/core -> @enterprise/contracts, @enterprise/db
-@enterprise/contracts -> zod only
-@enterprise/db -> drizzle-orm only
-@enterprise/ui -> UI-only dependencies
+┌─────────────────────────────────────────────────────────┐
+│                   @enterprise/web (ui/)                │
+│             Next.js 15 · App Router · SSR              │
+│                                                         │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐              │
+│  │  (auth)  │  │(dashboard)│ │ features │              │
+│  │ Sign In  │  │  Shell   │  │Resources │              │
+│  │ Sign Up  │  │ Settings │  │  CRUD    │              │
+│  └──────────┘  └──────────┘  └──────────┘              │
+├─────────────────────────────────────────────────────────┤
+│         ▼              ▼             ▼                 │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │             @enterprise/contracts               │    │
+│  │         Zod Schemas · Shared DTOs · Types      │    │
+│  └─────────────────────────────────────────────────┘    │
+│         ▼              ▼             ▼                 │
+│  ┌────────────┐ ┌────────────┐ ┌────────────┐          │
+│  │@enterprise/│ │@enterprise/│ │@enterprise/│          │
+│  │core        │ │db          │ │ui          │          │
+│  │Services,   │ │Drizzle ORM │ │shadcn/ui,  │          │
+│  │Auth, Utils │ │Schema, RLS │ │Tokens      │          │
+│  └────────────┘ └────────────┘ └────────────┘          │
+└─────────────────────────────────────────────────────────┘
 ```
 
-Key principles implemented in the starter:
-- Feature-oriented app structure under `ui/features/*`
-- Server-first data access with Supabase SSR clients
-- Service-layer-driven mutations (actions as thin wrappers)
-- Multi-tenant posture via tenant-aware data model + RLS-oriented architecture
+| Package | Path | Responsibility | Allowed Dependencies |
+|---------|------|----------------|----------------------|
+| `@enterprise/web` | `ui/` | Next.js app, routes, Server Actions, feature UI | `@enterprise/contracts`, `@enterprise/core`, `@enterprise/db`, `@enterprise/ui` |
+| `@enterprise/contracts` | `packages/contracts/` | Zod schemas, DTOs, shared types | `zod` only |
+| `@enterprise/core` | `packages/core/` | Services, auth utilities, Supabase clients | `@enterprise/contracts`, `@enterprise/db` |
+| `@enterprise/db` | `packages/db/` | Drizzle schema, policies, exported DB types | `drizzle-orm` only |
+| `@enterprise/ui` | `packages/ui/` | Shared design system primitives | UI-only deps (`clsx`, `tailwind-merge`, CVA, Radix, icons) |
 
-## Testing and quality commands
+## 👥 Users and Roles
+
+| Role | Read | Create | Update | Archive | Manage Users | View Audit | Enforcement |
+|------|------|--------|--------|---------|--------------|------------|-------------|
+| `owner` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | RLS + UI guards |
+| `admin` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | RLS + UI guards |
+| `member` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | RLS + UI guards |
+| `guest` | ✅ (limited) | ❌ | ❌ | ❌ | ❌ | ❌ | RLS + UI guards |
+
+Roles are stored in the `profiles` table and mirrored into JWT `app_metadata` (`tenant_id`, `role`) so PostgreSQL policies can evaluate authorization directly at query time.
+
+In this template, write operations are intentionally strict (`owner` and `admin` only for resources) to model enterprise defaults. You can extend this matrix per module, but keep the same policy-first approach.
+
+## 🏢 Multi-Tenant Model
+
+```text
+Supabase Auth (auth.users)
+        │
+        ▼ trigger: handle_new_user()
+   ┌─────────┐
+   │ tenants │ ← one per organization
+   └────┬────┘
+        │
+   ┌────▼────┐
+   │profiles │ ← user + tenant + role
+   └────┬────┘
+        │
+   ┌────▼─────────────────────────┐
+   │ domain tables (resources...) │
+   │ all have tenant_id + RLS     │
+   └──────────────────────────────┘
+```
+
+When a user signs up, the `handle_new_user()` trigger creates a tenant and a profile automatically.
+
+All domain tables include `tenant_id`. Every query is filtered by RLS, and policy checks read `tenant_id` + `role` from JWT claims in `app_metadata`. This keeps tenant isolation enforced in the database, not only in UI code.
+
+## 🔐 Security and RLS
+
+This template uses a three-layer security model:
+
+1. **Auth layer** — Supabase Auth issues JWTs and validates sessions.
+2. **Database layer** — RLS policies run on every protected table.
+3. **UI layer** — role checks hide unauthorized actions and routes.
+
+RLS claim pattern used across policies:
+
+```sql
+auth.jwt()->'app_metadata'->>'tenant_id'
+auth.jwt()->'app_metadata'->>'role'
+```
+
+Practical result:
+
+- Even if a UI bug exposes a button, unauthorized writes are blocked by RLS.
+- Even if someone crafts a direct API call, tenant isolation still holds.
+- Authorization is centralized in SQL policies, with UI checks for better UX.
+
+## 🧩 Example Module: Resources
+
+The `resources` module is the reference vertical slice for building new features.
+
+It demonstrates the full chain:
+
+1. **DB schema** (`packages/db/src/schema/resources.ts`) and RLS policies.
+2. **Contracts** (`packages/contracts/src/schemas/resources.ts`, DTOs/types).
+3. **Service** (`packages/core/src/services/resource-service.ts`) with `ServiceResult<T>`.
+4. **Actions/queries** (`ui/features/resources/actions.ts`, `queries.ts`) as thin wrappers.
+5. **Pages/components** under `ui/app/(dashboard)/dashboard/resources/` and `ui/features/resources/components/`.
+6. **Tests** in unit + E2E (`packages/*/resources*.test.ts`, `ui/e2e/resources/`).
+
+Use this as your blueprint for new modules such as projects, customers, assets, or tickets.
+
+## 🧪 Testing Strategy
+
+| Type | Tool | What | Location |
+|------|------|------|----------|
+| Unit | Vitest | Contracts, services, utils | `*.test.ts` colocated |
+| E2E | Playwright | Auth flows, CRUD, settings | `ui/e2e/` |
+
+Quality gates:
 
 ```bash
 pnpm typecheck
@@ -159,57 +178,145 @@ pnpm test
 pnpm e2e
 ```
 
-Notes:
-- `pnpm test` runs Vitest projects across workspaces
-- `pnpm e2e` runs Playwright auth + smoke coverage using `/sign-in` as canonical route (`/login` is compatibility redirect)
+`pnpm test` runs workspace unit projects through Turborepo.  
+`pnpm e2e` runs browser flows with Page Object patterns.
 
-## Instantiation
+## 🚀 Quick Start
 
-Use the provided script to create a new app instance:
+### 1) Prerequisites
+
+- Node.js `>=20`
+- pnpm `>=9`
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [Supabase CLI](https://supabase.com/docs/guides/cli/getting-started)
+
+### 2) Install + configure
 
 ```bash
-pnpm instantiate --name "My App" --domain "myapp.com"
+pnpm install
+cp .env.example .env.local
+ln -s ../.env.local ui/.env.local
 ```
 
-After instantiation, review package names, environment variables, and external service setup before deployment.
+Notes:
 
-## Technology stack
+- `.env.example` is pre-configured for local Supabase defaults.
+- The symlink makes Next.js in `ui/` consume the root `.env.local`.
 
-- Next.js 15 (App Router)
-- React 19
-- TypeScript 5.7+ (strict)
-- Tailwind CSS 4 + shadcn/ui
-- Supabase (Auth + Postgres + Storage)
-- Drizzle ORM
-- Vitest + Playwright
-- **Zod 3.24-compatible patterns (current repo state)**
+### 3) Start Supabase local
 
-## Caveats for public/template usage
+```bash
+supabase start
+```
 
-- This starter has improved baseline quality, but deeper product workflows still need implementation for real production SaaS use
-- Some docs/ADRs are architecture references and may require adaptation for your fork
-- Treat this as a strong foundation, not a plug-and-play finished product
+This starts Postgres + Auth + Storage + Studio, applies migrations, and runs `supabase/seed.sql`.
 
-## Documentation
+| Service | URL |
+|---------|-----|
+| API | http://127.0.0.1:55331 |
+| Studio | http://127.0.0.1:55333 |
+| Inbucket | http://127.0.0.1:55334 |
+| Postgres | `postgresql://postgres:postgres@127.0.0.1:55332/postgres` |
 
-### Getting started
+Seeded users for local development:
+
+- `admin@enterprise.dev` / `password123` (owner)
+- `member@enterprise.dev` / `password123`
+- `guest@enterprise.dev` / `password123`
+- `reset@enterprise.dev` / `password123`
+- `reset2@enterprise.dev` / `password123`
+
+### 4) Run dev
+
+```bash
+pnpm dev
+```
+
+Default routes:
+
+- Auth: `http://localhost:3000/sign-in`
+- Dashboard: `http://localhost:3000/dashboard`
+
+### 5) Useful commands
+
+```bash
+supabase start
+supabase stop
+supabase db reset
+supabase status
+
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm e2e
+```
+
+## 📁 Project Structure
+
+```text
+enterprise-platform-template/
+├── ui/                          → @enterprise/web (Next.js app)
+│   ├── app/(auth)/              → Auth pages
+│   ├── app/(dashboard)/         → Protected dashboard
+│   ├── features/resources/      → Example feature module
+│   └── e2e/                     → Playwright tests
+├── packages/
+│   ├── contracts/               → Zod schemas, DTOs, types
+│   ├── core/                    → Services, auth, Supabase clients
+│   ├── db/                      → Drizzle schema, RLS policies
+│   └── ui/                      → shadcn/ui components, tokens
+├── supabase/
+│   ├── config.toml              → Local Supabase config
+│   ├── migrations/              → SQL migrations
+│   └── seed.sql                 → Test user seed data
+└── docs/                        → Architecture and guides
+```
+
+## 📚 Documentation
+
+### Architecture
+
+- [Architecture Overview](./docs/architecture/overview.md)
+- [Users and Roles](./docs/architecture/users-and-roles.md)
+- [Multi-Tenant Model](./docs/architecture/multi-tenant.md)
+- [Service Layer](./docs/architecture/service-layer.md)
+- [Request Flow](./docs/architecture/request-flow.md)
+- [Resources Module](./docs/architecture/resources-module.md)
+- [MDX Migration Note](./docs/architecture/mdx-migration.md)
+
+### Project Guides
+
 - [Onboarding checklist](./docs/onboarding-checklist.md)
 - [Extension patterns](./docs/extension-patterns.md)
 - [Code conventions](./docs/code-conventions.md)
 - [Testing architecture](./docs/testing-architecture.md)
 
-### External services
+### External Services
+
 - [Supabase setup](./docs/supabase-setup.md)
 - [Vercel deployment](./docs/vercel-deployment.md)
 - [Sentry setup](./docs/sentry-setup.md)
 - [Resend setup](./docs/resend-setup.md)
 
-### Architecture decisions (ADRs)
+### ADRs
+
 - [ADR 001: Platform architecture](./docs/adr/001-platform-architecture.md)
 - [ADR 002: RLS helper functions](./docs/adr/002-rls-helper-functions.md)
 - [ADR 003: Service layer](./docs/adr/003-service-layer.md)
 - [ADR 004: Package dependencies](./docs/adr/004-package-dependencies.md)
 
-## License
+## 🤖 AI Skills
+
+This template includes repo-local AI skills under `skills/` to accelerate repetitive architecture and implementation tasks.
+
+```bash
+pnpm skills:setup      # Wire skills for OpenCode runtime
+pnpm skills:setup:all  # Wire all supported runtimes
+pnpm skills:sync       # Regenerate AGENTS auto-invoke tables
+```
+
+If you add or modify a skill, update metadata and rerun `skills:sync`.
+
+## 📝 License
 
 MIT. See [LICENSE](./LICENSE).

--- a/docs/architecture/mdx-migration.md
+++ b/docs/architecture/mdx-migration.md
@@ -1,0 +1,27 @@
+# MDX Migration Note
+
+Current architecture documentation is intentionally maintained as plain Markdown (`.md`) files.
+
+---
+
+## Current state
+
+- All docs in `docs/architecture/` are Markdown-only.
+- This keeps authoring simple and compatible with any editor, static renderer, or docs pipeline.
+
+## Planned future direction
+
+An MDX migration is planned for a future iteration, not the current one.
+
+Potential MDX benefits include:
+
+- Interactive diagrams and embedded visual components
+- Tabbed code examples (for service/action/query variants)
+- Reusable callout components for conventions and warnings
+- Richer onboarding experiences with dynamic snippets
+
+## Decision for now
+
+No migration action is required at this time.
+
+This is a roadmap item that can be evaluated when docs platform requirements justify MDX complexity.

--- a/docs/architecture/multi-tenant.md
+++ b/docs/architecture/multi-tenant.md
@@ -1,0 +1,139 @@
+# Multi-Tenant Architecture
+
+This template implements shared-database multi-tenancy where every domain row is tenant-scoped and enforced through PostgreSQL RLS.
+
+---
+
+## What multi-tenant means here
+
+All tenants live in the same database, but each tenant sees only its own data.
+
+Isolation is achieved through:
+
+- `tenant_id` column on tenant-scoped tables
+- JWT claims (`tenant_id`, `role`) in `app_metadata`
+- RLS policies that compare row tenant with claim tenant
+
+This avoids per-tenant databases while still enforcing strict boundaries.
+
+## Tenant creation flow
+
+```text
+auth.users INSERT (sign-up)
+        │
+        ▼
+handle_new_user() trigger
+  ├─ INSERT public.tenants
+  └─ INSERT public.profiles (role = owner)
+        │
+        ▼
+Application uses tenant_id from JWT claims
+```
+
+The trigger function runs as `SECURITY DEFINER`, which is necessary because target tables are RLS-protected.
+
+## Data isolation pattern
+
+Every tenant-scoped table follows the same model:
+
+1. Include `tenant_id UUID NOT NULL`.
+2. Enable row level security.
+3. Add `SELECT` policy for same-tenant users.
+4. Add mutation policies based on both tenant and role.
+
+Example from `resources`:
+
+- `SELECT`: any authenticated user in same tenant
+- `INSERT/UPDATE/DELETE`: only `owner` or `admin` in same tenant
+
+## JWT claim structure
+
+RLS relies on claims in `auth.users.raw_app_meta_data`:
+
+```json
+{
+  "provider": "email",
+  "providers": ["email"],
+  "tenant_id": "<uuid>",
+  "role": "owner"
+}
+```
+
+Policy expressions reference these fields directly.
+
+## RLS policy patterns
+
+### Tenant membership (read)
+
+```sql
+(auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id
+```
+
+### Tenant membership + elevated role (mutations)
+
+```sql
+(
+  (auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id
+  AND auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')
+)
+```
+
+Use this baseline unless a module explicitly requires broader write access.
+
+## Tenant data flow diagram
+
+```text
+Browser request with Supabase session
+        │
+        ▼
+Next.js server/action obtains user (JWT)
+        │
+        ▼
+Supabase executes SQL against tenant table
+        │
+        ▼
+RLS reads JWT app_metadata claims
+  ├─ tenant_id must match row tenant_id
+  └─ role must satisfy mutation policy
+        │
+        ▼
+Rows returned (or write denied)
+```
+
+## How to add a new tenant-scoped table
+
+1. **Schema** (`packages/db/src/schema/*.ts`)
+   - Add `tenantId` column (maps to `tenant_id`)
+   - Add indexes including `tenant_id`
+
+2. **Policies**
+   - Add select policy with tenant claim
+   - Add insert/update/delete policies with tenant + role checks
+
+3. **Migration**
+   - Generate SQL and verify only incremental changes are present
+
+4. **Contracts + services**
+   - Define DTOs in `@enterprise/contracts`
+   - Implement business logic in `@enterprise/core` service
+
+5. **Actions + UI**
+   - Keep actions thin
+   - Add role-aware controls in UI
+
+6. **Tests**
+   - Unit tests for service behavior
+   - E2E tests for tenant-safe CRUD flows
+
+## Common mistakes to avoid
+
+- Missing `tenant_id` on a domain table
+- Using app-level checks without RLS policies
+- Assuming UI guards are enough for security
+- Using service role credentials in request-driven user flows
+
+## Related docs
+
+- [Users and Roles](./users-and-roles.md)
+- [Request Flow](./request-flow.md)
+- [Service Layer](./service-layer.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,129 @@
+# Architecture Overview
+
+This template is a multi-tenant enterprise starter that enforces separation of concerns through package boundaries, a service layer, and database-first authorization with RLS.
+
+---
+
+## What this template is
+
+Enterprise Platform Template is a **foundation repository** for teams that want to start with strong defaults:
+
+- Monorepo boundaries already in place
+- Multi-tenant data model with tenant-scoped access
+- Auth + role model integrated with Supabase
+- Service layer pattern for business logic
+- Shared contracts as source of truth for inputs/outputs
+
+It is intentionally a template, not a complete product. You extend it with domain modules.
+
+## Package graph
+
+```text
+@enterprise/web (ui/)
+ ├─ depends on @enterprise/contracts
+ ├─ depends on @enterprise/core
+ ├─ depends on @enterprise/db
+ └─ depends on @enterprise/ui
+
+@enterprise/core
+ ├─ depends on @enterprise/contracts
+ └─ depends on @enterprise/db
+
+@enterprise/contracts
+ └─ depends on zod only
+
+@enterprise/db
+ └─ depends on drizzle-orm only
+
+@enterprise/ui
+ └─ UI-only dependencies (no business logic)
+```
+
+## Dependency direction rules
+
+```text
+Allowed:
+web -> contracts/core/db/ui
+core -> contracts/db
+contracts -> zod
+db -> drizzle-orm
+ui -> UI libs
+
+Forbidden:
+core -> web
+contracts -> core/db/web
+db -> core/contracts/web
+ui -> core/db/web
+```
+
+Why this matters:
+
+1. Keeps contracts reusable and framework-agnostic.
+2. Prevents hidden coupling between UI and database internals.
+3. Makes testing and refactoring easier because boundaries are explicit.
+
+## Layer ownership
+
+| Layer | Owns | Does not own |
+|-------|------|--------------|
+| `@enterprise/contracts` | DTO schemas, Zod validation, shared types | Database queries, UI components |
+| `@enterprise/db` | Table schemas, enums, indexes, RLS declarations | Feature business logic |
+| `@enterprise/core` | Business services, auth helpers, Supabase clients | Page components, route rendering |
+| `@enterprise/web` | Routes, Server Components, Server Actions, feature composition | Core business rules |
+| `@enterprise/ui` | Primitive components, styling tokens, UI utilities | Authentication, persistence logic |
+
+## Core conventions
+
+### 1) Service layer first
+
+Business logic lives in `packages/core/src/services/*`.
+
+- Services receive `SupabaseClient` as an argument.
+- Services return `ServiceResult<T>`.
+- Services do not call Next.js APIs such as `revalidatePath` or `redirect`.
+
+Server Actions in `ui/features/*/actions.ts` are thin wrappers around services.
+
+### 2) Contracts are the source of truth
+
+Every shared input/output schema should be defined in `@enterprise/contracts` and imported by:
+
+- Services
+- Actions
+- Forms
+- Tests
+
+This reduces shape drift between UI, server, and persistence layers.
+
+### 3) RLS everywhere
+
+Every tenant-scoped table uses `tenant_id` + RLS policies based on JWT claims.
+
+Policy pattern:
+
+```sql
+auth.jwt()->'app_metadata'->>'tenant_id'
+auth.jwt()->'app_metadata'->>'role'
+```
+
+This means authorization is enforced in PostgreSQL, not only in application code.
+
+## Reference module: resources
+
+`resources` is the canonical example feature and demonstrates the full vertical slice:
+
+1. DB schema + policies
+2. Contracts
+3. Service methods
+4. Server Actions
+5. App routes and components
+6. Unit + E2E tests
+
+See [Resources Module](./resources-module.md) for a complete map.
+
+## Related docs
+
+- [Users and Roles](./users-and-roles.md)
+- [Multi-Tenant Model](./multi-tenant.md)
+- [Service Layer](./service-layer.md)
+- [Request Flow](./request-flow.md)

--- a/docs/architecture/request-flow.md
+++ b/docs/architecture/request-flow.md
@@ -1,0 +1,148 @@
+# Request Flow
+
+This document explains how requests move from browser to database in this template, including where authentication and RLS checks occur.
+
+---
+
+## End-to-end flow
+
+```text
+Browser
+  │
+  ▼
+Next.js Route / Server Component / Server Action
+  │
+  ▼
+Feature Action/Query (ui/features/*)
+  │
+  ▼
+Service Layer (@enterprise/core/services/*)
+  │
+  ▼
+Supabase Client (@enterprise/core/supabase/*)
+  │
+  ▼
+PostgreSQL (RLS policies)
+```
+
+RLS is the final authority for tenant and role access.
+
+## CREATE operation flow (example: create resource)
+
+```text
+User submits form
+  │
+  ▼
+Server Action receives payload
+  │
+  ├─ Zod parse (createResourceSchema)
+  ├─ getServerClient()
+  ├─ auth.getUser() + tenant_id from app_metadata
+  ▼
+createResource(service)
+  │
+  ├─ insert into resources
+  ├─ optional audit log write (fire-and-forget)
+  ▼
+RLS checks tenant_id + role claim
+  │
+  ▼
+Action maps ServiceResult -> ActionResult
+  │
+  ▼
+revalidatePath("/dashboard/resources")
+```
+
+### Key checkpoints
+
+1. **Input validation** happens before DB access.
+2. **Auth context** comes from server-side user lookup.
+3. **Service** handles business logic and returns typed result.
+4. **RLS** decides whether write is actually allowed.
+
+## LIST operation flow (example: list resources)
+
+```text
+Browser loads /dashboard/resources
+  │
+  ▼
+Server Component page.tsx
+  │
+  ├─ requireAuth()
+  └─ getResources(query)
+        │
+        ▼
+listResources(service)
+        │
+        ▼
+SELECT from resources
+        │
+        ▼
+RLS filters rows by tenant_id claim
+```
+
+The UI receives only rows the current tenant is allowed to read.
+
+## Auth flow: sign-in to dashboard
+
+```text
+POST /sign-in
+  │
+  ▼
+signInAction -> signInWithPasswordService
+  │
+  ▼
+Supabase issues session cookies + JWT
+  │
+  ▼
+Next request enters middleware
+  │
+  ├─ updateSession() calls getUser() (refresh/validate)
+  ├─ reads profile.role
+  └─ redirects based on route + role
+  ▼
+Dashboard route renders if authenticated
+```
+
+Middleware guards protected pages (`/dashboard/*`) and redirects unauthenticated users to `/sign-in`.
+
+## Where RLS is applied
+
+RLS is evaluated in PostgreSQL for every query against protected tables:
+
+- `profiles`
+- `tenants`
+- `user_roles`
+- `audit_log`
+- `resources`
+
+Claim sources:
+
+```sql
+auth.jwt()->'app_metadata'->>'tenant_id'
+auth.jwt()->'app_metadata'->>'role'
+```
+
+Because claims are checked in SQL, tenant isolation remains enforced even if application logic has bugs.
+
+## Error propagation model
+
+| Layer | Error format | Responsibility |
+|-------|--------------|----------------|
+| Service | `ServiceResult<T>` failure (`error`, `code`) | Domain/business failure semantics |
+| Action | `ActionResult<T>` or redirect | UX-friendly response and navigation |
+| UI | inline state / route-level handling | User messaging and affordances |
+
+## Implementation guidance for new endpoints
+
+1. Add Zod schema in `@enterprise/contracts`.
+2. Implement service function in `@enterprise/core/services`.
+3. Create thin action/query wrapper in `ui/features/{feature}`.
+4. Use server components for reads when possible.
+5. Rely on RLS for final authorization, not UI checks.
+
+## Related docs
+
+- [Service Layer](./service-layer.md)
+- [Multi-Tenant Model](./multi-tenant.md)
+- [Users and Roles](./users-and-roles.md)

--- a/docs/architecture/resources-module.md
+++ b/docs/architecture/resources-module.md
@@ -1,0 +1,131 @@
+# Resources Module Reference
+
+The `resources` module is the template’s canonical end-to-end feature that demonstrates contracts, schema, services, actions, UI pages, and tests in one vertical slice.
+
+---
+
+## What this module demonstrates
+
+This module is intentionally generic so teams can clone the pattern for any domain entity.
+
+It shows:
+
+- Tenant-scoped table with RLS policies
+- Contract-first DTO and schema definitions
+- Service-layer business logic with `ServiceResult<T>`
+- Thin Server Actions with Zod validation + revalidation
+- Server Component data fetching + role-aware controls
+- Unit and E2E coverage
+
+## Vertical slice diagram
+
+```text
+packages/db schema + RLS
+        │
+        ▼
+packages/contracts schemas + DTOs
+        │
+        ▼
+packages/core service methods
+        │
+        ▼
+ui/features actions + queries
+        │
+        ▼
+ui/app pages + components
+        │
+        ▼
+unit tests + e2e tests
+```
+
+## File map
+
+### Database and contracts
+
+- `packages/db/src/schema/resources.ts` — Drizzle table, enums, indexes, and RLS policies
+- `supabase/migrations/20260422000003_resources_schema.sql` — generated SQL for `resources`
+- `packages/contracts/src/schemas/resources.ts` — Zod create/update/query schemas
+- `packages/contracts/src/dto/resources.ts` — input/output DTOs
+- `packages/contracts/src/types/resources.ts` — shared type exports
+- `packages/contracts/src/__tests__/resources.test.ts` — contract-level validation tests
+
+### Service layer
+
+- `packages/core/src/services/resource-service.ts` — list/get/create/update/delete functions
+- `packages/core/src/services/__tests__/resource-service.test.ts` — service behavior tests
+
+### Feature layer and routes
+
+- `ui/features/resources/actions.ts` — Server Actions for mutations
+- `ui/features/resources/queries.ts` — server-only read wrappers
+- `ui/features/resources/components/resource-form.tsx` — create/edit form
+- `ui/features/resources/components/resource-table.tsx` — list table
+- `ui/features/resources/components/resource-filters.tsx` — filtering controls
+- `ui/features/resources/components/resource-detail.tsx` — detail card
+- `ui/features/resources/components/delete-resource-button.tsx` — archive action UI
+- `ui/app/(dashboard)/dashboard/resources/page.tsx` — list page
+- `ui/app/(dashboard)/dashboard/resources/new/page.tsx` — create page
+- `ui/app/(dashboard)/dashboard/resources/[id]/page.tsx` — detail page
+- `ui/app/(dashboard)/dashboard/resources/[id]/edit/page.tsx` — edit page
+
+### E2E coverage
+
+- `ui/e2e/resources/resources.spec.ts` — auth redirects + CRUD happy paths + filters
+- `ui/e2e/resources/resources-page.ts` — Page Object model
+- `ui/e2e/resources/resources-seed.ts` — E2E setup/cleanup helpers
+
+## Behavior conventions in this module
+
+1. **Reads default to non-archived records** unless status filter is provided.
+2. **Delete is soft delete** (`status = "archived"`) rather than hard delete.
+3. **Writes are owner/admin only** via RLS and mirrored in UI controls.
+4. **Audit log writes are non-blocking** (fire-and-forget) to avoid mutation latency.
+
+## How to use this as a template for a new module
+
+### Step 1: Model the table
+
+- Create schema file in `packages/db/src/schema/{feature}.ts`
+- Add `tenant_id` and policy set
+- Generate migration and verify incremental SQL
+
+### Step 2: Define contracts
+
+- Add schemas in `packages/contracts/src/schemas/{feature}.ts`
+- Add DTO/type exports
+- Add validation tests
+
+### Step 3: Build service layer
+
+- Create `packages/core/src/services/{feature}-service.ts`
+- Keep business logic and Supabase queries here
+- Return `ServiceResult<T>` consistently
+
+### Step 4: Add action/query wrappers
+
+- `ui/features/{feature}/actions.ts` for mutations
+- `ui/features/{feature}/queries.ts` for reads
+
+### Step 5: Build route pages and components
+
+- Add list/new/detail/edit pages under `ui/app/(dashboard)/dashboard/{feature}`
+- Add reusable UI under `ui/features/{feature}/components`
+
+### Step 6: Add tests
+
+- Unit tests for contracts and services
+- Playwright E2E for auth redirect, CRUD, and edge cases
+
+## Checklist before considering a module complete
+
+- [ ] RLS policies implemented and reviewed
+- [ ] Contracts exported from `@enterprise/contracts`
+- [ ] Service functions tested
+- [ ] Actions stay thin (no business logic)
+- [ ] E2E covers user-facing happy paths and critical guards
+
+## Related docs
+
+- [Service Layer](./service-layer.md)
+- [Request Flow](./request-flow.md)
+- [Multi-Tenant Model](./multi-tenant.md)

--- a/docs/architecture/service-layer.md
+++ b/docs/architecture/service-layer.md
@@ -1,0 +1,149 @@
+# Service Layer Pattern
+
+This template places all business logic in `@enterprise/core` services so Server Actions remain thin, testable orchestration wrappers.
+
+---
+
+## Why services exist
+
+Without a service layer, logic gets duplicated across actions, route handlers, and components.
+
+The service pattern solves this by centralizing:
+
+- Validation-adjacent business rules
+- Persistence logic orchestration
+- Error code conventions
+- Audit logging calls for CUD operations
+
+Benefits:
+
+1. **Separation of concerns** — UI orchestration is separate from domain logic.
+2. **Testability** — services accept injected Supabase clients and can be mocked.
+3. **Reusability** — one service can be called by actions, jobs, or future APIs.
+
+## Service contract
+
+Services use the `ServiceResult<T>` union:
+
+```ts
+export interface ServiceSuccess<T> {
+  success: true;
+  data: T;
+}
+
+export interface ServiceFailure {
+  success: false;
+  error: string;
+  code?: string;
+}
+
+export type ServiceResult<T> = ServiceSuccess<T> | ServiceFailure;
+```
+
+Rules:
+
+- First argument is always a `SupabaseClient`.
+- Return `ServiceResult<T>` (never Next.js response types).
+- No `"use server"`, `redirect`, or `revalidatePath` in services.
+
+## Server Action contract
+
+Server Actions are thin wrappers with this flow:
+
+```text
+validate input (Zod)
+   -> get authenticated server client
+   -> call service
+   -> map ServiceResult to ActionResult / redirect
+   -> revalidatePath if needed
+```
+
+## Example: service function
+
+```ts
+export async function createResource(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  input: CreateResourceDto,
+): Promise<ServiceResult<ResourceEntity>> {
+  const { data, error } = await client
+    .from("resources")
+    .insert({
+      tenant_id: tenantId,
+      created_by: userId,
+      title: input.title,
+      type: input.type,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error: error.message, code: "CREATE_FAILED" };
+  }
+
+  return { success: true, data: mapRow(data) };
+}
+```
+
+## Example: action wrapper
+
+```ts
+"use server";
+
+export async function createResourceAction(input: Record<string, unknown>) {
+  const parsed = createResourceSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: { code: "VALIDATION_ERROR", message: "Invalid input" } };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+  if (!auth?.tenantId) {
+    return { success: false, error: { code: "UNAUTHORIZED", message: "Authentication required" } };
+  }
+
+  const result = await createResource(supabase, auth.tenantId, auth.userId, parsed.data);
+  if (!result.success) {
+    return { success: false, error: { code: result.code ?? "CREATE_FAILED", message: result.error } };
+  }
+
+  revalidatePath("/dashboard/resources");
+  return { success: true, data: result.data };
+}
+```
+
+## Testing strategy
+
+Service tests live in:
+
+- `packages/core/src/services/__tests__/*.test.ts`
+
+Test approach:
+
+1. Mock Supabase client methods (`from`, `select`, `insert`, etc.).
+2. Assert success and failure result shapes.
+3. Assert error code mapping (`CREATE_FAILED`, `LIST_FAILED`, etc.).
+4. Keep Next.js concerns out of service tests.
+
+## Naming and location conventions
+
+- File path: `packages/core/src/services/{feature}-service.ts`
+- Test path: `packages/core/src/services/__tests__/{feature}-service.test.ts`
+- Exporting: through local service index when part of platform surface
+
+## What goes where (quick checklist)
+
+| Concern | Put it in |
+|---------|-----------|
+| Zod schema | `@enterprise/contracts` |
+| DB table and RLS | `@enterprise/db` |
+| Business rule and query orchestration | `@enterprise/core/services/*` |
+| Input parsing, auth context, revalidation | `ui/features/*/actions.ts` |
+| UI rendering and interaction | `ui/app/*` + `ui/features/*/components` |
+
+## Related docs
+
+- [Request Flow](./request-flow.md)
+- [Resources Module](./resources-module.md)
+- [Architecture Overview](./overview.md)

--- a/docs/architecture/users-and-roles.md
+++ b/docs/architecture/users-and-roles.md
@@ -1,0 +1,134 @@
+# Users and Roles
+
+This template defines a four-role model (owner, admin, member, guest) enforced at both the database and UI layers.
+
+---
+
+## Role model at a glance
+
+| Role | Typical audience | Read tenant data | Create/update domain records | Manage users/roles | View audit log |
+|------|-------------------|------------------|------------------------------|--------------------|----------------|
+| `owner` | Organization creator | ✅ | ✅ | ✅ | ✅ |
+| `admin` | Tenant administrator | ✅ | ✅ | ✅ | ✅ |
+| `member` | Internal contributor | ✅ | ❌ (default template policy) | ❌ | ❌ |
+| `guest` | Limited collaborator | ✅ (scoped by module) | ❌ | ❌ | ❌ |
+
+> The exact matrix can evolve per feature, but the template default is conservative for writes.
+
+## Where roles are stored
+
+Roles exist in two places:
+
+1. **`public.profiles.role`** (source in relational model)
+2. **`auth.users.raw_app_meta_data.role`** (claim consumed by RLS)
+
+Tenant context also exists in two places:
+
+1. **`public.profiles.tenant_id`**
+2. **`auth.users.raw_app_meta_data.tenant_id`**
+
+This dual representation allows fast policy checks directly in SQL.
+
+## Signup to authorization flow
+
+```text
+User submits sign-up form
+        │
+        ▼
+Supabase Auth inserts auth.users row
+        │
+        ▼
+Trigger: handle_new_user()
+  ├─ creates tenants row
+  └─ creates profiles row with role = owner
+        │
+        ▼
+JWT contains app_metadata (tenant_id, role)
+        │
+        ▼
+RLS policies evaluate claims on every query
+```
+
+## Role flow in detail
+
+### Step 1: Signup
+
+User signs up through auth actions. Metadata is validated in contracts and passed to Supabase.
+
+### Step 2: Trigger provisioning
+
+The `handle_new_user()` trigger creates:
+
+- one tenant (`public.tenants`)
+- one profile (`public.profiles`) linked to that tenant
+- role defaults to `owner` for the first user
+
+### Step 3: JWT claim hydration
+
+`tenant_id` and `role` are present in `app_metadata` and used by RLS expressions.
+
+### Step 4: Runtime enforcement
+
+- Middleware verifies user session and routes unauthorized users away from protected pages.
+- SQL policies allow/deny read and write operations.
+- UI checks hide actions (for example, create/edit/delete buttons for members/guests).
+
+## Role checks in the UI
+
+UI checks are for user experience, not primary security.
+
+Pattern example:
+
+```tsx
+const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+```
+
+Use this for conditional controls such as:
+
+- “New Resource” button
+- Edit and archive actions
+- Tenant management views
+
+Even if a control is exposed accidentally, RLS remains the final gate.
+
+## RLS role checks
+
+Common policy predicates:
+
+```sql
+auth.jwt()->'app_metadata'->>'tenant_id'
+auth.jwt()->'app_metadata'->>'role'
+```
+
+Example write constraint:
+
+```sql
+auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')
+```
+
+## Seed users for local development
+
+`supabase/seed.sql` creates deterministic users:
+
+- `admin@enterprise.dev` / `password123` (owner)
+- `member@enterprise.dev` / `password123` (member)
+- `guest@enterprise.dev` / `password123` (guest)
+- `reset@enterprise.dev` / `password123` (member)
+- `reset2@enterprise.dev` / `password123` (member)
+
+It also aligns users into a single demo tenant for predictable E2E behavior.
+
+## Practical guidance
+
+When adding a new feature:
+
+1. Define who can read vs mutate.
+2. Encode those rules in RLS first.
+3. Mirror the same logic in UI checks for UX clarity.
+4. Add tests for both authorized and unauthorized paths.
+
+## Related docs
+
+- [Multi-Tenant Model](./multi-tenant.md)
+- [Request Flow](./request-flow.md)
+- [Service Layer](./service-layer.md)

--- a/packages/db/src/schema/platform.ts
+++ b/packages/db/src/schema/platform.ts
@@ -26,8 +26,11 @@ export const auditActionEnum = pgEnum("audit_action", [
   "custom",
 ]);
 
-const tenantClaimMatchesColumn = sql`((auth.jwt()->>'tenant_id')::uuid = tenant_id)`;
-const adminRoleClaim = sql`(auth.jwt()->>'role' IN ('owner', 'admin'))`;
+/** Matches the tenant_id column against the JWT app_metadata tenant_id claim */
+const tenantClaimMatchesColumn = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+
+/** Restricts mutations to owner and admin roles via app_metadata */
+const adminRoleClaim = sql`(auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))`;
 
 // ============================================================================
 // Tenants Table
@@ -52,7 +55,7 @@ export const tenants = pgTable(
       as: "permissive",
       for: "select",
       to: authenticatedRole,
-      using: sql`((auth.jwt()->>'tenant_id')::uuid = id)`,
+      using: sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = id)`,
     }),
     pgPolicy("tenants_insert", {
       as: "permissive",


### PR DESCRIPTION
## Summary

- Normalize all RLS claim helpers in `platform.ts` to use `app_metadata` (was using top-level JWT claims)
- Redesign README with professional template layout
- Create comprehensive architecture documentation suite

## Changes

### RLS normalization
`packages/db/src/schema/platform.ts` now uses:
```sql
auth.jwt()->'app_metadata'->>'tenant_id'
auth.jwt()->'app_metadata'->>'role'
```
This aligns the Drizzle source-of-truth with the migration SQL, seed data, and the resources schema — eliminating the inconsistency.

### README redesign
Complete rewrite following professional open-source template conventions:
- Badges (TypeScript, Next.js, React, Tailwind, Supabase, etc.)
- Features list with emoji icons
- Tech stack table
- Architecture diagram (ASCII)
- Users and Roles section
- Multi-Tenant Model section
- Security and RLS explanation
- Example Module overview
- Testing Strategy
- Quick Start
- Project Structure tree
- Documentation links

### Architecture docs (7 new files)

| Document | What it covers |
|----------|---------------|
| `docs/architecture/overview.md` | Package graph, dependency direction, key conventions |
| `docs/architecture/users-and-roles.md` | 4 roles, permissions matrix, auth flow diagram |
| `docs/architecture/multi-tenant.md` | Tenant creation, data isolation, RLS patterns |
| `docs/architecture/service-layer.md` | Service pattern, action pattern, testing strategy |
| `docs/architecture/request-flow.md` | End-to-end flows for CREATE, LIST, and auth |
| `docs/architecture/resources-module.md` | Reference module walkthrough, "create a feature" guide |
| `docs/architecture/mdx-migration.md` | Future roadmap for MDX docs migration |

## Validation

- [x] `pnpm typecheck` — 5/5 packages pass
- [x] `pnpm lint` — 132 files, 0 errors
- [x] `pnpm test` — 169 tests pass