### PR TITLE
refactor: restructure AGENTS.md hierarchy for clarity and reduced duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,18 @@ packages/ui/        → @enterprise/ui — shadcn/ui component library, design t
 docs/               → Product docs (PRD, RFE)
 ```
 
+## Workspace AGENTS.md
+
+Each workspace has its own AGENTS.md with specific rules. The runtime reads them by directory proximity — when editing a file, the nearest AGENTS.md in the path applies.
+
+| Workspace | AGENTS.md | Focus |
+|-----------|-----------|-------|
+| `ui/` | `ui/AGENTS.md` | Server Actions, features, E2E tests |
+| `packages/core/` | `packages/core/AGENTS.md` | Service layer, Supabase clients |
+| `packages/db/` | `packages/db/AGENTS.md` | Schema definition, migrations |
+| `packages/ui/` | `packages/ui/AGENTS.md` | Components, design tokens |
+| `packages/contracts/` | `packages/contracts/AGENTS.md` | Zod schemas, DTOs |
+
 ## Dependency Direction (ENFORCED)
 
 ```
@@ -45,42 +57,17 @@ NEVER create circular dependencies. NEVER import from @enterprise/web in any pac
 
 1. **Feature-based structure**: Each module in `ui/features/{module}/` with actions, queries, schemas, types, components, hooks
 2. **Server-first**: Landings with SSR. Dashboard with Server Components where possible. Client Components only for interactivity
-3. **Service layer**: ALL business logic lives in `packages/core/src/services/`. Server Actions are thin wrappers only (see below)
+3. **Service layer**: ALL business logic lives in `packages/core/src/services/`. Server Actions are thin wrappers only
 4. **Adapter pattern**: External integrations behind adapter interfaces for decoupling
 5. **RLS everywhere**: ALL queries go through Supabase RLS. No tenant bypass in frontend
 6. **Contracts as source of truth**: All DTOs, inputs, and outputs defined as Zod schemas in @enterprise/contracts
-7. **Explicit Supabase contracts**: Auth metadata shapes, storage paths, and env vars are typed and centralized (see below)
+7. **Explicit Supabase contracts**: Auth metadata shapes, storage paths, and env vars are typed and centralized
 
 ## Service Layer Pattern (ENFORCED)
 
 ALL business logic MUST live in `packages/core/src/services/`. Server Actions are **thin wrappers only**.
 
-### Server Action Pattern (MANDATORY for all mutations):
-
-```
-Server Action (thin wrapper)              Service (business logic)
-─────────────────────────                ────────────────────────
-"use server"                             NO "use server"
-1. Zod validation                        1. Receive typed data + SupabaseClient
-2. Get authenticated Supabase client     2. Execute business logic
-3. Call service function                 3. Return ServiceResult<T>
-4. Return ActionResult<T> on failure
-5. revalidatePath on success when needed
-6. Return ActionResult<T>
-```
-
-### Service Design Rules:
-- Services receive `SupabaseClient` as first arg (dependency injection — testable with mocks)
-- Services return `ServiceResult<T>` = `{ success: true; data: T } | { success: false; error: string; code?: string }`
-- Services have NO `"use server"`, NO `revalidatePath`, NO `redirect`, NO Sentry calls
-- Services live in `packages/core/src/services/{module}-service.ts`
-- Tests live in `packages/core/src/services/__tests__/{module}-service.test.ts`
-
-### Existing Services:
-| Service | API shape | What it covers |
-|---------|-----------|---------------|
-| `auth-service.ts` | function-based services returning `ServiceResult<T>` | Sign in, sign out, sign up, password reset |
-| `services/index.ts` | class-based platform services (`TenantService`, `ProfileService`, `AuditService`, `RoleService`) | Tenant, profile, audit, and role operations |
+**New services MUST use the function-based pattern** (like `auth-service.ts`). The class-based services in `index.ts` are legacy and will be migrated. See `packages/core/AGENTS.md` for the full service layer rules.
 
 ### When adding a new feature:
 1. Create `packages/core/src/services/{feature}-service.ts`
