### PR TITLE
docs: add AGENTS.md spec, contributing guide, and enterprise skills (commit, PR, docs)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+## Summary
+
+<!-- 1-3 bullet points: WHAT changed and WHY -->
+
+-
+
+## Changes
+
+<!-- Table of key files changed and what was done -->
+
+| File | Change |
+|------|--------|
+| `path/to/file` | What changed |
+
+## Verification
+
+<!-- Check all that apply -->
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] E2E tests pass (if feature has UI pages)
+- [ ] No `any` types introduced
+- [ ] No secrets in committed code
+
+<!-- Add workspace-specific sections below if applicable -->
+
+<details>
+<summary><b>UI Changes</b> (expand if applicable)</summary>
+
+- [ ] All UI states handled (loading, error, empty)
+- [ ] Responsive: tested at mobile (< 640px) and desktop (> 1024px)
+- [ ] E2E tests added/updated for new pages
+- [ ] Screenshots attached for visual changes
+
+</details>
+
+<details>
+<summary><b>Database Changes</b> (expand if applicable)</summary>
+
+- [ ] Migration is incremental (not a full dump)
+- [ ] RLS policies present for tenant-scoped tables
+- [ ] `supabase db reset` runs successfully
+
+</details>
+
+<details>
+<summary><b>Service Layer Changes</b> (expand if applicable)</summary>
+
+- [ ] Service uses function-based pattern
+- [ ] Unit tests with mocked Supabase client
+- [ ] No `"use server"` or Next.js APIs in this package
+
+</details>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,8 @@ Use these skills for detailed patterns on-demand. The runtime resolves them auto
 | `design-components` | shadcn/ui composition patterns |
 | `design-rules` | Glass Rule, Surface Hierarchy, motion |
 | `design-tokens` | Color system, typography, spacing |
+| `enterprise-commit` | Conventional commits with project scopes |
+| `enterprise-pr` | PR creation workflow and template |
 | `skill-creator` | Create new AI agent skills |
 | `skill-sync` | Sync skill metadata to AGENTS.md tables |
 
@@ -128,6 +130,9 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Adding error tracking to Server Actions | `sentry` |
 | After creating/modifying a skill | `skill-sync` |
 | App Router / Server Actions | `nextjs-15` |
+| Committing changes | `enterprise-commit` |
+| Creating a git commit | `enterprise-commit` |
+| Creating a pull request | `enterprise-pr` |
 | Configuring RLS at client level | `supabase` |
 | Configuring database connections | `supabase-postgres-best-practices` |
 | Creating new skills | `skill-creator` |
@@ -190,7 +195,10 @@ See `ui/AGENTS.md` for E2E test rules and conventions.
 - [ ] CUD operations use `AuditService.log()` or an equivalent audit abstraction
 - [ ] App URL uses `getAppUrl()`, NOT direct env var access
 
-## Commit Conventions
+## Commit & PR Conventions
 
