### PR TITLE
fix(release): remove component from release-please-config to fix PR title mismatch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,8 +17,7 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md",
-      "component": "enterprise-platform"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove `"component": "enterprise-platform"` from `release-please-config.json`

## Root Cause

When `component` is set, release-please generates release PR titles in the format:

```
chore: release enterprise-platform ${version}
```

But the existing release PR #13 was created without a component and had the title `chore: release main`, which does not match that pattern. This caused warnings on every run:

```
⚠ pullRequestTitlePattern miss the part of '${version}'
⚠ pullRequestTitlePattern miss the part of '${component}'
⚠ PR component: undefined does not match configured component: enterprise-platform
```

Release-please then failed to recognize the existing PR and created duplicate state.

## Fix

For a single-package repository, `component` provides no benefit and the title pattern it requires conflicts with the existing PR history. Removing it restores the default title format (`chore: release ${version}`) which matches how the repo was originally configured.

## Note on the GitHub API error

The `Something went wrong... 4C51:3BA7CE` error at the end of the log is a transient GitHub server-side failure during commit pagination — unrelated to this config issue. It will resolve itself on the next run.

## Changes

| File | Change |
|------|--------|
| `release-please-config.json` | Removed `"component": "enterprise-platform"` from package config |

## Test Plan

- [x] `pnpm lint` passes
- [x] Next push to `main` should run release-please without component mismatch warnings