### PR TITLE
feat: add Sentry instrumentation, CI migration deploy, and template adoption docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ A production-ready multi-tenant SaaS starter built with Next.js 15, React 19, Ty
 
 ---
 
-## Quick Start (Local Development)
+## Choose Your Path
+
+### Path A — Run locally now
+
+Best for daily development, local E2E tests, and validating RLS behavior.
 
 ### Prerequisites
 
@@ -33,7 +37,7 @@ cp .env.example .env.local
 ln -s ../.env.local ui/.env.local
 
 # 3. Start local Supabase (requires Docker)
-supabase start
+supabase start    # first run applies migrations + seed data
 
 # 4. Run dev server
 pnpm dev
@@ -55,7 +59,24 @@ If you prefer not to install Docker, you can point to a hosted Supabase project 
 
 ---
 
-## Deploy to Production
+### Path B — Deploy an MVP to the cloud quickly
+
+Best when you want a hosted demo or first production-like version without setting up CI automation yet.
+
+```bash
+supabase link --project-ref <ref>
+supabase db push
+```
+
+Then configure the **6 minimum required Vercel variables** and deploy.
+
+Use the dedicated guide:
+
+- [MVP Cloud Deploy](./docs/developer-guide/mvp-cloud-deploy.mdx)
+
+---
+
+### Path C — Production-ready automation
 
 The full production stack: **Supabase Cloud** (database + auth) + **Vercel** (hosting) + optional **Sentry** (monitoring) + **Resend** (email).
 
@@ -141,6 +162,7 @@ enterprise-platform/
 ### Developer Guide (start here)
 
 - [Getting Started](./docs/developer-guide/getting-started.mdx) — Local setup with Docker or cloud Supabase
+- [MVP Cloud Deploy](./docs/developer-guide/mvp-cloud-deploy.mdx) — Fastest path to a hosted MVP
 - [Supabase Setup](./docs/developer-guide/supabase-setup.mdx) — Auth, storage, RLS, migrations
 - [Environment Guide](./docs/developer-guide/environment-guide.mdx) — All env vars per environment
 - [Architecture](./docs/developer-guide/architecture.mdx) — Monorepo structure, service layer, conventions