-Use conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`
+Use conventional commits: `type(scope): description`. See the `enterprise-commit` skill for scopes, decision trees, and examples.
+
+PR template at `.github/PULL_REQUEST_TEMPLATE.md`. See the `enterprise-pr` skill for the full workflow.
+
 Never add AI attribution or Co-Authored-By headers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Use these skills for detailed patterns on-demand. The runtime resolves them auto
 | `design-rules` | Glass Rule, Surface Hierarchy, motion |
 | `design-tokens` | Color system, typography, spacing |
 | `enterprise-commit` | Conventional commits with project scopes |
+| `enterprise-docs` | Documentation style guide and writing standards |
 | `enterprise-pr` | PR creation workflow and template |
 | `skill-creator` | Create new AI agent skills |
 | `skill-sync` | Sync skill metadata to AGENTS.md tables |
@@ -133,6 +134,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Committing changes | `enterprise-commit` |
 | Creating a git commit | `enterprise-commit` |
 | Creating a pull request | `enterprise-pr` |
+| Writing documentation | `enterprise-docs` |
 | Configuring RLS at client level | `supabase` |
 | Configuring database connections | `supabase-postgres-best-practices` |
 | Creating new skills | `skill-creator` |

--- a/docs/developer-guide/agents-md-spec.mdx
+++ b/docs/developer-guide/agents-md-spec.mdx
@@ -1,0 +1,280 @@
+---
+title: "AGENTS.md Specification"
+description: "Formal pattern specification for writing AGENTS.md files — the constitutional documents that guide AI coding assistants in each workspace."
+owner: "Engineering"
+lastUpdated: "2026-05-06"
+---
+
+# AGENTS.md Specification
+
+This document defines the formal pattern for writing `AGENTS.md` files in the Enterprise Platform. Any new workspace MUST follow this specification to ensure AI agents receive consistent, actionable context.
+
+## Purpose
+
+`AGENTS.md` files are the **constitutional documents** of each workspace. They tell AI coding assistants:
+- What this workspace does
+- What rules are non-negotiable
+- Where to put new code
+- What correct code looks like
+- How to verify their work
+
+---
+
+## Hierarchy
+
+```mermaid
+graph TD
+    ROOT["AGENTS.md (root)<br/>Constitutional law"] --> PKG["packages/AGENTS.md<br/>Package boundary hub"]
+    ROOT --> UI["ui/AGENTS.md<br/>App workspace"]
+    PKG --> CORE["packages/core/AGENTS.md"]
+    PKG --> DB["packages/db/AGENTS.md"]
+    PKG --> UIPKG["packages/ui/AGENTS.md"]
+    PKG --> CONTRACTS["packages/contracts/AGENTS.md"]
+
+    style ROOT fill:#1e3a5f,stroke:#4a9eff,color:#fff
+    style PKG fill:#5c4d1a,stroke:#ffd700,color:#fff
+```
+
+**Resolution rules:**
+- Root `AGENTS.md` defines rules that ALL workspaces follow
+- Workspace `AGENTS.md` files **specialize** but NEVER contradict the root
+- If a conflict exists, the root wins
+- The nearest `AGENTS.md` in the file path applies (directory proximity)
+
+---
+
+## Required Sections (in order)
+
+Every workspace `AGENTS.md` MUST include these sections in this exact order:
+
+| # | Section | Purpose | Format |
+|---|---------|---------|--------|
+| 1 | **Title + Purpose** | What this workspace is | 1-2 sentences |
+| 2 | **Auto-invoke Skills** | When to load which skill | Table: Action → Skill |
+| 3 | **Critical Rules** | Non-negotiable constraints | ALWAYS/NEVER or ✅/❌ format |
+| 4 | **Decision Trees** | Where to put code | ASCII tree with branches |
+| 5 | **Patterns** | What correct code looks like | Code blocks (2-4 examples) |
+| 6 | **Rules** | Governance and conventions | Numbered list |
+| 7 | **Project Structure** | File/folder map | Annotated ASCII tree |
+| 8 | **Commands** | How to operate this workspace | Code block with scripts |
+| 9 | **QA Checklist** | Pre-commit verification | Checkbox list |
+
+---
+
+## Section Specifications
+
+### 1. Title + Purpose
+
+```markdown
+# @enterprise/{name} — Agent Instructions
+
+## Purpose
+
+{One to two sentences explaining what this workspace does and its role in the monorepo.}
+```
+
+### 2. Auto-invoke Skills
+
+```markdown
+### Auto-invoke Skills
+
+When performing these actions, ALWAYS invoke the corresponding skill FIRST:
+
+| Action | Skill |
+|--------|-------|
+| {Specific action description} | `{skill-name}` |
+```
+
+- Actions should be specific and trigger-oriented
+- Sort alphabetically
+- Only include skills relevant to THIS workspace
+
+### 3. Critical Rules — Non-Negotiable
+
+```markdown
+## Critical Rules — Non-Negotiable
+
+### {Category}
+
+- ALWAYS: {what to do} — `{code example if short}`
+- NEVER: {what not to do} — {why}
+```
+
+**Format options:**
+- `ALWAYS` / `NEVER` — for behavioral rules
+- `✅` / `❌` — for scope rules (what belongs/doesn't belong here)
+
+**Rules for this section:**
+- Binary only — no "sometimes" or "prefer"
+- Include inline code when the rule is about syntax
+- Keep to 3-5 categories max (React, Types, Styling, etc.)
+- This section is the **fallback** when skills don't load — include the most critical patterns
+
+### 4. Decision Trees
+
+```markdown
+## Decision Trees
+
+### {Decision Name}
+
+\`\`\`
+{Question}?
+├── {Condition A} → {Action A}
+├── {Condition B} → {Action B}
+└── {Condition C}
+    └── {Sub-condition} → {Action C}
+\`\`\`
+```
+
+**Rules:**
+- Answer the question "where does this go?" algorithmically
+- Use ASCII tree characters: `├──`, `└──`, `│`
+- Each leaf ends with a concrete location (file path or package)
+- Maximum 2 levels of nesting
+
+### 5. Patterns
+
+```markdown
+## Patterns
+
+### {Pattern Name}
+
+\`\`\`typescript
+// Code example — minimal, correct, uses real project imports
+\`\`\`
+```
+
+**Rules:**
+- Include 2-4 patterns (the most common operations in this workspace)
+- Use real imports from the project (`@enterprise/contracts`, etc.)
+- Keep examples minimal — show the pattern, not a full implementation
+- These are **fallback patterns** when the relevant skill doesn't load
+
+### 6. Rules
+
+```markdown
+## Rules
+
+1. **{Rule name}**: {Description with enough context to be unambiguous}
+2. ...
+```
+
+**Rules:**
+- Numbered, not bulleted
+- Bold the rule name
+- Keep to 5-8 rules max
+- These are governance rules, not code patterns (those go in section 3 and 5)
+
+### 7. Project Structure
+
+```markdown
+## Project Structure
+
+\`\`\`
+packages/{name}/
+├── package.json
+├── tsconfig.json
+├── AGENTS.md
+└── src/
+    ├── index.ts          # {annotation}
+    ├── {dir}/
+    │   ├── {file}.ts     # {annotation}
+    │   └── ...
+    └── ...
+\`\`\`
+```
+
+**Rules:**
+- Show 2 levels deep minimum
+- Annotate key files with `# {purpose}` comments
+- Mark generated files with `# ⚠️ GENERATED — do not edit`
+- Include enough structure that an agent knows where to create new files
+
+### 8. Commands
+
+```markdown
+## Commands
+
+\`\`\`bash
+pnpm --filter @enterprise/{name} typecheck    # TypeScript compilation
+pnpm --filter @enterprise/{name} test         # Unit tests
+pnpm --filter @enterprise/{name} lint         # Biome lint
+\`\`\`
+```
+
+**Rules:**
+- Show the exact commands an agent would run
+- Include `--filter` syntax for monorepo packages
+- Annotate each command with `# purpose`
+
+### 9. QA Checklist
+
+```markdown
+## QA Checklist (before commit)
+
+- [ ] {Workspace-specific check}
+- [ ] {Another check}
+```
+
+**Rules:**
+- Only include checks SPECIFIC to this workspace
+- Do NOT repeat checks from the root `AGENTS.md` QA Checklist
+- Keep to 5-8 items
+- Each item should be verifiable (not vague)
+
+---
+
+## Root AGENTS.md — Additional Sections
+
+The root `AGENTS.md` has extra sections not in workspace files:
+
+| Section | Purpose |
+|---------|---------|
+| **How to Use This Guide** | Explains the hierarchy (root vs workspace) |
+| **Tech Stack** | Full technology table |
+| **Monorepo Structure** | Workspace map with aliases |
+| **Workspace AGENTS.md** | Table linking all workspace docs |
+| **Dependency Direction** | ASCII graph of allowed imports |
+| **Architecture Principles** | Numbered doctrine (7 principles) |
+| **Service Layer Pattern** | The #1 enforced architectural pattern |
+| **Available Skills** | Catalog split into Generic / Platform-Specific |
+| **Language Policy** | English-only enforcement |
+| **Code Conventions** | Naming, exports, imports |
+| **Testing Policy** | What must be tested and how |
+| **QA Checklist** | Cross-workspace checks (15 items) |
+| **Commit Conventions** | Conventional commits format |
+
+---
+
+## Anti-Patterns
+
+| ❌ Don't | ✅ Do Instead |
+|----------|--------------|
+| Write rules as prose paragraphs | Use ALWAYS/NEVER or ✅/❌ binary format |
+| Describe placement in sentences | Use decision trees with ASCII branches |
+| Reference skills without inline fallback | Include 2-4 critical patterns inline |
+| Repeat root rules in workspace files | Only add workspace-SPECIFIC rules |
+| Write vague QA items ("code is clean") | Write verifiable items ("No `var()` in className") |
+| Show full implementations as patterns | Show minimal pattern — just enough to understand |
+| List 20+ rules in one section | Keep to 5-8 per section; split into categories |
+| Use `cd` commands for monorepo ops | Use `pnpm --filter @enterprise/{name}` |
+
+---
+
+## When to Create a New AGENTS.md
+
+Create a new workspace `AGENTS.md` when:
+
+1. You add a new package to `packages/`
+2. The package has its own conventions distinct from existing workspaces
+3. An AI agent working in that directory needs context not available in the root
+
+**Steps:**
+1. Create `packages/{name}/AGENTS.md` following this spec
+2. Add the workspace to the root `AGENTS.md` → "Workspace AGENTS.md" table
+3. Add the scope to `skills/skill-sync/assets/sync.sh:get_agents_path()` for auto-invoke sync
+4. Run `pnpm skills:sync` to populate the auto-invoke table
+
+---
+
+*Last updated: 2026-05-06*