@@ -88,96 +75,43 @@ Server Action (thin wrapper)              Service (business logic)
 3. Create thin Server Actions in `ui/features/{feature}/actions.ts`
 4. Use `AuditService.log()` or an equivalent platform logging abstraction for create/update/delete operations
 
-## Supabase Contracts (ENFORCED)
-
-### Auth Metadata
-- Registration metadata: use `RegistrationMetadata` type from `@enterprise/contracts`
-- Invitation metadata: use `InvitationMetadata` type from `@enterprise/contracts`
-- NEVER send raw untyped metadata to `supabase.auth.signUp()` — always use the typed schemas
-
-### Storage Paths
-- ALWAYS use `buildStoragePath(type, { tenantId, entityId, filename })` from `@enterprise/core/supabase/storage-paths`
-- NEVER construct storage paths with string concatenation
-- Path format `{tenantId}/{entityId}/{filename}` is enforced by RLS — changing it breaks authorization
-
-### Environment Variables
-- ALWAYS use `getAppUrl()` from `@enterprise/core/utils/env` for the application URL
-- Use `getEnv()` and the typed helpers in `@enterprise/core/utils/env` instead of ad-hoc `process.env` access in shared code
-
-### Audit Logging
-- Use `AuditService.log()` (or a thin wrapper around it) for CUD operations that need audit entries
-- Audit logging is fire-and-forget — it MUST NOT block the main operation
-- NEVER log PII (email, name, phone) in audit metadata
-
-## Skill Auto-Invoke Table
-
-Load these skills BEFORE writing any code when the context matches:
-
-| Context | Skill |
-|---------|-------|
-| React components, hooks, patterns | react-19 |
-| Next.js routing, Server Actions, data fetching | nextjs-15 |
-| TypeScript types, interfaces, generics | typescript |
-| Tailwind styling, cn(), theme variables | tailwind-4 |
-| Zod schemas, validation | typescript |
-| Zustand stores, state management | zustand-5 |
-| E2E tests, Page Objects | playwright |
-| Creating GitHub issues | issue-creation |
-| Creating pull requests | branch-pr |
-| Reviewing PRs | pr-review |
-| Drizzle schemas, migrations, DB queries | drizzle |
-| CSS tokens, theme variables, colors | design-tokens |
-| UI layout composition, visual hierarchy | design-rules |
-| Feature components, shadcn theming | design-components |
-| Sentry, error tracking, error boundaries, monitoring, observability | sentry |
-| Supabase auth, SSR, RLS, storage, CLI, MCP, Edge Functions | supabase |
-| Postgres query optimization, schema performance, connection management | supabase-postgres-best-practices |
-| Creating new AI agent skills, documenting patterns for AI | skill-creator |
+## Skills
 
 Repo-local skills require runtime wiring. Run `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so OpenCode can discover `.agents/skills` before relying on local skills such as `drizzle`, `supabase`, `sentry`, and the design-system skills.
 
-## Design Reference
+Skills not yet auto-synced (available globally or without metadata): `issue-creation`, `branch-pr`, `pr-review`. These are invoked by context from each workspace's own AGENTS.md auto-invoke table.
 
-Before implementing ANY UI component or page, follow this workflow:
+### Auto-invoke Skills
 
-### Step 1: Check existing UI primitives and tokens
-Inspect `packages/ui/src/components/` and `packages/ui/src/styles/globals.css` before creating new UI.
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
-### Step 2: Check existing screens or generate a reference
-If a Stitch project exists for this application, query its MCP to find relevant reference screens.
-If no Stitch project is configured, implement using the existing component patterns in the codebase.
-
-### Step 3: Implement following the design
-When writing the component code:
-- Use the **tokens** from `globals.css` (surface-container-*, primary-fixed-dim, etc.)
-- Follow the existing tonal layering and spacing patterns already used in `packages/ui` and `ui/`
-- Match the **layout and hierarchy** from any available reference screen
-- Use `@enterprise/ui` primitives and compose them consistently
-
-### Key principle
-Design references are DIRECTION, not pixel-perfect. The source of truth is the existing `@enterprise/ui` package plus the local CSS token definitions.
+| Action | Skill |
+|--------|-------|
+| Adding error tracking to Server Actions | `sentry` |
+| After creating/modifying a skill | `skill-sync` |
+| App Router / Server Actions | `nextjs-15` |
+| Configuring RLS at client level | `supabase` |
+| Configuring database connections | `supabase-postgres-best-practices` |
+| Creating new skills | `skill-creator` |
+| Implementing auth flows | `supabase` |
+| Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Regenerate AGENTS.md Auto-invoke tables (sync.sh) | `skill-sync` |
+| Reviewing schema performance | `supabase-postgres-best-practices` |
+| Setting up Supabase SSR cookies | `supabase` |
+| Troubleshoot why a skill is missing from AGENTS.md auto-invoke | `skill-sync` |
+| Using Zustand stores | `zustand-5` |
+| Using captureException or captureActionError | `sentry` |
+| Using getUser or getSession | `supabase` |
+| Working with Supabase clients | `supabase` |
+| Working with Tailwind classes | `tailwind-4` |
+| Working with error boundaries | `sentry` |
+| Writing Playwright E2E tests | `playwright` |
+| Writing React components | `react-19` |
+| Writing TypeScript types/interfaces | `typescript` |
 
 ## Language Policy (ENFORCED)
 
-**ALL generated artifacts MUST be in English.** No exceptions.
-
-| Artifact | Language | Example |
-|----------|----------|---------|
-| Variable/function names | English | `createResource`, `itemCount`, `buyerEmail` |
-| Type/interface names | English | `ActionResult`, `ResourceStatus`, `CheckInInput` |
-| Component names | English | `ResourceCard`, `TenantForm`, `CheckInPanel` |
-| File/folder names | English | `resource-card.tsx`, `check-in/`, `use-resource-form.ts` |
-| Code comments | English | `// Verify token hasn't been used before` |
-| Commit messages | English | `feat: add check-in scanner` |
-| PR titles and descriptions | English | Clear, concise English |
-| JSDoc / TSDoc | English | `@param resourceId - The UUID of the resource` |
-| Error messages (developer-facing) | English | `"Missing required environment variable"` |
-| Log messages | English | `console.error("Webhook signature verification failed")` |
-| README and technical docs | English | Architecture docs, setup guides |
-| AGENTS.md files | English | All agent instructions |
-| Test descriptions | English | `it("should reject already-used token")` |
-
-**Documentation is NOT an exception.** PRD, RFE, README, ADRs, and any future docs MUST be written and maintained in English.
+**ALL generated artifacts MUST be in English.** No exceptions — code, comments, commits, docs, types, file names, error messages, test descriptions.
 
 ## Code Conventions
 
