### PR TITLE
refactor: migrate platform services to ServiceResult pattern and centralize auth logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Enforce package boundaries
+        run: pnpm check:boundaries
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,28 +1,50 @@
-name: Security Review
+name: Security Checks
 
 permissions:
-  pull-requests: write  # Needed for leaving PR comments
   contents: read
+  security-events: write
 
 on:
   pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-  security:
+  dependency-audit:
+    name: Dependency Audit
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 2
-      
-      # Optional: Add more security checks as needed
-      # - name: Run security audits
-      #   run: pnpm audit
-      
-      # This is a placeholder for security review automation
-      # You can add tools like: npm audit, trivy, sonarqube, etc.
-      - name: Dependency check
-        run: |
-          echo "Security checks placeholder"
-          echo "Add tools like: npm audit, trivy, snyk, etc."
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level=high
+
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ Load these skills BEFORE writing any code when the context matches:
 
 Repo-local skills require runtime wiring. Run `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so OpenCode can discover `.agents/skills` before relying on local skills such as `drizzle`, `supabase`, `sentry`, and the design-system skills.
 
+Availability note:
+- Repo-local skills live in `skills/` and are discovered through `.agents/skills` after setup.
+- Skills like `issue-creation`, `branch-pr`, and `pr-review` may come from your global agent runtime, not this repository.
+
 ## Design Reference
 
 Before implementing ANY UI component or page, follow this workflow:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
+    "check:boundaries": "node scripts/check-boundaries.mjs",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "pnpm": {
     "overrides": {
-      "next": "15.5.14"
+      "next": "15.5.15"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "pnpm": {
     "overrides": {
-      "next": "15.5.15"
+      "next": "15.5.15",
+      "postcss": ">=8.5.10"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/packages/contracts/src/schemas/platform.test.ts
+++ b/packages/contracts/src/schemas/platform.test.ts
@@ -67,18 +67,13 @@ describe("authSessionSchema", () => {
 
 describe("registrationMetadataSchema", () => {
   it("accepts valid metadata", () => {
-    expect(registrationMetadataSchema.parse({ name: "Owner User", role: "owner" })).toEqual({
+    expect(registrationMetadataSchema.parse({ name: "Owner User" })).toEqual({
       name: "Owner User",
-      role: "owner",
     });
   });
 
   it("accepts optional name as undefined", () => {
-    expect(registrationMetadataSchema.parse({ role: "member" })).toEqual({ role: "member" });
-  });
-
-  it("rejects invalid role", () => {
-    expect(() => registrationMetadataSchema.parse({ role: "invalid" })).toThrow();
+    expect(registrationMetadataSchema.parse({})).toEqual({});
   });
 });
 

--- a/packages/contracts/src/schemas/platform.ts
+++ b/packages/contracts/src/schemas/platform.ts
@@ -51,7 +51,6 @@ export const authSessionSchema = z.object({
 /** Registration metadata sent to Supabase auth.signUp() */
 export const registrationMetadataSchema = z.object({
   name: z.string().min(1).max(255).optional(),
-  role: userRoleSchema.optional(),
 });
 
 /** Invitation metadata sent to Supabase auth APIs */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,12 +30,12 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "next": "^15.1.0",
+    "next": "^15.5.15",
     "react": "^19.0.0",
     "typescript": "^5.7.0"
   },
   "peerDependencies": {
-    "next": "^15.1.0",
+    "next": "^15.5.15",
     "react": "^19.0.0"
   }
 }

--- a/packages/core/src/services/__tests__/auth-service.test.ts
+++ b/packages/core/src/services/__tests__/auth-service.test.ts
@@ -103,7 +103,7 @@ describe("auth-service", () => {
       }
     });
 
-    it("profile query error returns PROFILE_NOT_FOUND", async () => {
+    it("profile query error returns ROLE_LOOKUP_FAILED", async () => {
       const client = createMockClient() as SupabaseClient & {
         __mockSingle: ReturnType<typeof vi.fn>;
       };
@@ -123,11 +123,11 @@ describe("auth-service", () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.code).toBe("PROFILE_NOT_FOUND");
+        expect(result.code).toBe("ROLE_LOOKUP_FAILED");
       }
     });
 
-    it("null/undefined profile role returns success with role: null", async () => {
+    it("null/undefined profile role returns success with guest role", async () => {
       const client = createMockClient() as SupabaseClient & {
         __mockSingle: ReturnType<typeof vi.fn>;
       };
@@ -145,7 +145,7 @@ describe("auth-service", () => {
         password: "password123",
       });
 
-      expect(result).toEqual({ success: true, data: { role: null } });
+      expect(result).toEqual({ success: true, data: { role: "guest" } });
     });
   });
 

--- a/packages/core/src/services/__tests__/platform-services.test.ts
+++ b/packages/core/src/services/__tests__/platform-services.test.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import { createPlatformServiceContext, ProfileService, TenantService } from "../index";
+
+function createContext(db: SupabaseClient) {
+  return createPlatformServiceContext(db, {
+    userId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    tenantId: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    role: "owner",
+    email: "owner@enterprise.dev",
+  });
+}
+
+describe("platform services", () => {
+  it("TenantService.getCurrent parses JSON settings into object", async () => {
+    const singleMock = vi.fn().mockResolvedValue({
+      data: {
+        id: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        name: "Enterprise",
+        slug: "enterprise",
+        status: "active",
+        settings: '{"theme":"dark"}',
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      },
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ single: singleMock });
+    const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ select: selectMock });
+    const db = { from: fromMock } as unknown as SupabaseClient;
+
+    const service = new TenantService(createContext(db));
+    const result = await service.getCurrent();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.settings).toEqual({ theme: "dark" });
+    }
+  });
+
+  it("ProfileService.updateSelf returns PROFILE_NOT_FOUND when mutation returns null row", async () => {
+    const singleMock = vi.fn().mockResolvedValue({ data: null, error: null });
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock });
+    const eqMock = vi.fn().mockReturnValue({ select: selectMock });
+    const updateMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const fromMock = vi.fn().mockReturnValue({ update: updateMock });
+    const db = { from: fromMock } as unknown as SupabaseClient;
+
+    const service = new ProfileService(createContext(db));
+    const result = await service.updateSelf({ name: "Updated" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("PROFILE_NOT_FOUND");
+    }
+  });
+});

--- a/packages/core/src/services/auth-service.ts
+++ b/packages/core/src/services/auth-service.ts
@@ -1,4 +1,4 @@
-import type { RegistrationMetadata, UserRole } from "@enterprise/contracts";
+import type { PlatformUser, RegistrationMetadata, UserRole } from "@enterprise/contracts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 export interface ServiceSuccess<T> {
@@ -44,6 +44,92 @@ export interface UpdatePasswordServiceInput {
   password: string;
 }
 
+export interface UserRoleServiceData {
+  role: UserRole;
+}
+
+const ROLE_HOME_PATHS: Record<UserRole, string> = {
+  owner: "/dashboard",
+  admin: "/dashboard",
+  member: "/dashboard",
+  guest: "/",
+};
+
+export function resolveRoleRedirectPath(role: UserRole | null | undefined): string {
+  if (!role) {
+    return "/dashboard";
+  }
+
+  return ROLE_HOME_PATHS[role] ?? "/dashboard";
+}
+
+export async function getUserRoleService(
+  client: SupabaseClient,
+  userId: string,
+): Promise<ServiceResult<UserRoleServiceData>> {
+  const { data: profile, error } = await client
+    .from("profiles")
+    .select("role")
+    .eq("id", userId)
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    return {
+      success: false,
+      error: "Could not load user role",
+      code: "ROLE_LOOKUP_FAILED",
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      role: (profile?.role as UserRole | null | undefined) ?? "guest",
+    },
+  };
+}
+
+export async function getCurrentPlatformUserService(
+  client: SupabaseClient,
+): Promise<ServiceResult<PlatformUser | null>> {
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser();
+
+  if (error) {
+    return {
+      success: false,
+      error: "Could not resolve authenticated user",
+      code: "AUTH_USER_LOOKUP_FAILED",
+    };
+  }
+
+  if (!user) {
+    return { success: true, data: null };
+  }
+
+  const { data: profile } = await client
+    .from("profiles")
+    .select("tenant_id, role, name, avatar_url")
+    .eq("id", user.id)
+    .single();
+
+  return {
+    success: true,
+    data: {
+      id: user.id,
+      createdAt: new Date(user.created_at),
+      updatedAt: new Date(user.updated_at ?? user.created_at),
+      email: user.email ?? "",
+      name: profile?.name ?? null,
+      avatarUrl: profile?.avatar_url ?? null,
+      role: (profile?.role as UserRole | undefined) ?? "guest",
+      tenantId: profile?.tenant_id ?? "",
+    },
+  };
+}
+
 export async function signInWithPasswordService(
   client: SupabaseClient,
   input: SignInServiceInput,
@@ -65,24 +151,16 @@ export async function signInWithPasswordService(
     return { success: false, error: "User not found after sign-in", code: "USER_NOT_FOUND" };
   }
 
-  const { data: profile, error: profileError } = await client
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
+  const roleResult = await getUserRoleService(client, user.id);
 
-  if (profileError) {
-    return {
-      success: false,
-      error: "Could not load user profile",
-      code: "PROFILE_NOT_FOUND",
-    };
+  if (!roleResult.success) {
+    return roleResult;
   }
 
   return {
     success: true,
     data: {
-      role: (profile?.role as UserRole | null | undefined) ?? null,
+      role: roleResult.data.role,
     },
   };
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,8 +1,89 @@
 // Platform service layer - base services for multi-tenant operations
 // These are meant to be extended by domain-specific services
 
-import type { NewAuditLogEntry } from "@enterprise/db/schema/platform";
+import type { NewAuditLogEntry } from "@enterprise/db";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ServiceResult } from "./auth-service";
+
+interface TenantRow {
+  id: string;
+  name: string;
+  slug: string;
+  status: "active" | "inactive" | "suspended";
+  settings: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TenantRecord extends Omit<TenantRow, "settings"> {
+  settings: Record<string, unknown> | null;
+}
+
+export interface ProfileRecord {
+  id: string;
+  tenant_id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+  role: "owner" | "admin" | "member" | "guest";
+  created_at: string;
+  updated_at: string;
+}
+
+interface AuditLogRow {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  action: string;
+  resource: string;
+  resource_id: string | null;
+  metadata: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+export interface AuditLogRecord extends Omit<AuditLogRow, "metadata"> {
+  metadata: Record<string, unknown> | null;
+}
+
+export interface UserRoleRecord {
+  id: string;
+  user_id: string;
+  tenant_id: string;
+  role: "owner" | "admin" | "member" | "guest";
+  granted_by: string;
+  granted_at: string;
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function mapTenantRecord(row: TenantRow): TenantRecord {
+  return {
+    ...row,
+    settings: parseJsonRecord(row.settings),
+  };
+}
+
+function mapAuditLogRecord(row: AuditLogRow): AuditLogRecord {
+  return {
+    ...row,
+    metadata: parseJsonRecord(row.metadata),
+  };
+}
 
 /** Auth context - extracted from Supabase auth */
 export interface AuthContext {
@@ -18,6 +99,13 @@ export interface PlatformServiceContext {
   db: SupabaseClient;
 }
 
+export function createPlatformServiceContext(
+  db: SupabaseClient,
+  auth: AuthContext,
+): PlatformServiceContext {
+  return { db, auth };
+}
+
 /** ============================================================================
  * Tenant Service
  * ============================================================================ */
@@ -27,19 +115,26 @@ export class TenantService {
   constructor(private ctx: PlatformServiceContext) {}
 
   /** Get current tenant */
-  async getCurrent() {
+  async getCurrent(): Promise<ServiceResult<TenantRecord>> {
     const { data, error } = await this.ctx.db
       .from("tenants")
       .select("*")
       .eq("id", this.ctx.auth.tenantId)
       .single();
 
-    if (error) throw new Error(error.message);
-    return data;
+    if (error) {
+      return { success: false, error: error.message, code: "TENANT_GET_FAILED" };
+    }
+
+    if (!data) {
+      return { success: false, error: "Tenant not found", code: "TENANT_NOT_FOUND" };
+    }
+
+    return { success: true, data: mapTenantRecord(data as TenantRow) };
   }
 
   /** Update tenant settings */
-  async update(settings: Record<string, unknown>) {
+  async update(settings: Record<string, unknown>): Promise<ServiceResult<TenantRecord>> {
     const { data, error } = await this.ctx.db
       .from("tenants")
       .update({ settings: JSON.stringify(settings) })
@@ -47,14 +142,29 @@ export class TenantService {
       .select()
       .single();
 
-    if (error) throw new Error(error.message);
-    return data;
+    if (error) {
+      return { success: false, error: error.message, code: "TENANT_UPDATE_FAILED" };
+    }
+
+    if (!data) {
+      return { success: false, error: "Tenant not found", code: "TENANT_NOT_FOUND" };
+    }
+
+    return { success: true, data: mapTenantRecord(data as TenantRow) };
   }
 
   /** Check if tenant is active */
-  async isActive(): Promise<boolean> {
-    const tenant = await this.getCurrent();
-    return tenant.status === "active";
+  async isActive(): Promise<ServiceResult<boolean>> {
+    const tenantResult = await this.getCurrent();
+
+    if (!tenantResult.success) {
+      return tenantResult;
+    }
+
+    return {
+      success: true,
+      data: tenantResult.data.status === "active",
+    };
   }
 }
 
@@ -67,43 +177,59 @@ export class ProfileService {
   constructor(private ctx: PlatformServiceContext) {}
 
   /** Get current user profile */
-  async getCurrent() {
+  async getCurrent(): Promise<ServiceResult<ProfileRecord>> {
     const { data, error } = await this.ctx.db
       .from("profiles")
       .select("*")
       .eq("id", this.ctx.auth.userId)
       .single();
 
-    if (error) throw new Error(error.message);
-    return data;
+    if (error) {
+      return { success: false, error: error.message, code: "PROFILE_GET_FAILED" };
+    }
+
+    if (!data) {
+      return { success: false, error: "Profile not found", code: "PROFILE_NOT_FOUND" };
+    }
+
+    return { success: true, data: data as ProfileRecord };
   }
 
   /** Get profile by ID */
-  async getById(userId: string) {
+  async getById(userId: string): Promise<ServiceResult<ProfileRecord | null>> {
     const { data, error } = await this.ctx.db
       .from("profiles")
       .select("*")
       .eq("id", userId)
       .single();
 
-    if (error) return null;
-    return data;
+    if (error && error.code !== "PGRST116") {
+      return { success: false, error: error.message, code: "PROFILE_GET_BY_ID_FAILED" };
+    }
+
+    return { success: true, data: (data ?? null) as ProfileRecord | null };
   }
 
   /** Get all profiles in tenant */
-  async listInTenant(limit = 50, offset = 0) {
+  async listInTenant(limit = 50, offset = 0): Promise<ServiceResult<ProfileRecord[]>> {
     const { data, error } = await this.ctx.db
       .from("profiles")
       .select("*")
       .eq("tenant_id", this.ctx.auth.tenantId)
       .range(offset, offset + limit - 1);
 
-    if (error) throw new Error(error.message);
-    return data ?? [];
+    if (error) {
+      return { success: false, error: error.message, code: "PROFILE_LIST_FAILED" };
+    }
+
+    return { success: true, data: (data ?? []) as ProfileRecord[] };
   }
 
   /** Update own profile */
-  async updateSelf(updates: { name?: string; avatarUrl?: string }) {
+  async updateSelf(updates: {
+    name?: string;
+    avatarUrl?: string;
+  }): Promise<ServiceResult<ProfileRecord>> {
     const { data, error } = await this.ctx.db
       .from("profiles")
       .update({
@@ -115,8 +241,15 @@ export class ProfileService {
       .select()
       .single();
 
-    if (error) throw new Error(error.message);
-    return data;
+    if (error) {
+      return { success: false, error: error.message, code: "PROFILE_UPDATE_FAILED" };
+    }
+
+    if (!data) {
+      return { success: false, error: "Profile not found", code: "PROFILE_NOT_FOUND" };
+    }
+
+    return { success: true, data: data as ProfileRecord };
   }
 }
 
@@ -134,7 +267,7 @@ export class AuditService {
     resource: string,
     resourceId?: string,
     metadata?: Record<string, unknown>,
-  ) {
+  ): Promise<ServiceResult<null>> {
     const entry: NewAuditLogEntry = {
       tenantId: this.ctx.auth.tenantId,
       userId: this.ctx.auth.userId,
@@ -149,13 +282,19 @@ export class AuditService {
     const { error } = await this.ctx.db.from("audit_log").insert(entry);
 
     if (error) {
-      console.error("Failed to log audit entry:", error);
-      // Don't throw - audit failure shouldn't break the main operation
+      return { success: false, error: error.message, code: "AUDIT_LOG_FAILED" };
     }
+
+    return { success: true, data: null };
   }
 
   /** Get audit log for tenant */
-  async query(filters: { userId?: string; action?: string; resource?: string; limit?: number }) {
+  async query(filters: {
+    userId?: string;
+    action?: string;
+    resource?: string;
+    limit?: number;
+  }): Promise<ServiceResult<AuditLogRecord[]>> {
     let query = this.ctx.db
       .from("audit_log")
       .select("*")
@@ -175,8 +314,14 @@ export class AuditService {
 
     const { data, error } = await query;
 
-    if (error) throw new Error(error.message);
-    return data ?? [];
+    if (error) {
+      return { success: false, error: error.message, code: "AUDIT_QUERY_FAILED" };
+    }
+
+    return {
+      success: true,
+      data: ((data ?? []) as AuditLogRow[]).map(mapAuditLogRecord),
+    };
   }
 }
 
@@ -195,14 +340,16 @@ export class RoleService {
   }
 
   /** Require a specific role or throw */
-  requireRole(requiredRole: "owner" | "admin" | "member" | "guest") {
+  requireRole(requiredRole: "owner" | "admin" | "member" | "guest"): ServiceResult<null> {
     if (!this.hasRole(requiredRole)) {
-      throw new Error(`Required role: ${requiredRole}`);
+      return { success: false, error: `Required role: ${requiredRole}`, code: "INSUFFICIENT_ROLE" };
     }
+
+    return { success: true, data: null };
   }
 
   /** Get user's role in tenant */
-  async getUserRole(userId: string) {
+  async getUserRole(userId: string): Promise<ServiceResult<UserRoleRecord | null>> {
     const { data, error } = await this.ctx.db
       .from("user_roles")
       .select("*")
@@ -210,13 +357,23 @@ export class RoleService {
       .eq("tenant_id", this.ctx.auth.tenantId)
       .single();
 
-    if (error) return null;
-    return data;
+    if (error && error.code !== "PGRST116") {
+      return { success: false, error: error.message, code: "USER_ROLE_GET_FAILED" };
+    }
+
+    return { success: true, data: (data ?? null) as UserRoleRecord | null };
   }
 
   /** Update user role (admin only) */
-  async updateUserRole(userId: string, role: "owner" | "admin" | "member" | "guest") {
-    this.requireRole("admin");
+  async updateUserRole(
+    userId: string,
+    role: "owner" | "admin" | "member" | "guest",
+  ): Promise<ServiceResult<ProfileRecord>> {
+    const roleRequirement = this.requireRole("admin");
+
+    if (!roleRequirement.success) {
+      return roleRequirement;
+    }
 
     const { data, error } = await this.ctx.db
       .from("profiles")
@@ -226,7 +383,14 @@ export class RoleService {
       .select()
       .single();
 
-    if (error) throw new Error(error.message);
-    return data;
+    if (error) {
+      return { success: false, error: error.message, code: "USER_ROLE_UPDATE_FAILED" };
+    }
+
+    if (!data) {
+      return { success: false, error: "Profile not found", code: "PROFILE_NOT_FOUND" };
+    }
+
+    return { success: true, data: data as ProfileRecord };
   }
 }

--- a/packages/core/src/supabase/contracts.ts
+++ b/packages/core/src/supabase/contracts.ts
@@ -10,7 +10,7 @@ export interface Database {
           name: string;
           slug: string;
           status: "active" | "inactive" | "suspended";
-          settings: Record<string, unknown> | null;
+          settings: string | null;
           created_at: string;
           updated_at: string;
         };
@@ -19,7 +19,7 @@ export interface Database {
           name: string;
           slug: string;
           status?: "active" | "inactive" | "suspended";
-          settings?: Record<string, unknown> | null;
+          settings?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -28,7 +28,7 @@ export interface Database {
           name?: string;
           slug?: string;
           status?: "active" | "inactive" | "suspended";
-          settings?: Record<string, unknown> | null;
+          settings?: string | null;
           created_at?: string;
           updated_at?: string;
         };
@@ -99,7 +99,7 @@ export interface Database {
           action: "create" | "read" | "update" | "delete" | "login" | "logout" | "custom";
           resource: string;
           resource_id: string | null;
-          metadata: Record<string, unknown> | null;
+          metadata: string | null;
           ip_address: string | null;
           user_agent: string | null;
           created_at: string;
@@ -111,7 +111,7 @@ export interface Database {
           action: "create" | "read" | "update" | "delete" | "login" | "logout" | "custom";
           resource: string;
           resource_id?: string | null;
-          metadata?: Record<string, unknown> | null;
+          metadata?: string | null;
           ip_address?: string | null;
           user_agent?: string | null;
           created_at?: string;
@@ -123,7 +123,7 @@ export interface Database {
           action?: "create" | "read" | "update" | "delete" | "login" | "logout" | "custom";
           resource?: string;
           resource_id?: string | null;
-          metadata?: Record<string, unknown> | null;
+          metadata?: string | null;
           ip_address?: string | null;
           user_agent?: string | null;
           created_at?: string;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "drizzle-orm": "^0.39.0"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "drizzle-kit": "^0.31.0",

--- a/packages/ui/src/styles/theme-generated.css
+++ b/packages/ui/src/styles/theme-generated.css
@@ -1,6 +1,6 @@
 /*
  * AUTO-GENERATED — Do not edit manually.
- * Generated: 2026-04-24T18:41:17.341Z
+ * Generated: 2026-04-29T20:12:06.876Z
  * Source: packages/ui/src/themes/{light,dark}.json
  * Run `pnpm build:theme` to regenerate.
  */

--- a/packages/ui/src/tokens/index.ts
+++ b/packages/ui/src/tokens/index.ts
@@ -1,6 +1,6 @@
 /**
  * AUTO-GENERATED — Do not edit manually.
- * Generated: 2026-04-24T18:41:17.343Z
+ * Generated: 2026-04-29T20:12:06.882Z
  * Source: packages/ui/src/themes/light.json
  * Run `pnpm build:theme` to regenerate.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  next: 15.5.14
+  next: 15.5.15
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -62,8 +63,8 @@ importers:
         version: 3.25.76
     devDependencies:
       next:
-        specifier: 15.5.14
-        version: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 15.5.15
+        version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -74,8 +75,8 @@ importers:
   packages/db:
     dependencies:
       drizzle-orm:
-        specifier: ^0.39.0
-        version: 0.39.3(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)
     devDependencies:
       drizzle-kit:
         specifier: ^0.31.0
@@ -146,7 +147,7 @@ importers:
         version: link:../packages/ui
       '@sentry/nextjs':
         specifier: ^10.48.0
-        version: 10.50.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2)
+        version: 10.50.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -157,8 +158,8 @@ importers:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.5)
       next:
-        specifier: 15.5.14
-        version: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 15.5.15
+        version: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -970,53 +971,53 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@next/env@15.5.14':
-    resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
 
-  '@next/swc-darwin-arm64@15.5.14':
-    resolution: {integrity: sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==}
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.14':
-    resolution: {integrity: sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==}
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.14':
-    resolution: {integrity: sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==}
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.14':
-    resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.14':
-    resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.14':
-    resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.14':
-    resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.14':
-    resolution: {integrity: sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==}
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2148,7 +2149,7 @@ packages:
     resolution: {integrity: sha512-IyDaOpbWUzfAqFoTQUSpvmG1fC6GBkCOd6eTYoT8ZNfxXYPBVd4eQFTNNh09CvOkNe1QIVvVshajg1TqUNWK4g==}
     engines: {node: '>=18'}
     peerDependencies:
-      next: 15.5.14
+      next: 15.5.15
 
   '@sentry/node-core@10.50.0':
     resolution: {integrity: sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==}
@@ -2683,8 +2684,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.39.3:
-    resolution: {integrity: sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -2694,17 +2695,19 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
@@ -2742,6 +2745,8 @@ packages:
         optional: true
       '@types/sql.js':
         optional: true
+      '@upstash/redis':
+        optional: true
       '@vercel/postgres':
         optional: true
       '@xata.io/client':
@@ -2751,6 +2756,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -3126,8 +3133,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next@15.5.14:
-    resolution: {integrity: sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==}
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3220,10 +3227,6 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -4232,30 +4235,30 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@next/env@15.5.14': {}
+  '@next/env@15.5.15': {}
 
-  '@next/swc-darwin-arm64@15.5.14':
+  '@next/swc-darwin-arm64@15.5.15':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.14':
+  '@next/swc-darwin-x64@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.14':
+  '@next/swc-linux-arm64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.14':
+  '@next/swc-linux-arm64-musl@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.14':
+  '@next/swc-linux-x64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.14':
+  '@next/swc-linux-x64-musl@15.5.15':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.14':
+  '@next/swc-win32-arm64-msvc@15.5.15':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.14':
+  '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
   '@opentelemetry/api-logs@0.207.0':
@@ -5447,7 +5450,7 @@ snapshots:
 
   '@sentry/core@10.50.0': {}
 
-  '@sentry/nextjs@10.50.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2)':
+  '@sentry/nextjs@10.50.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -5460,7 +5463,7 @@ snapshots:
       '@sentry/react': 10.50.0(react@19.2.5)
       '@sentry/vercel-edge': 10.50.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2)
-      next: 15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.60.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -6042,7 +6045,7 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.39.3(@opentelemetry/api@1.9.1)(@types/pg@8.15.6):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
@@ -6418,24 +6421,24 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.14(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 15.5.14
+      '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001788
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.14
-      '@next/swc-darwin-x64': 15.5.14
-      '@next/swc-linux-arm64-gnu': 15.5.14
-      '@next/swc-linux-arm64-musl': 15.5.14
-      '@next/swc-linux-x64-gnu': 15.5.14
-      '@next/swc-linux-x64-musl': 15.5.14
-      '@next/swc-win32-arm64-msvc': 15.5.14
-      '@next/swc-win32-x64-msvc': 15.5.14
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
@@ -6500,12 +6503,6 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const repoRoot = process.cwd();
+
+const allowedWorkspaceImports = {
+  "packages/contracts": [],
+  "packages/db": [],
+  "packages/core": ["@enterprise/contracts", "@enterprise/db"],
+  "packages/ui": ["@enterprise/contracts"],
+  ui: ["@enterprise/contracts", "@enterprise/core", "@enterprise/ui", "@enterprise/db"],
+};
+
+const ignoredDirectories = new Set(["node_modules", ".next", "dist", ".turbo", ".git"]);
+const workspaceRoots = Object.keys(allowedWorkspaceImports);
+
+function collectFiles(directory) {
+  const files = [];
+  const entries = readdirSync(directory);
+
+  for (const entry of entries) {
+    if (ignoredDirectories.has(entry)) {
+      continue;
+    }
+
+    const absolutePath = join(directory, entry);
+    const stats = statSync(absolutePath);
+
+    if (stats.isDirectory()) {
+      files.push(...collectFiles(absolutePath));
+      continue;
+    }
+
+    if (entry.endsWith(".ts") || entry.endsWith(".tsx") || entry.endsWith(".mts")) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+function getWorkspaceRoot(filePath) {
+  const repoRelativePath = relative(repoRoot, filePath).replace(/\\/g, "/");
+  return (
+    workspaceRoots.find((workspaceRoot) => repoRelativePath.startsWith(`${workspaceRoot}/`)) ?? null
+  );
+}
+
+function getImports(fileContent) {
+  const importRegex = /(?:import|export)\s+(?:type\s+)?(?:[^"']*?from\s+)?["']([^"']+)["']/g;
+  const imports = [];
+  let match = importRegex.exec(fileContent);
+
+  while (match) {
+    imports.push(match[1]);
+    match = importRegex.exec(fileContent);
+  }
+
+  return imports;
+}
+
+const violations = [];
+
+for (const workspaceRoot of workspaceRoots) {
+  const rootPath = join(repoRoot, workspaceRoot);
+  const files = collectFiles(rootPath);
+
+  for (const filePath of files) {
+    const sourceWorkspace = getWorkspaceRoot(filePath);
+
+    if (!sourceWorkspace) {
+      continue;
+    }
+
+    const allowedTargets = allowedWorkspaceImports[sourceWorkspace];
+    const fileContent = readFileSync(filePath, "utf8");
+    const importSpecifiers = getImports(fileContent);
+
+    for (const importSpecifier of importSpecifiers) {
+      if (!importSpecifier.startsWith("@enterprise/")) {
+        continue;
+      }
+
+      if (/^@enterprise\/[a-z-]+\/(src|schema\/platform)/.test(importSpecifier)) {
+        violations.push({
+          filePath,
+          reason: `Deep package import is not allowed: ${importSpecifier}`,
+        });
+        continue;
+      }
+
+      const packageMatch = importSpecifier.match(/^@enterprise\/[a-z-]+/);
+
+      if (!packageMatch) {
+        continue;
+      }
+
+      const targetPackage = packageMatch[0];
+
+      if (targetPackage === "@enterprise/web" && sourceWorkspace !== "ui") {
+        violations.push({
+          filePath,
+          reason: "Packages MUST NOT import from @enterprise/web",
+        });
+        continue;
+      }
+
+      if (sourceWorkspace === "ui") {
+        if (!allowedTargets.includes(targetPackage)) {
+          violations.push({
+            filePath,
+            reason: `ui can only import ${allowedTargets.join(", ")}; found ${targetPackage}`,
+          });
+        }
+
+        continue;
+      }
+
+      const sourcePackageName = `@enterprise/${sourceWorkspace.split("/")[1]}`;
+
+      if (targetPackage === sourcePackageName) {
+        continue;
+      }
+
+      if (!allowedTargets.includes(targetPackage)) {
+        violations.push({
+          filePath,
+          reason: `${sourceWorkspace} cannot import ${targetPackage}`,
+        });
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("\nBoundary check failed:\n");
+
+  for (const violation of violations) {
+    console.error(`- ${relative(repoRoot, violation.filePath)} — ${violation.reason}`);
+  }
+
+  process.exit(1);
+}
+
+console.log("Boundary check passed.");

--- a/skills/drizzle/SKILL.md
+++ b/skills/drizzle/SKILL.md
@@ -29,7 +29,7 @@ All database **schema** work lives in `packages/db/` (schema-only package).
 All database **query** code lives in `packages/core/` or Server Actions / Route Handlers in `ui/`.
 NEVER place query logic or client setup in `packages/db/`.
 
-> **CURRENT STATE**: `packages/db/src/schema.ts` uses `pgTable.withRLS()` on all 7 tables,
+> **CURRENT STATE**: `packages/db/src/schema/platform.ts` defines the platform tables,
 > defines inline `pgPolicy()` rules, exports `$inferSelect`/`$inferInsert` types (with `Row`
 > suffix), and uses `auth.tenant_id()` / `auth.user_role()` / `auth.user_sede_id()` helper
 > functions in RLS policies. These functions must be created via custom migration.
@@ -130,7 +130,7 @@ import { eq, and, or, desc, sql } from 'drizzle-orm';
 
 | Item | Path | Notes |
 |------|------|-------|
-| Schema (platform) | `packages/db/src/platform.ts` | tenants, profiles, userRoleEnum |
+| Schema (platform) | `packages/db/src/schema/platform.ts` | tenants, profiles, userRoleEnum |
 | Schema (domain) | `packages/db/src/domain.ts` | sedes, eventos, orders, tickets, notifications + enums |
 | Schema (helpers) | `packages/db/src/helpers.ts` | RLS SQL fragments (isTenantMember, isAdminOrAbove) |
 | Schema (relations) | `packages/db/src/relations.ts` | All Drizzle relations() definitions |

--- a/skills/drizzle/references/pgvector-migrations.md
+++ b/skills/drizzle/references/pgvector-migrations.md
@@ -143,7 +143,7 @@ pnpm --filter @sala/db db:studio
 
 ```bash
 # The ONLY supported workflow in this project:
-# 1. Modify schema in packages/db/src/schema.ts
+# 1. Modify schema in packages/db/src/schema/platform.ts
 # 2. Generate migration SQL
 pnpm db:generate              # Creates SQL in ./migrations/
 # 3. Review the generated SQL

--- a/skills/drizzle/references/schema-rls-patterns.md
+++ b/skills/drizzle/references/schema-rls-patterns.md
@@ -9,7 +9,7 @@ Detailed patterns for Drizzle ORM schema definition and Row Level Security polic
 ### Basic Table with Conventions
 
 ```typescript
-// packages/db/src/schema.ts
+// packages/db/src/schema/platform.ts
 import { pgTable, pgPolicy, sql, uuid, text, timestamp, boolean, integer, pgEnum } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { authenticatedRole, anonRole } from 'drizzle-orm/supabase';

--- a/skills/zod-4/SKILL.md
+++ b/skills/zod-4/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch, WebSearch, Task
 ---
 
-> **WARNING — VERSION MISMATCH**: This project uses **Zod 3.24** (`zod@^3.24.0`). The patterns below document **Zod 4** breaking changes for future migration. Do NOT use Zod 4 syntax (`z.email()`, `z.uuid()`, `z.url()`, `{ error: "..." }`) until the project upgrades. Current Zod 3 patterns: `z.string().email()`, `z.string().uuid()`, `z.string().url()`, `{ message: "..." }`.
+> **WARNING — VERSION MISMATCH**: This project uses **Zod 3.25** (`zod@^3.25.0`). The patterns below document **Zod 4** breaking changes for future migration. Do NOT use Zod 4 syntax (`z.email()`, `z.uuid()`, `z.url()`, `{ error: "..." }`) until the project upgrades. Current Zod 3 patterns: `z.string().email()`, `z.string().uuid()`, `z.string().url()`, `{ message: "..." }`.
 
 ## Breaking Changes from Zod 3
 

--- a/supabase/migrations/20260420000002_custom_triggers.sql
+++ b/supabase/migrations/20260420000002_custom_triggers.sql
@@ -58,9 +58,19 @@ BEGIN
     NEW.id,
     new_tenant_id,
     NEW.email,
-    COALESCE(NEW.raw_user_meta_data->>'full_name', ''),
+    COALESCE(NEW.raw_user_meta_data->>'name', NEW.raw_user_meta_data->>'full_name', ''),
     'owner'
   );
+
+  -- Persist RLS claims in app metadata (never in user metadata)
+  UPDATE auth.users
+  SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb) || jsonb_build_object(
+    'tenant_id',
+    new_tenant_id,
+    'role',
+    'owner'
+  )
+  WHERE id = NEW.id;
 
   RETURN NEW;
 END;

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,26 @@
+# @enterprise/web — Agent Instructions
+
+## Purpose
+
+Next.js 15 App Router application for the Enterprise Platform template.
+
+## Layer Rules (MANDATORY)
+
+- UI routes/components MAY import from `@enterprise/contracts`, `@enterprise/core`, `@enterprise/ui`, and `@enterprise/db`
+- UI code MUST NOT implement business logic that belongs in `@enterprise/core/services`
+- Server Actions MUST remain thin wrappers (validate input, get client, call service, return result)
+- Auth and role decisions SHOULD be delegated to core services when possible
+
+## Skills Discoverability
+
+Repo-local skills are stored in `skills/` and exposed to OpenCode via the `.agents/skills` symlink.
+
+Run one of these before relying on repo-local skills:
+
+```bash
+pnpm skills:setup
+# or
+./skills/setup.sh --opencode
+```
+
+Without this setup, only globally installed skills are discoverable.

--- a/ui/app/(dashboard)/dashboard/page.tsx
+++ b/ui/app/(dashboard)/dashboard/page.tsx
@@ -1,3 +1,8 @@
+import {
+  createPlatformServiceContext,
+  ProfileService,
+  TenantService,
+} from "@enterprise/core/services";
 import { getServerClient } from "@enterprise/core/supabase/server";
 import { getAppUrl } from "@enterprise/core/utils/env";
 import {
@@ -14,11 +19,23 @@ export const metadata = { title: "Dashboard" };
 export default async function DashboardPage() {
   const user = await requireAuth();
   const supabase = await getServerClient();
+  const context = createPlatformServiceContext(supabase, {
+    userId: user.id,
+    tenantId: user.tenantId,
+    role: user.role,
+    email: user.email,
+  });
 
-  const [{ data: tenant }, { data: profile }] = await Promise.all([
-    supabase.from("tenants").select("name, slug, status").eq("id", user.tenantId).single(),
-    supabase.from("profiles").select("updated_at").eq("id", user.id).single(),
+  const tenantService = new TenantService(context);
+  const profileService = new ProfileService(context);
+
+  const [tenantResult, profileResult] = await Promise.all([
+    tenantService.getCurrent(),
+    profileService.getCurrent(),
   ]);
+
+  const tenant = tenantResult.success ? tenantResult.data : null;
+  const profile = profileResult.success ? profileResult.data : null;
 
   const appUrl = getAppUrl();
 

--- a/ui/app/(dashboard)/dashboard/settings/page.tsx
+++ b/ui/app/(dashboard)/dashboard/settings/page.tsx
@@ -1,3 +1,8 @@
+import {
+  createPlatformServiceContext,
+  ProfileService,
+  TenantService,
+} from "@enterprise/core/services";
 import { getServerClient } from "@enterprise/core/supabase/server";
 import { getAppUrl } from "@enterprise/core/utils/env";
 import {
@@ -14,11 +19,23 @@ export const metadata = { title: "Settings" };
 export default async function SettingsPage() {
   const user = await requireAuth();
   const supabase = await getServerClient();
+  const context = createPlatformServiceContext(supabase, {
+    userId: user.id,
+    tenantId: user.tenantId,
+    role: user.role,
+    email: user.email,
+  });
 
-  const [{ data: tenant }, { data: profile }] = await Promise.all([
-    supabase.from("tenants").select("name, slug, status").eq("id", user.tenantId).single(),
-    supabase.from("profiles").select("name, email, role, updated_at").eq("id", user.id).single(),
+  const tenantService = new TenantService(context);
+  const profileService = new ProfileService(context);
+
+  const [tenantResult, profileResult] = await Promise.all([
+    tenantService.getCurrent(),
+    profileService.getCurrent(),
   ]);
+
+  const tenant = tenantResult.success ? tenantResult.data : null;
+  const profile = profileResult.success ? profileResult.data : null;
 
   return (
     <div className="flex flex-col gap-6">

--- a/ui/features/auth/actions.test.ts
+++ b/ui/features/auth/actions.test.ts
@@ -8,6 +8,7 @@ const {
   mockRequestPasswordResetService,
   mockSignOutService,
   mockUpdatePasswordService,
+  mockResolveRoleRedirectPath,
   mockRedirect,
   mockNormalizeSafeRedirectPath,
   mockGetAppUrl,
@@ -18,6 +19,9 @@ const {
   mockRequestPasswordResetService: vi.fn(),
   mockSignOutService: vi.fn(),
   mockUpdatePasswordService: vi.fn(),
+  mockResolveRoleRedirectPath: vi.fn((role: string | null | undefined) =>
+    role === "guest" ? "/" : "/dashboard",
+  ),
   mockRedirect: vi.fn((path: string) => {
     throw createRedirectError(path);
   }),
@@ -45,6 +49,7 @@ vi.mock("@enterprise/core/services/auth-service", () => ({
   requestPasswordResetService: mockRequestPasswordResetService,
   signOutService: mockSignOutService,
   updatePasswordService: mockUpdatePasswordService,
+  resolveRoleRedirectPath: mockResolveRoleRedirectPath,
 }));
 
 vi.mock("./redirects", () => ({

--- a/ui/features/auth/actions.ts
+++ b/ui/features/auth/actions.ts
@@ -10,6 +10,7 @@ import {
 } from "@enterprise/contracts";
 import {
   requestPasswordResetService,
+  resolveRoleRedirectPath,
   signInWithPasswordService,
   signOutService,
   signUpService,
@@ -20,19 +21,8 @@ import { getAppUrl } from "@enterprise/core/utils/env";
 import { redirect } from "next/navigation";
 import { normalizeSafeRedirectPath } from "./redirects";
 
-const ROLE_REDIRECTS: Record<UserRole, string> = {
-  owner: "/dashboard",
-  admin: "/dashboard",
-  member: "/dashboard",
-  guest: "/",
-};
-
 function resolveRoleRedirect(role: UserRole | null | undefined) {
-  if (!role) {
-    return "/dashboard";
-  }
-
-  return ROLE_REDIRECTS[role] ?? "/dashboard";
+  return resolveRoleRedirectPath(role);
 }
 
 const AUTH_CALLBACK_PATH = "/auth/callback";
@@ -88,7 +78,6 @@ export async function signUpAction(formData: FormData) {
 
   const metadata = registrationMetadataSchema.parse({
     name: parsedInput.data.name,
-    role: "member",
   });
 
   const supabase = await getServerClient();

--- a/ui/features/auth/queries.test.ts
+++ b/ui/features/auth/queries.test.ts
@@ -1,24 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRedirectError, REDIRECT_SENTINEL } from "../../test-utils/redirect";
 
-const { mockGetServerClient, mockRedirect, mockGetUser, chain } = vi.hoisted(() => {
-  const singleMock = vi.fn();
-  const eqMock = vi.fn(() => ({ single: singleMock }));
-  const selectMock = vi.fn(() => ({ eq: eqMock }));
-  const fromMock = vi.fn(() => ({ select: selectMock }));
-  const chain = { fromMock, selectMock, eqMock, singleMock };
-
+const { mockGetServerClient, mockRedirect, mockGetCurrentPlatformUserService } = vi.hoisted(() => {
   return {
     mockGetServerClient: vi.fn(),
     mockRedirect: vi.fn((path: string) => {
       throw createRedirectError(path);
     }),
-    mockGetUser: vi.fn(),
-    chain,
+    mockGetCurrentPlatformUserService: vi.fn(),
   };
 });
 
 vi.mock("server-only", () => ({}));
+
+vi.mock("@enterprise/core/services/auth-service", () => ({
+  getCurrentPlatformUserService: mockGetCurrentPlatformUserService,
+}));
 
 vi.mock("@enterprise/core/supabase/server", () => ({
   getServerClient: mockGetServerClient,
@@ -35,17 +32,12 @@ async function loadQueries() {
 
 describe("queries", () => {
   beforeEach(() => {
-    mockGetServerClient.mockResolvedValue({
-      auth: {
-        getUser: mockGetUser,
-      },
-      from: chain.fromMock,
-    });
+    mockGetServerClient.mockResolvedValue({});
   });
 
   describe("getCurrentUser", () => {
     it("unauthenticated user returns null", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+      mockGetCurrentPlatformUserService.mockResolvedValue({ success: true, data: null });
 
       const { getCurrentUser } = await loadQueries();
       const result = await getCurrentUser();
@@ -54,22 +46,17 @@ describe("queries", () => {
     });
 
     it("authenticated user with profile returns mapped PlatformUser fields", async () => {
-      mockGetUser.mockResolvedValue({
+      mockGetCurrentPlatformUserService.mockResolvedValue({
+        success: true,
         data: {
-          user: {
-            id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            created_at: "2024-01-01T00:00:00.000Z",
-            updated_at: "2024-01-02T00:00:00.000Z",
-            email: "member@enterprise.dev",
-          },
-        },
-      });
-      chain.singleMock.mockResolvedValue({
-        data: {
-          tenant_id: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+          email: "member@enterprise.dev",
+          tenantId: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
           role: "member",
           name: "Member User",
-          avatar_url: "https://example.com/avatar.png",
+          avatarUrl: "https://example.com/avatar.png",
         },
       });
 
@@ -84,22 +71,22 @@ describe("queries", () => {
         role: "member",
         tenantId: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
       });
-      expect(result?.createdAt).toBeInstanceOf(Date);
-      expect(result?.updatedAt).toBeInstanceOf(Date);
     });
 
     it("authenticated user without profile returns fallback values", async () => {
-      mockGetUser.mockResolvedValue({
+      mockGetCurrentPlatformUserService.mockResolvedValue({
+        success: true,
         data: {
-          user: {
-            id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            created_at: "2024-01-01T00:00:00.000Z",
-            updated_at: "2024-01-02T00:00:00.000Z",
-            email: "guest@enterprise.dev",
-          },
+          id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+          email: "guest@enterprise.dev",
+          role: "guest",
+          name: null,
+          avatarUrl: null,
+          tenantId: "",
         },
       });
-      chain.singleMock.mockResolvedValue({ data: null });
 
       const { getCurrentUser } = await loadQueries();
       const result = await getCurrentUser();
@@ -115,7 +102,7 @@ describe("queries", () => {
 
   describe("requireAuth", () => {
     it("unauthenticated user triggers redirect('/sign-in')", async () => {
-      mockGetUser.mockResolvedValue({ data: { user: null } });
+      mockGetCurrentPlatformUserService.mockResolvedValue({ success: true, data: null });
 
       const { requireAuth } = await loadQueries();
 
@@ -125,22 +112,17 @@ describe("queries", () => {
     });
 
     it("authenticated user returns resolved PlatformUser", async () => {
-      mockGetUser.mockResolvedValue({
+      mockGetCurrentPlatformUserService.mockResolvedValue({
+        success: true,
         data: {
-          user: {
-            id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            created_at: "2024-01-01T00:00:00.000Z",
-            updated_at: "2024-01-02T00:00:00.000Z",
-            email: "member@enterprise.dev",
-          },
-        },
-      });
-      chain.singleMock.mockResolvedValue({
-        data: {
-          tenant_id: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+          email: "member@enterprise.dev",
+          tenantId: "b1b2c3d4-e5f6-7890-abcd-ef1234567890",
           role: "member",
           name: "Member User",
-          avatar_url: null,
+          avatarUrl: null,
         },
       });
 

--- a/ui/features/auth/queries.ts
+++ b/ui/features/auth/queries.ts
@@ -1,37 +1,20 @@
 import "server-only";
 
-import type { PlatformUser, UserRole } from "@enterprise/contracts";
+import type { PlatformUser } from "@enterprise/contracts";
+import { getCurrentPlatformUserService } from "@enterprise/core/services/auth-service";
 import { getServerClient } from "@enterprise/core/supabase/server";
 import { redirect } from "next/navigation";
 
 /** Get the current authenticated user or null */
 export async function getCurrentUser(): Promise<PlatformUser | null> {
   const supabase = await getServerClient();
+  const result = await getCurrentPlatformUserService(supabase);
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
+  if (!result.success) {
     return null;
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("tenant_id, role, name, avatar_url")
-    .eq("id", user.id)
-    .single();
-
-  return {
-    id: user.id,
-    createdAt: new Date(user.created_at),
-    updatedAt: new Date(user.updated_at ?? user.created_at),
-    email: user.email ?? "",
-    name: profile?.name ?? null,
-    avatarUrl: profile?.avatar_url ?? null,
-    role: ((profile?.role as UserRole | undefined) ?? "guest") as UserRole,
-    tenantId: profile?.tenant_id ?? "",
-  };
+  return result.data;
 }
 
 /** Require authentication — redirects to sign-in if unauthenticated */

--- a/ui/middleware.test.ts
+++ b/ui/middleware.test.ts
@@ -1,31 +1,37 @@
-import type { UserRole } from "@enterprise/contracts";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetUser, mockUpdateSession, chain, mockCreateMiddlewareClient } = vi.hoisted(() => {
-  const singleMock = vi.fn();
-  const eqMock = vi.fn(() => ({ single: singleMock }));
-  const selectMock = vi.fn(() => ({ eq: eqMock }));
-  const fromMock = vi.fn(() => ({ select: selectMock }));
-  const chain = { fromMock, selectMock, eqMock, singleMock };
-
+const {
+  mockGetUser,
+  mockUpdateSession,
+  mockCreateMiddlewareClient,
+  mockGetUserRoleService,
+  mockResolveRoleRedirectPath,
+} = vi.hoisted(() => {
   return {
     mockGetUser: vi.fn(),
     mockUpdateSession: vi.fn(),
-    chain,
     mockCreateMiddlewareClient: vi.fn(() => ({
       auth: {
         getUser: vi.fn(),
       },
-      from: vi.fn(),
     })),
+    mockGetUserRoleService: vi.fn(),
+    mockResolveRoleRedirectPath: vi.fn((role: string | null | undefined) =>
+      role === "guest" ? "/" : "/dashboard",
+    ),
   };
 });
 
 vi.mock("@enterprise/core/supabase/middleware", () => ({
   createMiddlewareClient: mockCreateMiddlewareClient,
   updateSession: mockUpdateSession,
+}));
+
+vi.mock("@enterprise/core/services/auth-service", () => ({
+  getUserRoleService: mockGetUserRoleService,
+  resolveRoleRedirectPath: mockResolveRoleRedirectPath,
 }));
 
 interface CreateRequestOptions {
@@ -52,7 +58,6 @@ async function loadMiddleware() {
     auth: {
       getUser: mockGetUser,
     },
-    from: chain.fromMock,
   });
 
   return import("./middleware");
@@ -69,7 +74,7 @@ function expectRedirectPath(response: NextResponse, expectedPath: string): void 
 describe("middleware auth flow", () => {
   beforeEach(() => {
     mockUpdateSession.mockResolvedValue(NextResponse.next());
-    chain.singleMock.mockResolvedValue({ data: { role: "member" }, error: null });
+    mockGetUserRoleService.mockResolvedValue({ success: true, data: { role: "member" } });
   });
 
   it("unauthenticated request to a public route (e.g., /sign-in) returns pass-through response", async () => {
@@ -110,23 +115,22 @@ describe("middleware auth flow", () => {
 
     const { middleware } = await loadMiddleware();
 
-    const roleCases: Array<{ role: UserRole; expected: string }> = [
-      { role: "owner", expected: "/dashboard" },
-      { role: "admin", expected: "/dashboard" },
-      { role: "member", expected: "/dashboard" },
-      { role: "guest", expected: "/" },
-    ];
+    mockGetUserRoleService.mockResolvedValueOnce({ success: true, data: { role: "owner" } });
+    const ownerResult = await middleware(createRequest("/"));
+    expectRedirectPath(ownerResult, "/dashboard");
 
-    for (const roleCase of roleCases) {
-      chain.singleMock.mockResolvedValueOnce({ data: { role: roleCase.role }, error: null });
-      const result = await middleware(createRequest("/"));
-      expectRedirectPath(result, roleCase.expected);
-    }
+    mockGetUserRoleService.mockResolvedValueOnce({ success: true, data: { role: "guest" } });
+    const guestResult = await middleware(createRequest("/"));
+    expectRedirectPath(guestResult, "/");
   });
 
   it("authenticated request with missing profile defaults to guest and redirects to / for public-entry routes", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
-    chain.singleMock.mockResolvedValue({ data: null, error: { message: "not found" } });
+    mockGetUserRoleService.mockResolvedValue({
+      success: false,
+      error: "Could not load user role",
+      code: "ROLE_LOOKUP_FAILED",
+    });
 
     const { middleware } = await loadMiddleware();
     const result = await middleware(createRequest("/sign-in"));
@@ -136,7 +140,7 @@ describe("middleware auth flow", () => {
 
   it("authenticated server action POST to a public route does not redirect", async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
-    chain.singleMock.mockResolvedValue({ data: { role: "member" }, error: null });
+    mockGetUserRoleService.mockResolvedValue({ success: true, data: { role: "member" } });
 
     const { middleware } = await loadMiddleware();
     const result = await middleware(

--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -1,4 +1,7 @@
-import type { UserRole } from "@enterprise/contracts";
+import {
+  getUserRoleService,
+  resolveRoleRedirectPath,
+} from "@enterprise/core/services/auth-service";
 import { createMiddlewareClient, updateSession } from "@enterprise/core/supabase/middleware";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -12,13 +15,6 @@ const PUBLIC_ROUTES = [
 ];
 const AUTH_COMPLETION_ROUTES = ["/auth/callback", "/reset-password"];
 const PROTECTED_ROUTES = ["/dashboard"];
-
-const ROLE_REDIRECTS: Record<UserRole, string> = {
-  owner: "/dashboard",
-  admin: "/dashboard",
-  member: "/dashboard",
-  guest: "/",
-};
 
 const supabaseUrl = process.env["NEXT_PUBLIC_SUPABASE_URL"];
 const supabaseAnonKey = process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
@@ -63,13 +59,10 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
-  const role = (profile?.role as UserRole | undefined) ?? "guest";
-  const roleHome = ROLE_REDIRECTS[role] ?? "/dashboard";
+  const roleResult = await getUserRoleService(supabase, user.id);
+  const roleHome = roleResult.success
+    ? resolveRoleRedirectPath(roleResult.data.role)
+    : resolveRoleRedirectPath("guest");
 
   if (isServerActionRequest) {
     return response;

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.468.0",
-    "next": "^15.1.0",
+    "next": "^15.5.15",
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary

- **ServiceResult migration**: All platform services (`TenantService`, `ProfileService`, `AuditService`, `RoleService`) now return `ServiceResult<T>` instead of throwing exceptions, aligning with the established `auth-service` pattern documented in AGENTS.md
- **Centralized auth logic**: Extracted `getUserRoleService`, `getCurrentPlatformUserService`, and `resolveRoleRedirectPath` into the service layer — middleware and queries no longer make direct Supabase calls for role/user resolution
- **RLS app_metadata fix**: Signup trigger now persists `tenant_id` and `role` in `raw_app_meta_data`, and Drizzle schema RLS policies read from `app_metadata` (fixes redirect loops caused by missing JWT claims)

## Additional Changes

- Real security CI workflow replacing placeholder (`pnpm audit` + gitleaks)
- Package boundary enforcement script (`scripts/check-boundaries.mjs`) + CI step
- Removed `role` from `registrationMetadataSchema` (role is assigned by DB trigger, not client)
- Fixed Supabase contracts: JSON columns typed as `string | null` (matches actual API)
- Corrected Zod version refs in docs/skills (3.24 → 3.25)
- Fixed drizzle skill paths (`schema.ts` → `schema/platform.ts`)
- Added `ui/AGENTS.md` with layer rules
- All tests updated and passing (212 tests across 3 packages)

## Verification

- [x] `pnpm typecheck` — 6/6 passed
- [x] `pnpm lint` — 161 files, 0 issues
- [x] `pnpm test` — 212 tests passed
- [x] `pnpm check:boundaries` — passed