--- a/docs/developer-guide/contributing-docs.mdx
+++ b/docs/developer-guide/contributing-docs.mdx
@@ -1,0 +1,160 @@
+---
+title: "Contributing to Documentation"
+description: "How to add or modify documentation in the Enterprise Platform, including structure, conventions, and AI-driven documentation patterns."
+owner: "Engineering"
+lastUpdated: "2026-05-06"
+---
+
+# Contributing to Documentation
+
+This guide explains how documentation is organized, how to contribute new pages, and how to ensure your docs are AI-agent friendly.
+
+## Documentation Structure
+
+The Enterprise Platform documentation is organized into these sections:
+
+```
+docs/
+├── developer-guide/       # How to build with and extend the platform
+│   ├── getting-started    # Clone, install, run
+│   ├── architecture       # System design overview
+│   ├── conventions        # Code conventions (TS, Zod, React, etc.)
+│   ├── ai-skills          # AI Skills system setup and usage
+│   ├── testing-strategy   # Unit + E2E testing approach
+│   ├── theme-system       # Design token pipeline
+│   ├── supabase-setup     # Database and auth configuration
+│   ├── environment-guide  # Environment variables reference
+│   └── ...
+├── architecture/          # Deep-dive architecture docs (ADR-adjacent)
+│   ├── overview           # High-level system map
+│   ├── multi-tenant       # Tenant isolation via RLS
+│   ├── service-layer      # Service layer patterns
+│   ├── request-flow       # Request lifecycle
+│   └── extension-patterns # How to extend the platform
+└── adr/                   # Architecture Decision Records
+    ├── 001-platform-architecture
+    ├── 002-rls-helper-functions
+    ├── 003-service-layer
+    └── 004-package-dependencies
+```
+
+| Section | Audience | Content Type |
+|---------|----------|--------------|
+| `developer-guide/` | New contributors, daily development | How-to guides, setup, conventions |
+| `architecture/` | Technical leads, architects | Design decisions, data flow, patterns |
+| `adr/` | Future selves, new team members | Historical decision records |
+
+## AI-Driven Documentation
+
+This project uses an **AGENTS.md system** to guide AI coding assistants. Documentation contributes to this system in two ways:
+
+1. **Skills reference docs** — Skills in `skills/` may point to `docs/` pages as their single source of truth
+2. **AGENTS.md files** — Each workspace has an `AGENTS.md` that AI agents read for context
+
+When writing documentation, consider: "Would an AI agent benefit from knowing this?" If yes, ensure the relevant `AGENTS.md` or skill references the doc.
+
+See [AI Skills](./ai-skills.mdx) for the full system overview.
+
+---
+
+## Page Format
+
+Every documentation page uses `.mdx` format with required frontmatter:
+
+```mdx
+---
+title: "Page Title"
+description: "One-sentence description of what this page covers."
+owner: "Engineering"
+lastUpdated: "2026-05-06"
+---
+
+# Page Title
+
+## Purpose
+
+What this document covers and why it exists.
+
+## Scope
+
+- Included: what topics this page addresses
+- Excluded: what topics are covered elsewhere (with links)
+
+---
+
+## Content sections...
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | ✅ | Page title (appears in navigation) |
+| `description` | ✅ | One-sentence summary |
+| `owner` | ✅ | Team or person responsible |
+| `lastUpdated` | ✅ | ISO date of last significant update |
+
+---
+
+## Writing Conventions
+
+### Language
+
+- ALL documentation MUST be in English (matches project Language Policy)
+- Use present tense and active voice
+- Be direct — avoid "you might want to" or "it's possible to"
+
+### Structure
+
+- Start with **Purpose** + **Scope** (what's in, what's out)
+- Use `---` horizontal rules to separate major sections
+- Prefer tables over bullet lists when comparing options
+- Use code blocks with language annotation for all code examples
+- Keep headings action-oriented: "Adding a New Service" not "New Services"
+
+### Code Examples
+
+- Always show the **correct** pattern first, then the **wrong** pattern
+- Annotate with `// ✅ Correct` and `// ❌ Wrong`
+- Keep examples minimal — show the pattern, not a full implementation
+- Use real project paths and imports (e.g., `@enterprise/contracts`, not `@acme/utils`)
+
+### Cross-References
+
+- Link to other docs using relative paths: `[Architecture](./architecture.mdx)`
+- Reference AGENTS.md when the doc is normative: "This is enforced in `packages/core/AGENTS.md`"
+- Never duplicate content — link to the source of truth instead
+
+---
+
+## Adding a New Page
+
+1. Create `docs/{section}/{page-name}.mdx` with the frontmatter template above
+2. Write content following the conventions in this doc
+3. If the page documents a convention that AI agents should follow, update the relevant `AGENTS.md` or skill to reference it
+4. Submit a PR with the `docs:` commit prefix
+
+---
+
+## Modifying Existing Pages
+
+1. Update the content
+2. Update the `lastUpdated` field in frontmatter
+3. If the change affects AI agent behavior (new rules, changed patterns), also update the relevant `AGENTS.md`
+4. Submit a PR
+
+---
+
+## Quick Reference
+
+| Goal | Action |
+|------|--------|
+| Add a developer guide | Create `docs/developer-guide/{name}.mdx` |
+| Add an architecture doc | Create `docs/architecture/{name}.md` |
+| Record an architecture decision | Create `docs/adr/{NNN}-{description}.md` |
+| Update AI agent rules | Edit the relevant workspace `AGENTS.md` |
+| Create a new AI skill | Use the `skill-creator` skill |
+
+---
+
+*Last updated: 2026-05-06*