@@ -198,17 +132,7 @@ Every feature module MUST include tests. This is NOT optional.
 | Unit tests | Vitest | Contracts, utilities, pure logic | `*.test.ts` colocated with source |
 | E2E tests | Playwright | Every feature with UI pages | `ui/e2e/{feature}/` |
 
-### E2E Test Rules
-- Every feature that adds dashboard pages MUST include Playwright E2E tests
-- Tests cover: CRUD happy paths + critical edge cases (auth, validation, error states)
-- Use Page Object Model pattern (see `playwright` skill)
-- Auth helper in `ui/e2e/helpers/auth.ts` for login flow reuse
-- Test files: `ui/e2e/{feature}/{feature}.spec.ts`
-
-### SDD Task Generation Rule
-When `sdd-tasks` generates a task breakdown for a feature with UI pages, it MUST include:
-- A testing phase with E2E test tasks for every user-facing flow
-- Unit test tasks for contracts, utilities, and business logic
+See `ui/AGENTS.md` for E2E test rules and conventions.
 
 ## QA Checklist (before every PR)
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,23 +1,6 @@
 # Packages — Agent Instructions
 
-### Auto-invoke Skills
-
-When performing these actions, invoke the corresponding available skill FIRST. Repo-local skills require `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so the runtime can see `.agents/skills`.
-
-| Action | Skill |
-|--------|-------|
-| Adding RLS policies | `drizzle` |
-| Creating database relations | `drizzle` |
-| Creating database schemas | `drizzle` |
-| Defining table columns and types | `drizzle` |
-| Implementing pgvector/embeddings | `drizzle` |
-| Running migrations | `drizzle` |
-| Working with Supabase auth | `drizzle` |
-| Writing database queries | `drizzle` |
-| TypeScript types, exports, interfaces, strict-mode fixes | `typescript` |
-| React package UI work | `react-19` |
-| Tailwind styling in shared UI packages | `tailwind-4` |
-| Playwright E2E work | `playwright` |
+Each package has its own AGENTS.md with workspace-specific rules and auto-invoke tables. See `packages/*/AGENTS.md` for details.
 
 ## Package Boundary Rules
 
@@ -32,7 +15,7 @@ When performing these actions, invoke the corresponding available skill FIRST. R
 @enterprise/contracts → zod (ONLY external dep)
 @enterprise/core      → @enterprise/contracts + @enterprise/db + supabase
 @enterprise/db        → drizzle-orm (ONLY external dep, NO business logic)
-@enterprise/ui        → clsx + tailwind-merge + CVA + lucide-react (NO business logic)
+@enterprise/ui        → clsx + tailwind-merge + CVA + lucide-react + radix-ui (NO business logic)
 ```
 
 ## Adding a New Package
@@ -42,3 +25,4 @@ When performing these actions, invoke the corresponding available skill FIRST. R
 3. Extend root tsconfig: `"extends": "../../tsconfig.json"`
 4. Add to consuming package's dependencies: `"@enterprise/{name}": "workspace:*"`
 5. Add to `ui/next.config.ts` transpilePackages if it contains JSX
+6. Create `packages/{name}/AGENTS.md` following the template of an existing package. Add the new scope to `skills/skill-sync/assets/sync.sh:get_agents_path()` so auto-invoke tables are maintained

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -6,14 +6,15 @@ Single source of truth for all data shapes (DTOs). Every Zod schema, input type,
 
 ### Auto-invoke Skills
 
-When performing these actions, invoke the corresponding installed skill FIRST:
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
 | TypeScript types, DTO exports, strict-mode fixes | `typescript` |
 | Making permission or role-based decisions | `typescript` |
+| Writing Zod validation schemas | `typescript` |
 
-There is currently **no installed Zod 3 skill** in this repo. Follow the local rules below for schema work.
+Project uses **Zod 3.24**. A `zod-4` skill exists for future migration reference. Current validation patterns follow the rules below.
 
 ---
 
@@ -22,7 +23,7 @@ There is currently **no installed Zod 3 skill** in this repo. Follow the local r
 1. **Zero internal deps**: Only dependency is `zod`. Never import from `@enterprise/core`, `@enterprise/ui`, or `@enterprise/web`
 2. **Schema naming**: Always suffix with `Schema` (e.g., `createResourceSchema`)
 3. **Type inference**: Derive TypeScript types from schemas using `z.infer<typeof schema>`
-4. **File organization**: Keep shared contracts in the current structure — `src/dto/platform.ts`, `src/schemas/platform.ts`, and `src/types/platform.ts`
+4. **File organization**: Organize by domain: `src/{dto,schemas,types}/{domain}.ts`. Platform-level contracts live in `platform.ts`; feature-specific contracts in their own files (e.g., `resources.ts`, `theme.ts`)
 5. **Barrel export**: `index.ts` re-exports everything
 6. **Enums**: Define as `const` arrays + `z.enum()` for runtime validation AND type narrowing
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -6,21 +6,25 @@ Shared business infrastructure: Supabase clients, service layer, auth helpers, a
 
 ### Auto-invoke Skills
 
-When performing these actions, invoke the corresponding available skill FIRST. Repo-local skills require `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so the runtime can see `.agents/skills`.
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
 | Adding RLS policies | `drizzle` |
+| Configuring RLS at client level | `supabase` |
+| Configuring database connections | `supabase-postgres-best-practices` |
 | Creating database relations | `drizzle` |
 | Creating database schemas | `drizzle` |
+| Defining auth-related database schemas or RLS policies | `drizzle` |
 | Defining table columns and types | `drizzle` |
-| Implementing feature business logic in server actions or routing | `nextjs-15` |
+| Implementing auth flows | `supabase` |
 | Implementing pgvector/embeddings | `drizzle` |
-| Making permission or role-based decisions | `typescript` |
+| Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Reviewing schema performance | `supabase-postgres-best-practices` |
 | Running migrations | `drizzle` |
-| Working with Supabase auth | `drizzle` |
-| Strict TypeScript work in services or helpers | `typescript` |
-| Working with Supabase clients, SSR, storage, CLI | `supabase` |
+| Setting up Supabase SSR cookies | `supabase` |
+| Using getUser or getSession | `supabase` |
+| Working with Supabase clients | `supabase` |
 | Writing database queries | `drizzle` |
 
 ---
@@ -46,9 +50,10 @@ src/services/
 ```
 
 ### Rules
-- Services receive `SupabaseClient` as first arg when following the function-based pattern
+- **New services MUST use the function-based pattern** (like `auth-service.ts`). The class-based services in `index.ts` are legacy and will be migrated
+- Services receive `SupabaseClient` as first arg (dependency injection — testable with mocks)
 - Services return `ServiceResult<T>` — NEVER `ActionResult<T>`
-- Services have NO `"use server"`, NO `revalidatePath`, NO `redirect`
+- Services have NO `"use server"`, NO `revalidatePath`, NO `redirect`, NO Sentry calls (services must be testable without observability infrastructure — Sentry calls belong in Server Actions or error boundaries)
 - New features MUST create a service before creating actions
 
 ### Adding a New Service

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -4,7 +4,21 @@
 
 ### Auto-invoke Skills
 
-Use the repo-local `drizzle` skill for schema and migration work after running `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so the runtime can see `.agents/skills`.
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
+
+| Action | Skill |
+|--------|-------|
+| Adding RLS policies | `drizzle` |
+| Configuring database connections | `supabase-postgres-best-practices` |
+| Creating database relations | `drizzle` |
+| Creating database schemas | `drizzle` |
+| Defining auth-related database schemas or RLS policies | `drizzle` |
+| Defining table columns and types | `drizzle` |
+| Implementing pgvector/embeddings | `drizzle` |
+| Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Reviewing schema performance | `supabase-postgres-best-practices` |
+| Running migrations | `drizzle` |
+| Writing database queries | `drizzle` |
 
 ---
 
@@ -39,7 +53,7 @@ This package is **SCHEMA-ONLY**. It defines the database structure using Drizzle
 The correct workflow:
 
 ```bash
-# 1. Modify schema in src/schema/platform.ts
+# 1. Modify schema files in src/schema/ (create new domain files as needed)
 
 # 2. Generate a migration from the schema
 pnpm --filter @enterprise/db db:generate
@@ -90,7 +104,8 @@ packages/db/
 └── src/
     ├── index.ts               # Barrel export
     └── schema/
-        └── platform.ts        # Tables, enums, and exported schema types
+        ├── platform.ts        # Platform tables (tenants, profiles, roles, audit)
+        └── resources.ts       # Domain tables (new domain files follow this pattern)
 ```
 
 ## Dependency Direction

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -6,7 +6,7 @@ Shared UI component library based on shadcn/ui. It owns design tokens, base comp
 
 ### Auto-invoke Skills
 
-When performing these actions, invoke the corresponding available skill FIRST. Repo-local skills require `pnpm skills:setup` (or `./skills/setup.sh --opencode`) so the runtime can see `.agents/skills`.
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
@@ -24,9 +24,6 @@ When performing these actions, invoke the corresponding available skill FIRST. R
 | Modifying globals.css or @theme tokens | `design-tokens` |
 | Setting typography font families or weights | `design-tokens` |
 | Styling component visual hierarchy | `design-rules` |
-| Writing or refactoring React components | `react-19` |
-| Strict TypeScript changes in UI components | `typescript` |
-| Tailwind styling, tokens, and class composition | `tailwind-4` |
 
 ---
 

--- a/skills/drizzle/SKILL.md
+++ b/skills/drizzle/SKILL.md
@@ -10,7 +10,7 @@ license: Apache-2.0
 metadata:
   author: anyoneAI
   version: "1.1.0"
-  scope: [packages, packages/db, packages/core, ui]
+  scope: [packages/db, packages/core, ui]
   auto_invoke:
     - "Creating database schemas"
     - "Defining table columns and types"
@@ -18,7 +18,7 @@ metadata:
     - "Creating database relations"
     - "Running migrations"
     - "Writing database queries"
-    - "Working with Supabase auth"
+    - "Defining auth-related database schemas or RLS policies"
     - "Implementing pgvector/embeddings"
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, Task
 ---

--- a/skills/sentry/SKILL.md
+++ b/skills/sentry/SKILL.md
@@ -4,6 +4,11 @@ description: "Sentry instrumentation patterns for @enterprise/web — Server Act
 metadata:
   author: enterprise-platform
   version: "1.0.0"
+  scope: [ui, root]
+  auto_invoke:
+    - "Adding error tracking to Server Actions"
+    - "Working with error boundaries"
+    - "Using captureException or captureActionError"
 ---
 
 # Sentry Instrumentation — @enterprise/web

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -89,18 +89,21 @@ show_menu() {
     SETUP_COPILOT=${selected[4]}
 }
 
-copy_agents_md() {
+symlink_agents_md() {
     local target_name="$1"
     local count=0
 
     while IFS= read -r -d '' agents_file; do
         local agents_dir
         agents_dir="$(dirname "$agents_file")"
-        cp "$agents_file" "$agents_dir/$target_name"
+        local target_path="$agents_dir/$target_name"
+        [ -L "$target_path" ] && rm "$target_path"
+        [ -f "$target_path" ] && rm "$target_path"
+        ln -s "AGENTS.md" "$target_path"
         count=$((count + 1))
     done < <(find "$REPO_ROOT" \( -name "AGENTS.md" -o -name "AGENTS.MD" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/.venv/*" -print0 2>/dev/null)
 
-    echo -e "${GREEN}  ✓ Copied $count AGENTS.md -> $target_name${NC}"
+    echo -e "${GREEN}  ✓ Symlinked $count AGENTS.md -> $target_name${NC}"
 }
 
 setup_claude() {
@@ -110,7 +113,7 @@ setup_claude() {
     [ -d "$target" ] && mv "$target" "$REPO_ROOT/.claude/skills.backup.$(date +%s)"
     ln -s "$SKILLS_SOURCE" "$target"
     echo -e "${GREEN}  ✓ .claude/skills -> skills/${NC}"
-    copy_agents_md "CLAUDE.md"
+    symlink_agents_md "CLAUDE.md"
 }
 
 setup_opencode() {
@@ -130,7 +133,7 @@ setup_gemini() {
     [ -d "$target" ] && mv "$target" "$REPO_ROOT/.gemini/skills.backup.$(date +%s)"
     ln -s "$SKILLS_SOURCE" "$target"
     echo -e "${GREEN}  ✓ .gemini/skills -> skills/${NC}"
-    copy_agents_md "GEMINI.md"
+    symlink_agents_md "GEMINI.md"
 }
 
 setup_codex() {

--- a/skills/skill-sync/assets/sync.sh
+++ b/skills/skill-sync/assets/sync.sh
@@ -194,7 +194,12 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
         mv "$agents_path.tmp" "$agents_path"
         echo -e "${GREEN}  ✓ Updated Auto-invoke section${NC}"
     else
-        echo -e "${YELLOW}  ! No existing Auto-invoke section in $agents_path${NC}"
+        echo -e "${YELLOW}  ! No existing Auto-invoke section in $agents_path — appending${NC}"
+        {
+            echo ""
+            cat "$section_file"
+        } >> "$agents_path"
+        echo -e "${GREEN}  ✓ Created Auto-invoke section${NC}"
     fi
 
     rm -f "$section_file"

--- a/skills/supabase-postgres-best-practices/SKILL.md
+++ b/skills/supabase-postgres-best-practices/SKILL.md
@@ -8,6 +8,11 @@ metadata:
   organization: Supabase
   date: January 2026
   abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+  scope: [packages/db, packages/core, root]
+  auto_invoke:
+    - "Optimizing Postgres queries"
+    - "Reviewing schema performance"
+    - "Configuring database connections"
 ---
 
 # Supabase Postgres Best Practices

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -4,6 +4,13 @@ description: "Use when doing ANY task involving Supabase. Triggers: Supabase pro
 metadata:
   author: supabase
   version: "0.1.0"
+  scope: [packages/core, ui, root]
+  auto_invoke:
+    - "Working with Supabase clients"
+    - "Implementing auth flows"
+    - "Configuring RLS at client level"
+    - "Using getUser or getSession"
+    - "Setting up Supabase SSR cookies"
 ---
 
 # Supabase

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,94 @@
+# @enterprise/web — Agent Instructions
+
+## Purpose
+
+Next.js 15 App Router application. This is the deployable frontend workspace that consumes all `@enterprise/*` packages.
+
+### Auto-invoke Skills
+
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
+
+| Action | Skill |
+|--------|-------|
+| Adding RLS policies | `drizzle` |
+| Adding error tracking to Server Actions | `sentry` |
+| Adding hover states or transitions | `design-rules` |
+| App Router / Server Actions | `nextjs-15` |
+| Building dashboard cards or panels | `design-components` |
+| Building mobile-first UI | `design-components` |
+| Choosing between border and tonal shift | `design-rules` |
+| Choosing colors for components | `design-tokens` |
+| Composing layout structure | `design-rules` |
+| Composing shadcn components for a screen | `design-components` |
+| Configuring RLS at client level | `supabase` |
+| Creating cards, panels, or containers | `design-rules` |
+| Creating database relations | `drizzle` |
+| Creating database schemas | `drizzle` |
+| Creating feature components | `design-components` |
+| Creating navigation or layout components | `design-components` |
+| Defining auth-related database schemas or RLS policies | `drizzle` |
+| Defining spacing or border radius values | `design-tokens` |
+| Defining table columns and types | `drizzle` |
+| Implementing auth flows | `supabase` |
+| Implementing pgvector/embeddings | `drizzle` |
+| Modifying globals.css or @theme tokens | `design-tokens` |
+| Running migrations | `drizzle` |
+| Setting typography font families or weights | `design-tokens` |
+| Setting up Supabase SSR cookies | `supabase` |
+| Styling component visual hierarchy | `design-rules` |
+| Using Zustand stores | `zustand-5` |
+| Using captureException or captureActionError | `sentry` |
+| Using getUser or getSession | `supabase` |
+| Working with Supabase clients | `supabase` |
+| Working with Tailwind classes | `tailwind-4` |
+| Working with error boundaries | `sentry` |
+| Writing Playwright E2E tests | `playwright` |
+| Writing React components | `react-19` |
+| Writing TypeScript types/interfaces | `typescript` |
+| Writing database queries | `drizzle` |
+
+---
+
+## Rules
+
+1. **Feature-based structure**: Each feature module lives in `features/{module}/` with `actions.ts`, `queries.ts`, `schemas.ts`, `types.ts`, `components/`, and `hooks/`.
+2. **Server Actions are thin wrappers**: Validate with Zod, get authenticated client, call service, return `ActionResult<T>`. No business logic here.
+3. **Server Components first**: Use Client Components (`"use client"`) only when interactivity is required (forms, event handlers, hooks).
+4. **Path aliases**: Use `@/` to import from within this workspace (e.g., `@/features/auth/actions`).
+5. **Package imports**: Use workspace aliases (`@enterprise/ui`, `@enterprise/core`, `@enterprise/contracts`).
+6. **No default exports**: Except Next.js pages (`page.tsx`), layouts (`layout.tsx`), and error boundaries (`error.tsx`).
+7. **E2E tests**: Every feature with dashboard pages MUST have Playwright E2E tests in `e2e/{feature}/`.
+
+## Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `app/` | Next.js App Router pages, layouts, and route handlers |
+| `features/` | Feature modules (actions, queries, components, hooks) |
+| `components/` | Shared app-level components (not feature-specific) |
+| `lib/` | App-level utilities (Sentry helpers, shared hooks) |
+| `e2e/` | Playwright E2E test suites |
+| `test-utils/` | Shared test utilities and helpers |
+
+## Design Reference
+
+Before implementing ANY UI component or page, follow this workflow:
+
+1. **Check existing UI primitives and tokens** — Inspect `packages/ui/src/components/` and `packages/ui/src/styles/globals.css` before creating new UI.
+2. **Check existing screens or generate a reference** — If a Stitch project exists, query its MCP for relevant reference screens. Otherwise, implement using existing component patterns.
+3. **Implement following the design** — Use tokens from `globals.css`, follow existing tonal layering and spacing patterns, use `@enterprise/ui` primitives consistently.
+
+Design references are DIRECTION, not pixel-perfect. The source of truth is the existing `@enterprise/ui` package plus the local CSS token definitions.
+
+## E2E Test Rules
+
+- Every feature that adds dashboard pages MUST include Playwright E2E tests
+- Tests cover: CRUD happy paths + critical edge cases (auth, validation, error states)
+- Use Page Object Model pattern (see `playwright` skill)
+- Auth helper in `e2e/helpers/auth.ts` for login flow reuse
+- Test files: `e2e/{feature}/{feature}.spec.ts`
+
+### SDD Task Generation Rule
+When `sdd-tasks` generates a task breakdown for a feature with UI pages, it MUST include:
+- A testing phase with E2E test tasks for every user-facing flow
+- Unit test tasks for contracts, utilities, and business logic


### PR DESCRIPTION
## Summary

- Root AGENTS.md reduced from 243 to 158 lines by applying Root=POLICY / Children=PROCEDURE principle
- Added Workspace AGENTS.md navigation table for agent discoverability across workspaces
- Fixed 3 CRITICALs from adversarial dual-judge review: skill metadata gaps, wrong skill mappings, CLAUDE.md drift

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Reduced to policy-only: removed Service Layer detail, Supabase Contracts, Design Reference, E2E rules (delegated to children). Added Workspace navigation table. Consolidated dual skill tables into one auto-generated |
| `ui/AGENTS.md` | **Created** — received Design Reference, E2E Test Rules, full auto-invoke table (28 entries) |
| `packages/AGENTS.md` | Removed duplicate auto-invoke table, added `radix-ui` to deps, added step 6 (create AGENTS.md for new packages) |
| `packages/core/AGENTS.md` | Added function-based service mandate, Sentry prohibition with rationale, supabase/sentry/postgres skills in auto-invoke |
| `packages/db/AGENTS.md` | Updated structure tree (added `resources.ts`), fixed migration step for multi-file schemas |
| `packages/contracts/AGENTS.md` | Standardized preamble, multi-file org pattern, updated Zod 3.24 note |
| `skills/supabase/SKILL.md` | Added `metadata.scope` and `metadata.auto_invoke` — was invisible to sync.sh |
| `skills/sentry/SKILL.md` | Added `metadata.scope` and `metadata.auto_invoke` — was invisible to sync.sh |
| `skills/supabase-postgres-best-practices/SKILL.md` | Added `metadata.scope` and `metadata.auto_invoke` — was invisible to sync.sh |
| `skills/drizzle/SKILL.md` | Renamed "Working with Supabase auth" → "Defining auth-related database schemas or RLS policies", removed `packages` from scope |
| `skills/setup.sh` | Changed `copy_agents_md` → `symlink_agents_md` (CLAUDE.md = symlink to AGENTS.md, zero drift) |
| `skills/skill-sync/assets/sync.sh` | Added fallback: appends Auto-invoke section when missing instead of just warning |

## Motivation

Adversarial dual-judge review (Judgment Day protocol) found that:
1. **3 critical skills** (supabase, sentry, supabase-postgres-best-practices) had no `metadata.scope`/`auto_invoke` → invisible to sync.sh → `packages/core` only had drizzle entries despite being the Supabase integration hub
2. **"Working with Supabase auth" → `drizzle`** was wrong in 4 files — agents editing auth flows would load schema patterns instead of Supabase auth patterns
3. **CLAUDE.md files** were stale copies that never received fixes — symlinks eliminate drift permanently
4. **Root AGENTS.md** mixed policy with procedure, duplicating content already in child AGENTS.md files