@@ -181,6 +203,27 @@ supabase start        # Start local Supabase
 supabase stop         # Stop local Supabase
 supabase db reset     # Reset and re-seed local DB
 ```
+
+## What is optional vs required?
+
+### Required for local development
+
+- Node.js
+- pnpm
+- Supabase CLI
+- Docker (only if using local Supabase)
+
+### Required for a hosted MVP
+
+- Supabase cloud project
+- `supabase db push`
+- 6 Vercel environment variables
+
+### Optional until you want production hardening
+
+- GitHub Secrets for automated migration deploy
+- Sentry DSN / source map upload
+- Resend email integration
 
 ## AI Skills
 

--- a/docs/developer-guide/getting-started.mdx
+++ b/docs/developer-guide/getting-started.mdx
@@ -41,6 +41,11 @@ ln -s ../.env.local ui/.env.local    # Next.js reads from ui/
 
 ## Choose Your Development Mode
 
+Pick one path and ignore the rest for now:
+
+- **Option A: Local Supabase** → best for daily work, RLS validation, and E2E tests
+- **Option B: Cloud Supabase** → best when you want a shared backend or do not want Docker installed
+
 | Mode | When to Use | Requires Docker |
 |------|-------------|----------------|
 | **Option A: Local Supabase** | Full offline dev, test RLS locally, run E2E tests | Yes |
@@ -114,6 +119,8 @@ The local database is seeded with test users from `supabase/seed.sql`:
 ---
 
 ## Option B: Cloud Supabase (No Docker)
+
+> **✅ Best for a fast MVP:** If your goal is to get a demo or first deployment online quickly, this is usually the shortest path. Pair this with [MVP Cloud Deploy](./mvp-cloud-deploy.mdx).
 
 ### 1. Create a Supabase Project
 

--- a/docs/developer-guide/index.mdx
+++ b/docs/developer-guide/index.mdx
@@ -16,23 +16,33 @@ Single, reliable starting point for developers working in the Enterprise Platfor
 - Included: local setup, cloud setup, production deployment, architecture model, conventions, testing, theme system, environment management.
 - Excluded: product requirements (see [PRD examples](../example-prd.md)), technical specifications (see [RFC examples](../example-rfc.md)).
 
-## Reading Order
+## Choose Your Path
+
+### Path A — I want to run it locally now
 
 1. [Getting Started](./getting-started.mdx) — Prerequisites, install, first run (local + cloud)
-2. [Supabase Setup](./supabase-setup.mdx) — Local and cloud Supabase, deploy DB to cloud
-3. [Environment Guide](./environment-guide.mdx) — All environment variables per environment
-4. [Architecture](./architecture.mdx) — Monorepo, packages, dependency graph, service layer
-5. [Conventions](./conventions.mdx) — Code style, TypeScript, Zod, Drizzle, Git commits
-6. [Testing Strategy](./testing-strategy.mdx) — Vitest + Playwright, coverage matrix
-7. [Theme System](./theme-system.mdx) — JSON-configurable themes, light/dark mode
-8. [Production Deployment](./production-deployment.mdx) — Supabase cloud + Vercel + Sentry + Resend
-9. [Onboarding Checklist](./onboarding-checklist.mdx) — New developer checklist
+2. [Supabase Setup](./supabase-setup.mdx) — Local auth, storage, RLS, deterministic test users
+3. [Onboarding Checklist](./onboarding-checklist.mdx) — Final sanity check for a new developer
+
+### Path B — I want an MVP in the cloud quickly
+
+1. [MVP Cloud Deploy](./mvp-cloud-deploy.mdx) — The shortest path: Supabase cloud + `supabase db push` + Vercel
+2. [Environment Guide](./environment-guide.mdx) — Copy the minimum variables for cloud dev / production
+3. [Production Deployment](./production-deployment.mdx) — Expand to automation, Sentry, Resend when ready
+
+### Path C — I want production-ready automation
+
+1. [Production Deployment](./production-deployment.mdx) — Supabase cloud + Vercel + Sentry + Resend + CI migration deploy
+2. [Architecture](./architecture.mdx) — Monorepo, packages, dependency graph, service layer
+3. [Conventions](./conventions.mdx) — Code style, TypeScript, Zod, Drizzle, Git commits
+4. [Testing Strategy](./testing-strategy.mdx) — Vitest + Playwright, coverage matrix
+5. [Theme System](./theme-system.mdx) — JSON-configurable themes, light/dark mode
 
 > **✅ Start here:** If you just cloned the template and want to run it locally, go directly to [Getting Started](./getting-started.mdx).
 
 > **ℹ️ MDX Rendering:** These MDX files are readable as repo documentation (GitHub, VS Code). An MDX rendering pipeline (e.g., Fumadocs, next-mdx-remote) can be added to serve them as a docs site. The Callout and CommandPanel components will render correctly once that pipeline is in place.
 
-## Quick Start
+## Fastest Start
 
 **First Run (Local Supabase)**
 
@@ -54,6 +64,12 @@ pnpm dev                          # http://localhost:3000
 | Example RFC | `docs/example-rfc.md` | Technical spec template |
 | Agent Instructions | `AGENTS.md` (+ nested) | AI agent rules per monorepo level |
 | Extension Patterns | `docs/architecture/extension-patterns.md` | How to add new packages and modules |
+
+## Mental Model
+
+- **Local path** → best for daily development and E2E tests
+- **Cloud MVP path** → best when you want to show a working product quickly without setting up Docker or CI automation
+- **Production-ready path** → best when you want traceability, automatic migrations, Sentry, and operational hardening
 
 ---
 

--- a/docs/developer-guide/mvp-cloud-deploy.mdx
+++ b/docs/developer-guide/mvp-cloud-deploy.mdx
@@ -1,0 +1,144 @@
+---
+title: "MVP Cloud Deploy"
+description: "The shortest path from cloned template to a working cloud MVP using Supabase Cloud and Vercel."
+owner: "Engineering"
+lastUpdated: "2026-04-24"
+---
+
+# MVP Cloud Deploy
+
+## Purpose
+
+Provide the fastest path to get the template running in the cloud with the minimum required configuration.
+
+## Scope
+
+- Included: Supabase cloud project, database deploy, minimum Vercel env vars, first production deploy.
+- Excluded: CI automation, Sentry, Resend, preview environments, custom domains.
+
+## When to Use This Path
+
+Choose this guide if you want:
+
+- a working hosted MVP quickly
+- no Docker dependency
+- no GitHub Secrets setup yet
+- no CI-driven database deploy yet
+
+> **✅ Recommended for templates:** This is the lowest-friction path for a new team evaluating the starter.
+
+## What You Need
+
+- A GitHub repository with this template
+- A Supabase account
+- A Vercel account
+- Node.js and Supabase CLI installed locally
+
+## Step 1 — Create a Supabase Cloud Project
+
+1. Go to [supabase.com](https://supabase.com) and create a new project.
+2. Save the database password in your password manager.
+3. Note the project reference from the URL: `https://supabase.com/dashboard/project/<REF>`.
+
+## Step 2 — Deploy the Template Database
+
+From your local clone of the template:
+
+**Push database schema to Supabase cloud**
+
+```bash
+supabase link --project-ref <REF>
+supabase db push
+```
+
+This applies everything from `supabase/migrations/` to your cloud database.
+
+> **ℹ️ What this does:** It creates the schema, RLS helpers, tables, policies, and storage-related SQL defined by the template.
+
+> **⚠️ Important:** `supabase db push` does not run `supabase/seed.sql`. Seed data is local-only by design.
+
+## Step 3 — Get the Minimum Required Supabase Credentials
+
+In **Supabase Dashboard → Settings → API**, copy:
+
+- `Project URL`
+- `anon public key`
+- `service_role secret key`
+
+## Step 4 — Import the Repo in Vercel
+
+1. Go to [vercel.com](https://vercel.com) → **Add New Project**.
+2. Import your repository.
+3. Use these settings:
+
+| Setting | Value |
+|---------|-------|
+| Framework Preset | Next.js |
+| Install Command | `pnpm install` |
+| Build Command | `pnpm build` |
+| Output Directory | `.next` |
+
+## Step 5 — Configure the Minimum Required Vercel Environment Variables
+
+These are the only variables required for an MVP deploy:
+
+| Variable | Required for MVP | Value |
+|----------|------------------|-------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes | `https://<REF>.supabase.co` |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | From Supabase API settings |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | From Supabase API settings |
+| `NEXT_PUBLIC_APP_URL` | Yes | Your Vercel production URL |
+| `NEXT_PUBLIC_APP_NAME` | Yes | Your app name |
+| `NEXT_PUBLIC_APP_ENV` | Yes | `production` |
+
+Add them in **Vercel → Project → Settings → Environment Variables**.
+
+> **ℹ️ Not required yet:** `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `RESEND_API_KEY`, `EMAIL_FROM`, and GitHub Secrets are optional for this MVP path.
+
+## Step 6 — Configure Supabase Auth URLs
+
+In **Supabase Dashboard → Authentication → URL Configuration**:
+
+| Setting | Value |
+|---------|-------|
+| Site URL | Your Vercel production URL |
+| Redirect URLs | `https://your-app.vercel.app/**` |
+
+Without this step, auth redirects (sign-up, password reset, OAuth callbacks) will break.
+
+## Step 7 — Deploy
+
+Push your branch or trigger a deployment from Vercel.
+
+If you already connected the repo, Vercel will build automatically.
+
+## Step 8 — Verify the MVP
+
+After deploy, verify these routes manually:
+
+- `/sign-in`
+- `/sign-up`
+- `/dashboard`
+- `/dashboard/resources`
+- `/dashboard/settings`
+
+## MVP Checklist
+
+- [ ] Supabase cloud project created
+- [ ] `supabase db push` completed successfully
+- [ ] 6 minimum Vercel env vars configured
+- [ ] Supabase Site URL configured
+- [ ] App deployed in Vercel
+- [ ] Sign-in and dashboard routes work
+
+## What Comes Next
+
+Once the MVP is live, the next recommended upgrades are:
+
+1. [Production Deployment](./production-deployment.mdx) — GitHub Secrets, automated migration deploy, Sentry, Resend
+2. [Environment Guide](./environment-guide.mdx) — Full variable reference
+3. [Supabase Setup](./supabase-setup.mdx) — Storage, RLS verification, local/cloud workflows
+
+---
+
+*Last updated: 2026-04-24*

--- a/docs/developer-guide/production-deployment.mdx
+++ b/docs/developer-guide/production-deployment.mdx
@@ -16,6 +16,19 @@ This guide walks through every step required to deploy the Enterprise Platform t
 - **Included**: Supabase production project, Vercel deployment, Sentry error tracking, Resend email, post-deploy verification, troubleshooting
 - **Excluded**: Custom domains/DNS configuration, CDN tuning, database performance optimization
 
+## Before You Continue
+
+This guide is for the **production-ready** path.
+
+If you only want the fastest hosted MVP, stop here and use [MVP Cloud Deploy](./mvp-cloud-deploy.mdx) instead.
+
+### Use this guide when you want:
+
+- automated database deploys from CI
+- Sentry already wired for traceability
+- optional Resend email ready for production
+- GitHub Secrets and Vercel env vars fully configured
+
 ---
 
 ## Overview: The Production Stack
@@ -87,7 +100,15 @@ INSERT INTO storage.buckets (id, name, public) VALUES
 
 ## Step 2: GitHub Secrets
 
-The CI workflow reads secrets from **GitHub repository Settings → Secrets and variables → Actions**. Configure all of these before your first push to `main`.
+The CI workflow reads secrets from **GitHub repository Settings → Secrets and variables → Actions**.
+
+> **ℹ️ Are all of these required for the template?** No.
+>
+> - **Required for CI build:** the `NEXT_PUBLIC_*` values used by `pnpm build`
+> - **Required for automated migration deploy:** `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`
+> - **Optional but recommended for observability:** the Sentry secrets
+>
+> If you are following the MVP path and deploying manually, you can skip GitHub Secrets entirely.
 
 ### 2.1 Add Secrets
 
@@ -111,6 +132,21 @@ The CI workflow reads secrets from **GitHub repository Settings → Secrets and 
 | `SENTRY_PROJECT` | Optional | Sentry project slug | Source map upload |
 
 > **ℹ️ Sentry secrets are optional:** If `SENTRY_AUTH_TOKEN` is absent, source maps are not uploaded but the build still succeeds (`silent: true` is set). Sentry event capture requires only `NEXT_PUBLIC_SENTRY_DSN` at runtime.
+
+### Minimum GitHub Secrets for Automation
+
+If you want the full production-ready pipeline, the **minimum** GitHub Secrets set is:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_APP_NAME`
+- `NEXT_PUBLIC_APP_ENV`
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_PROJECT_ID`
+- `SUPABASE_DB_PASSWORD`
+
+Add the Sentry secrets only if you want observability and source maps.
 
 ---
 
@@ -160,6 +196,19 @@ Add every variable in **Project → Settings → Environment Variables**, select
 | `EMAIL_FROM` | Production | Your verified sender email |
 
 > **🚨 Sensitive variables:** Mark `SUPABASE_SERVICE_ROLE_KEY`, `SENTRY_AUTH_TOKEN`, and `RESEND_API_KEY` as **Sensitive** in Vercel. Sensitive variables are write-only — they cannot be viewed after saving.
+
+### Minimum Vercel Variables for a Production MVP
+
+If you only want a working production deployment without optional integrations, the minimum required set is:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_APP_NAME`
+- `NEXT_PUBLIC_APP_ENV`
+
+Everything else in the table is optional or recommended for production hardening.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Sentry SDK instrumentation and source-map-ready Next.js configuration
- Add automated Supabase migration deployment in CI on push to `main`
- Improve developer documentation for template adoption with clear local, MVP cloud, and production-ready paths

## Changes

### Observability and Deployment

| Area | What |
|------|------|
| **Sentry** | Add `@sentry/nextjs` v10 instrumentation for server, edge, and client runtimes |
| **CI** | Add `Deploy Migrations` step to `ci.yml` using `supabase db push` on push to `main` |
| **Next.js** | Wrap `ui/next.config.ts` with `withSentryConfig` (source maps, tunnel route, logger stripping) |
| **Utilities** | Add `ui/lib/sentry.ts` with `captureActionError`, `beforeSendFilter`, PII scrubbing, and environment mapping |

### Documentation Fixes

| File | What |
|------|------|
| `docs/developer-guide/mvp-cloud-deploy.mdx` | New guide for the shortest path to a hosted MVP |
| `docs/developer-guide/index.mdx` | Reorganized around 3 paths: local, cloud MVP, production-ready |
| `docs/developer-guide/getting-started.mdx` | Better path selection + `supabase db reset` clarification |
| `docs/developer-guide/production-deployment.mdx` | Required vs optional config, GitHub Secrets, Vercel env vars |
| README | Reframed as a template: local path, MVP cloud path, production-ready path |

### Template Usability Improvements

This PR makes the template clearer for first-time adopters by separating:

- **Required for local development**
- **Required for a fast hosted MVP**
- **Optional / recommended for production hardening**

That means things like GitHub Secrets and Sentry are now documented as **optional for MVP**, not as mandatory template setup.

## GitHub Secrets Added to Docs

The docs now explain when these are needed:

- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_PROJECT_ID`
- `SUPABASE_DB_PASSWORD`
- `SENTRY_AUTH_TOKEN`
- `SENTRY_ORG`
- `SENTRY_PROJECT`
- `NEXT_PUBLIC_*` build envs

## QA

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅
- `pnpm build` ✅

## Notes

- These commits were pushed to `feat/sentry-ci-deployment` after PR #21 had already been merged, so this follow-up PR is required to bring them into `main`.