--- a/skills/enterprise-commit/SKILL.md
+++ b/skills/enterprise-commit/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: enterprise-commit
+description: >
+  Creates professional git commits following conventional-commits format with project-specific scopes.
+  Trigger: When creating commits, after completing code changes, when user asks to commit.
+license: Apache-2.0
+metadata:
+  author: enterprise-platform
+  version: "1.0"
+  scope: [root, ui, packages/core, packages/db, packages/ui, packages/contracts]
+  auto_invoke:
+    - "Creating a git commit"
+    - "Committing changes"
+---
+
+## Critical Rules
+
+- ALWAYS use conventional-commits format: `type(scope): description`
+- ALWAYS keep the first line under 72 characters
+- ALWAYS ask for user confirmation before committing
+- ALWAYS structure commits as deliverable work units (not file-type batches)
+- NEVER be overly specific (avoid counts like "6 files", "3 components")
+- NEVER include implementation details in the title
+- NEVER use `-n` flag unless user explicitly requests it
+- NEVER use `git push --force` or `git push -f` (destructive, rewrites history)
+- NEVER add "Co-Authored-By" or AI attribution headers
+- NEVER proactively offer to commit — wait for explicit user request
+
+---
+
+## Commit Format
+
+```
+type(scope): concise description
+
+- Key change 1
+- Key change 2
+- Key change 3
+```
+
+### Types
+
+| Type | Use When |
+|------|----------|
+| `feat` | New feature or functionality |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `chore` | Maintenance, dependencies, configs |
+| `refactor` | Code change without feature/fix |
+| `test` | Adding or updating tests |
+| `perf` | Performance improvement |
+| `style` | Formatting, no code change |
+
+### Scopes (Project-Specific)
+
+| Scope | When | Examples |
+|-------|------|----------|
+| `ui` | Changes in `ui/` (app, features, pages) | `feat(ui): add resource list page` |
+| `core` | Changes in `packages/core/` (services, clients) | `feat(core): add resource service` |
+| `db` | Changes in `packages/db/` (schema, migrations) | `feat(db): add resources table with RLS` |
+| `contracts` | Changes in `packages/contracts/` (schemas, DTOs) | `feat(contracts): add resource schemas` |
+| `ui-pkg` | Changes in `packages/ui/` (components, tokens) | `feat(ui-pkg): add data table component` |
+| `e2e` | Changes in `ui/e2e/` (Playwright tests) | `test(e2e): add resource CRUD tests` |
+| `skills` | Changes in `skills/` | `docs(skills): add commit conventions skill` |
+| `ci` | Changes in `.github/` | `ci: add PR template` |
+| `deps` | Dependency updates | `chore(deps): bump next to 15.3` |
+| *omit* | Multiple scopes or root-level changes | `docs: update AGENTS.md pattern` |
+
+### Scope Selection Rule
+
+```
+Changes in ONE workspace?
+├── Yes → Use that workspace scope
+└── No (multiple workspaces)
+    ├── Changes are related (same feature) → Omit scope
+    └── Changes are unrelated → Split into separate commits
+```
+
+---
+
+## Good vs Bad Examples
+
+### Title Line
+
+```
+# ✅ GOOD — Concise and clear
+feat(core): add resource service with CRUD operations
+fix(ui): resolve dashboard loading state flash
+refactor(db): normalize audit log schema
+docs: update AGENTS.md workspace specifications
+test(e2e): add auth flow E2E coverage
+
+# ❌ BAD — Too specific, too long, or missing context
+feat(core): add resource service with create, read, update, delete, list, and search operations
+fix(ui): fix the bug in dashboard component on line 45 of resource-list.tsx
+chore: update stuff
+feat: add things
+```
+
+### Body (Bullet Points)
+
+```
+# ✅ GOOD — High-level, outcome-focused
+- Add CRUD operations with tenant isolation via RLS
+- Include audit logging for create/update/delete
+- Wire service into Server Actions with Zod validation
+
+# ❌ BAD — Too detailed, file-focused
+- Modified resource-service.ts lines 45-120
+- Added 3 new functions and 2 interfaces
+- Updated index.ts to export new service
+```
+
+---
+
+## Decision Tree
+
+```
+Single file changed?
+├── Yes → Title only, may omit body
+└── No → Include body with 2-5 bullet points
+
+Multiple scopes affected?
+├── Same feature across workspaces → Omit scope
+├── Unrelated changes → Split into separate commits
+└── Single workspace → Include scope
+
+What type?
+├── New user-facing behavior → feat
+├── Bug that users experience → fix
+├── Internal restructure, no behavior change → refactor
+├── Only tests added/changed → test
+├── Only docs/comments → docs
+└── Dependencies, CI, configs → chore
+```
+
+---
+
+## Work Unit Rules
+
+Commits represent **deliverable work units**, not file-type batches:
+
+| ❌ File-type batches | ✅ Work-unit commits |
+|---------------------|---------------------|
+| `add schemas` | `feat(contracts): add resource validation schemas` |
+| `add service` | `feat(core): add resource service with tenant isolation` |
+| `add tests` | Tests included WITH the feature commit |
+| `update docs` | Docs included WITH the user-facing change |
+
+**Each commit should:**
+- Have one clear purpose
+- Leave the repo in a working state
+- Include tests/docs for that unit when relevant
+- Be a candidate for its own PR if the change grows
+
+---
+
+## Workflow
+
+1. **Analyze changes**
+   ```bash
+   git status
+   git diff --stat HEAD
+   git log -3 --oneline  # Check recent commit style
+   ```
+
+2. **Draft commit message**
+   - Choose type from table above
+   - Determine scope (single workspace → use it; multiple → omit)
+   - Write title < 72 chars, outcome-focused
+   - Add 2-5 bullet points for multi-file changes
+
+3. **Present to user for confirmation**
+   - Show files to be committed
+   - Show proposed message
+   - Wait for explicit "yes" / confirmation
+
+4. **Execute commit**
+   ```bash
+   git add <files>
+   git commit -m "type(scope): description
+
+   - Change 1
+   - Change 2"
+   ```
+
+---
+
+## Commands
+
+```bash
+# Check state before committing
+git status
+git diff --stat HEAD
+git diff --cached --stat
+
+# Standard commit (single line)
+git add <files>
+git commit -m "type(scope): description"
+
+# Multi-line commit with body
+git commit -m "type(scope): description
+
+- Change 1
+- Change 2
+- Change 3"
+
+# Check recent commit style for consistency
+git log --oneline -5
+```

--- a/skills/enterprise-docs/SKILL.md
+++ b/skills/enterprise-docs/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: enterprise-docs
+description: >
+  Documentation style guide and writing standards for the Enterprise Platform.
+  Trigger: When writing documentation, guides, READMEs, or MDX pages.
+license: Apache-2.0
+metadata:
+  author: enterprise-platform
+  version: "1.0"
+  scope: [root]
+  auto_invoke:
+    - "Writing documentation"
+    - "Creating MDX pages"
+    - "Adding developer guides"
+---
+
+## Critical Rules
+
+- ALWAYS write in English (project Language Policy — no exceptions)
+- ALWAYS include frontmatter with `title`, `description`, `owner`, `lastUpdated`
+- ALWAYS start pages with Purpose + Scope sections
+- ALWAYS use `---` horizontal rules between major sections
+- ALWAYS show correct pattern first (✅), then wrong pattern (❌) in code examples
+- ALWAYS define acronyms on first use: "Row-Level Security (RLS)"
+- NEVER duplicate content — link to the source of truth instead
+- NEVER use "you might want to" or "it's possible to" — be direct
+- NEVER add emojis unless explicitly requested
+
+---
+
+## Page Format
+
+```mdx
+---
+title: "Page Title"
+description: "One-sentence description of what this page covers."
+owner: "Engineering"
+lastUpdated: "2026-05-07"
+---
+
+# Page Title
+
+## Purpose
+
+What this document covers and why it exists.
+
+## Scope
+
+- Included: what topics this page addresses
+- Excluded: what topics are covered elsewhere (with links)
+
+---
+
+## Content sections...
+
+---
+
+*Last updated: 2026-05-07*
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | ✅ | Page title — Sentence case, not Title Case |
+| `description` | ✅ | One-sentence summary for navigation/search |
+| `owner` | ✅ | Responsible team or person |
+| `lastUpdated` | ✅ | ISO date of last significant update |
+
+---
+
+## Writing Conventions
+
+### Voice and Tone
+
+- Use **present tense** and **active voice**: "The service validates input" not "Input will be validated"
+- Be **direct** and **imperative**: "Run `pnpm test`" not "You should run..."
+- Use **second person** ("you/your") when addressing the reader
+- Use **inclusive language**: avoid gendered pronouns, use "they/them" for generic references
+- Avoid militaristic language: "address the issue" not "fight the bug"
+
+### Capitalization
+
+- **Headings**: Sentence case — "How to configure auth" not "How to Configure Auth"
+- **Code references**: Keep exact casing — `getUser()`, `ActionResult<T>`, `@enterprise/core`
+- **Proper nouns**: Capitalize product names — Supabase, Next.js, Tailwind CSS, Drizzle
+
+### Technical Terminology
+
+- Define acronyms on first use: "Row-Level Security (RLS)" then "RLS" thereafter
+- Prefer verbal constructions: "The migration was generated" not "The generation of the migration"
+- Use project-specific terms consistently:
+  | Term | Meaning |
+  |------|---------|
+  | Server Action | Next.js server function in `features/*/actions.ts` |
+  | Service | Business logic function in `packages/core/src/services/` |
+  | Contract | Zod schema + inferred type in `@enterprise/contracts` |
+  | Workspace | A package or app within the monorepo |
+
+---
+
+## Structure Patterns
+
+### Prefer Tables Over Bullets for Comparisons
+
+```markdown
+<!-- ✅ Clear comparison -->
+| Pattern | When to Use |
+|---------|-------------|
+| Server Component | Data fetching, no interactivity |
+| Client Component | Forms, event handlers, hooks |
+
+<!-- ❌ Hard to scan -->
+- Server Components are for data fetching with no interactivity
+- Client Components are for forms, event handlers, and hooks
+```
+
+### Use Decision Trees for Placement Questions
+
+```markdown
+<!-- ✅ Algorithmic -->
+Is it business logic?
+├── Yes → packages/core/src/services/
+└── No → ...
+
+<!-- ❌ Prose -->
+If the code contains business logic, it should go in the services directory
+within the core package.
+```
+
+### Callouts / Admonitions
+
+Use blockquotes with bold labels for emphasis:
+
+```markdown
+> **Warning**: Disabling RLS exposes all tenant data to any authenticated user.
+
+> **Note**: This pattern requires the `supabase` skill to be loaded first.
+
+> **Important**: Never import from `@enterprise/web` in any package.
+```
+
+---
+
+## Code Examples
+
+### Annotation Standard
+
+```typescript
+// ✅ Correct — function-based service with DI
+export async function createResource(
+  client: SupabaseClient,
+  input: CreateResourceDto,
+): Promise<ServiceResult<Resource>> {
+  // ...
+}
+
+// ❌ Wrong — class-based, creates own client
+class ResourceService {
+  private client = createClient();
+  async create(input: CreateResourceDto) { /* ... */ }
+}
+```
+
+### Rules for Examples
+
+- Show the **correct** pattern FIRST, then the wrong one
+- Keep examples **minimal** — pattern only, not full implementation
+- Use **real project imports** (`@enterprise/contracts`, `@enterprise/core`)
+- Annotate with `// ✅ Correct` and `// ❌ Wrong` on the first line
+- Include the **language annotation** in code fences: ` ```typescript `
+
+---
+
+## Cross-References
+
+- Link to other docs using **relative paths**: `[Architecture](./architecture.mdx)`
+- Reference AGENTS.md when the doc is normative: "Enforced in `packages/core/AGENTS.md`"
+- When a skill covers the topic in depth, reference the skill: "See `drizzle` skill for patterns"
+- NEVER duplicate content across pages — link to the source
+
+---
+
+## Decision Trees
+
+### Where Does a New Doc Go?
+
+```
+Is it a how-to for daily development?
+├── Yes → docs/developer-guide/{topic}.mdx
+└── No
+    ├── Is it a deep-dive on system design?
+    │   └── Yes → docs/architecture/{topic}.md
+    ├── Is it a decision record (why we chose X)?
+    │   └── Yes → docs/adr/{NNN}-{description}.md
+    └── Is it a product requirement or RFC?
+        └── Yes → docs/ root level (prd-*.md, rfc-*.md)
+```
+
+### Should This Also Update AGENTS.md?
+
+```
+Does it define a rule that AI agents should follow?
+├── Yes → Update the relevant workspace AGENTS.md or skill
+└── No
+    ├── Does a skill reference this doc?
+    │   └── Yes → Keep the doc as source of truth, skill points to it
+    └── No → Doc is standalone, no AGENTS.md update needed
+```
+
+---
+
+## AI-Driven Documentation
+
+When writing documentation, consider: "Would an AI agent benefit from knowing this?"
+
+- If YES → ensure the relevant `AGENTS.md` or skill references the doc
+- If the doc defines conventions that agents must follow → the doc is the source of truth, the skill or AGENTS.md points to it
+- Skills use `references/` directories to point to docs — never duplicate doc content in a skill
+
+---
+
+## Commands
+
+```bash
+# Create a new developer guide page
+# (then fill with frontmatter template above)
+touch docs/developer-guide/{topic}.mdx
+
+# Create an ADR
+touch docs/adr/{NNN}-{description}.md
+
+# Verify frontmatter is valid (manual check)
+head -10 docs/developer-guide/{topic}.mdx
+```
+
+---
+
+## QA Checklist (before committing docs)
+
+- [ ] Frontmatter has all 4 required fields
+- [ ] Page starts with Purpose + Scope
+- [ ] Sections separated by `---` horizontal rules
+- [ ] Code examples use ✅/❌ annotation
+- [ ] Acronyms defined on first use
+- [ ] No duplicated content — links to source of truth
+- [ ] Cross-references use relative paths
+- [ ] `lastUpdated` field reflects today's date
+- [ ] If normative → relevant AGENTS.md or skill updated

--- a/skills/enterprise-pr/SKILL.md
+++ b/skills/enterprise-pr/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: enterprise-pr
+description: >
+  Creates Pull Requests for Enterprise Platform following the project template and conventions.
+  Trigger: When creating a pull request, opening a PR, or preparing changes for review.
+license: Apache-2.0
+metadata:
+  author: enterprise-platform
+  version: "1.0"
+  scope: [root]
+  auto_invoke:
+    - "Creating a pull request"
+    - "Opening a PR"
+    - "Preparing changes for review"
+---
+
+## Critical Rules
+
+- ALWAYS fill every section of the PR template (Context, Summary, Changes, Verification)
+- ALWAYS use conventional-commit format for PR title: `type(scope): description`
+- ALWAYS link related issues with `Closes #N`, `Fixes #N`, or `Resolves #N`
+- ALWAYS include workspace-specific checklist items when applicable
+- NEVER create a PR without running quality checks first (`pnpm typecheck && pnpm lint && pnpm test`)
+- NEVER push `--force` to main/master
+- NEVER include secrets, `.env` files, or credentials in the PR
+
+---
+
+## PR Creation Workflow
+
+```
+1. Ensure branch is up to date with main
+2. Run quality checks: pnpm typecheck && pnpm lint && pnpm test
+3. Review all commits: git log main..HEAD --oneline
+4. Review full diff: git diff main...HEAD --stat
+5. Fill PR template sections
+6. Create PR: gh pr create --title "type(scope): description" --body "..."
+7. Verify CI passes
+```
+
+---
+
+## Branch Naming
+
+```
+^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)\/[a-z0-9._-]+$
+```
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feat/{description}` | `feat/resource-crud` |
+| Bug fix | `fix/{description}` | `fix/auth-redirect-loop` |
+| Docs | `docs/{description}` | `docs/agents-md-spec` |
+| Refactor | `refactor/{description}` | `refactor/service-layer` |
+| Chore | `chore/{description}` | `chore/bump-dependencies` |
+
+---
+
+## PR Template
+
+The template lives at `.github/PULL_REQUEST_TEMPLATE.md`. Every PR body MUST contain:
+
+### Structure
+
+```markdown
+## Summary
+
+- {1-3 bullet points explaining WHAT and WHY}
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `path/to/file` | What changed |
+
+## Verification
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] {Workspace-specific checks}
+```
+
+---
+
+## Workspace-Specific Checks
+
+When a PR touches specific workspaces, add the relevant checklist:
+
+### UI Changes (`ui/`)
+
+```markdown
+### UI Verification
+- [ ] All UI states handled (loading, error, empty)
+- [ ] Responsive: tested at mobile (< 640px) and desktop (> 1024px)
+- [ ] E2E tests added/updated for new pages
+- [ ] Screenshots attached for visual changes
+```
+
+### Database Changes (`packages/db/`)
+
+```markdown
+### Database Verification
+- [ ] Migration is incremental (not a full dump)
+- [ ] RLS policies present for tenant-scoped tables
+- [ ] `supabase db reset` runs successfully
+```
+
+### Service Layer Changes (`packages/core/`)
+
+```markdown
+### Service Layer Verification
+- [ ] Service uses function-based pattern
+- [ ] Unit tests with mocked Supabase client
+- [ ] No `"use server"` or Next.js APIs in this package
+```
+
+### Contract Changes (`packages/contracts/`)
+
+```markdown
+### Contract Verification
+- [ ] Schemas have colocated type exports
+- [ ] No imports from other @enterprise/* packages
+- [ ] Tests cover validation edge cases
+```
+
+---
+
+## Title Conventions
+
+Same as commit conventions (conventional-commits):
+
+```
+feat(ui): add resource list page
+fix(core): resolve tenant isolation leak
+docs: add AGENTS.md specification
+refactor(db): normalize audit log indexes
+test(e2e): add auth flow coverage
+chore(deps): bump next to 15.3
+```
+
+---
+
+## Decision Tree
+
+```
+Is this a single-workspace change?
+├── Yes → Include scope in title: type(scope): description
+└── No  → Omit scope: type: description
+
+Does it fix an issue?
+├── Yes → Add "Closes #N" in Summary section
+└── No  → No issue linkage required (but recommended)
+
+Are there UI changes?
+├── Yes → Add UI Verification checklist + screenshots
+└── No  → Standard checklist only
+
+Are there DB schema changes?
+├── Yes → Add Database Verification checklist
+└── No  → Skip
+
+Is the diff > 400 lines?
+├── Yes → Consider splitting into chained PRs (see chained-pr skill)
+└── No  → Single PR is fine
+```
+
+---
+
+## Before Creating PR
+
+1. ✅ Branch is up to date with main (`git pull origin main --rebase`)
+2. ✅ `pnpm typecheck` passes
+3. ✅ `pnpm lint` passes
+4. ✅ `pnpm test` passes
+5. ✅ E2E tests pass (if feature has UI: `pnpm e2e`)
+6. ✅ Commits follow conventional-commits format
+7. ✅ No `any` types introduced
+8. ✅ No secrets in code
+
+---
+
+## Commands
+
+```bash
+# Ensure branch is current
+git pull origin main --rebase
+
+# Run all quality checks
+pnpm typecheck && pnpm lint && pnpm test
+
+# Review what will be in the PR
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+
+# Create PR with heredoc body
+gh pr create --title "feat(scope): description" --body "$(cat <<'EOF'
+## Summary
+
+- Add resource CRUD feature with tenant isolation
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `packages/core/src/services/resource-service.ts` | New service with CRUD operations |
+| `ui/features/resources/actions.ts` | Server Actions (thin wrappers) |
+| `ui/e2e/resources/resources.spec.ts` | E2E test coverage |
+
+## Verification
+
+- [x] `pnpm typecheck` passes
+- [x] `pnpm lint` passes
+- [x] `pnpm test` passes
+- [x] `pnpm e2e` passes
+
+Closes #42
+EOF
+)"
+
+# Create draft PR
+gh pr create --draft --title "feat(scope): wip description"
+```


### PR DESCRIPTION
## Summary

- Adds formal specification for writing `AGENTS.md` files (the pattern all workspaces follow)
- Adds documentation contribution guide (page format, conventions, AI-driven docs)
- Creates `enterprise-commit`, `enterprise-pr`, and `enterprise-docs` skills with project-specific patterns
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with workspace-specific collapsible checklists

## Changes

| File | Change |
|------|--------|
| `docs/developer-guide/agents-md-spec.mdx` | Formal pattern: 9 required sections, hierarchy diagram, anti-patterns, when to create new |
| `docs/developer-guide/contributing-docs.mdx` | Doc structure, page format, writing conventions, AI-driven cross-references |
| `skills/enterprise-commit/SKILL.md` | Conventional commits with project scopes, decision trees, good/bad examples |
| `skills/enterprise-pr/SKILL.md` | PR workflow, branch naming, workspace-specific checklists, 400-line awareness |
| `skills/enterprise-docs/SKILL.md` | Documentation style guide: voice, inclusive language, callouts, code annotations |
| `.github/PULL_REQUEST_TEMPLATE.md` | Standardized template with collapsible UI/DB/Service Layer sections |
| `AGENTS.md` | Reference all 3 new skills in catalog and auto-invoke table |

## Motivation

1. The AGENTS.md pattern needed a formal spec for new workspaces
2. Commit/PR conventions were 2 lines — now proper skills with scopes and examples
3. Documentation writing had no loadable skill — agents writing docs had no style guide
4. All three inspired by Prowler's skill system, adapted to our TypeScript monorepo context

## Verification

- [x] Skills have valid frontmatter with `metadata.auto_invoke`
- [x] Auto-invoke entries added to root AGENTS.md
- [x] PR template renders correctly on GitHub
- [x] Patterns persisted in engram for cross-session access