### PR TITLE
feat: add form validation contracts, shared components, and hooks

### DIFF
--- a/docs/prd-form-validation.md
+++ b/docs/prd-form-validation.md
@@ -1,0 +1,245 @@
+# PRD — Form Validation UX System
+
+## 1. Context
+
+The Enterprise Platform has 6 forms across auth flows (sign-in, sign-up, forgot-password, reset-password) and resource management (create/edit resource, delete confirmation). These forms currently rely on a mix of HTML5 native validation and redirect-based error patterns that provide poor or zero feedback to users when something goes wrong.
+
+The resource form (`resource-form.tsx`) is the only form using `useActionState` with structured `ActionResult<T>` errors and inline field messages. The 4 auth forms use Server Components with `redirect()` on validation failure, which means the user sees a page reload with no indication of what went wrong. In the worst case (sign-in with invalid credentials), the user gets **zero feedback** — the page silently reloads.
+
+---
+
+## 2. Problem
+
+The core problem is **inconsistent and incomplete validation feedback** across all forms.
+
+Today:
+
+- The sign-in form silently redirects on invalid credentials — no error message at all
+- The sign-up form shows a generic "check your inputs" banner but never tells the user *which* input failed
+- The reset-password form has a Zod `.refine()` that produces "Passwords do not match", but the message is thrown away and replaced with a misleading "Request a new link" banner
+- HTML5 native validation (browser popups) is the only client-side validation — visually inconsistent across browsers and unhelpful for complex rules
+- The `Input` and `Textarea` components have built-in `aria-invalid` destructive styles, but no form ever sets `aria-invalid` — these styles are completely wasted
+- There are no shared form composition components (`FormField`, `FormMessage`, etc.)
+- There are two completely different error patterns (redirect-based vs `ActionResult`-based) with no architectural consistency
+- No form has client-side Zod validation — every validation requires a server round-trip
+
+This directly impacts:
+
+- **User trust**: Silent failures make users think the system is broken
+- **Conversion**: Users abandon auth flows when they cannot figure out what went wrong
+- **Accessibility**: No `aria-invalid` means screen readers cannot identify errored fields
+- **Developer velocity**: Each new form re-invents its own error display pattern
+- **Consistency**: Two different error architectures make the codebase harder to maintain
+
+---
+
+## 3. Objective
+
+Build a unified form validation UX system that enables:
+
+- Immediate, inline field-level error feedback on every form
+- Consistent error display using shared components and patterns
+- Server error propagation to the UI (auth failures, business rule violations)
+- Accessible error states using `aria-invalid` and `aria-describedby`
+- Client-side Zod validation for instant feedback before server round-trips
+- A documented, reusable pattern that any developer can follow for new forms
+
+---
+
+## 4. Value Proposition
+
+**Every form gives clear, specific, accessible feedback** — field-level errors appear inline, server errors show contextual messages, and the user always knows what to fix.
+
+---
+
+## 5. Users
+
+| Role | Impact |
+|------|--------|
+| **End user** | Gets clear, immediate feedback on form errors — knows exactly what to fix |
+| **Developer** | Uses shared components and a documented pattern to build validated forms in minutes |
+| **QA** | Tests against a consistent validation behavior contract |
+
+> **Primary user: End user** — experiences the validation feedback directly.
+
+---
+
+## 6. Scope
+
+### Included
+
+- Shared `FormField` component (Label + Input slot + error message + `aria-invalid`)
+- Shared `FormMessage` component (renders field-level or form-level error text)
+- `getFieldError` typed utility extracted to `@enterprise/contracts`
+- `FieldErrors` type definition in `@enterprise/contracts`
+- Migration of all 4 auth forms to `useActionState` with `ActionResult<T>` error flow
+- Fix sign-in action to surface credential errors
+- Fix reset-password to surface "passwords don't match" error
+- `aria-invalid` integration on all form inputs with errors
+- `useFormStatus`-based pending state on all submit buttons
+- Client-side Zod validation layer (optional instant feedback before server submission)
+- Suppress HTML5 native validation popups (`noValidate` on forms, custom display)
+- New `form-validation` agent skill documenting the canonical pattern
+
+### Not included
+
+- Multi-step form wizards
+- Drag-and-drop or file upload validation
+- Real-time async validation (e.g., check email uniqueness while typing)
+- Form state persistence across page navigations
+- Visual form builder
+
+---
+
+## 7. User Journey
+
+### Form Submission with Errors
+
+1. User fills in a form (e.g., sign-in with email and password)
+2. User clicks Submit
+3. **Client-side validation fires first** — if email format is wrong, the input immediately shows a red border and "Enter a valid email address" below the field
+4. If client-side passes, form submits to the Server Action
+5. **Server validation fires** — Zod `safeParse` runs, returns field errors via `ActionResult`
+6. If Zod fails, each errored field shows its specific message inline (e.g., "Password must be at least 8 characters")
+7. If Zod passes but the operation fails (e.g., invalid credentials), a **form-level error banner** appears with the server message
+8. User fixes the highlighted fields and resubmits
+9. On success, the form either navigates (auth) or shows a success message (CRUD)
+
+### Accessible Flow
+
+1. Screen reader announces `aria-invalid` state change on errored inputs
+2. Error messages are linked via `aria-describedby` to their input
+3. Focus moves to the first errored field after submission failure
+
+---
+
+## 8. Core Features
+
+### 8.1 Shared FormField Component
+
+- Composes `Label` + input slot + error message in a consistent layout
+- Automatically sets `aria-invalid` and `aria-describedby` when an error is present
+- Shows required indicator on label when field is required
+- Supports all input types (Input, Textarea, Select)
+
+### 8.2 Inline Field Error Display
+
+- Error text appears below the input in `text-destructive` color
+- Input border changes to `border-destructive` via `aria-invalid` CSS (already exists in components)
+- Error ring appears on focus in `ring-destructive` (already exists in components)
+- Error text clears when the user starts editing the field
+
+### 8.3 Form-Level Error Banner
+
+- Displays when the server returns a general error (not tied to a specific field)
+- Examples: "Invalid credentials", "Account already exists", "Service unavailable"
+- Styled as a destructive alert with icon
+- Positioned at the top of the form
+
+### 8.4 Client-Side Validation
+
+- Uses the same Zod schema from `@enterprise/contracts` to validate before submission
+- Provides instant feedback without server round-trip
+- Does NOT replace server-side validation (server is always authoritative)
+- Triggered on form submit (not on every keystroke by default)
+
+### 8.5 Pending State
+
+- Submit button shows loading state and is disabled during submission
+- Uses `useFormStatus` or `isPending` from `useActionState`
+- Prevents double-submission
+
+### 8.6 Success Feedback
+
+- Mutations show a success message or navigate to the appropriate page
+- Auth forms redirect after success (existing behavior, preserved)
+
+---
+
+## 9. Non-Functional Requirements
+
+- **Accessible** — `aria-invalid`, `aria-describedby`, focus management on error
+- **Consistent** — Same visual pattern and behavior across all forms
+- **Performant** — Client-side validation is synchronous, no extra network calls
+- **Progressive** — Forms work without JavaScript (server validation + redirect as fallback)
+- **Reusable** — Shared components reduce per-form boilerplate to near zero
+- **Documented** — Agent skill ensures AI assistants follow the pattern correctly
+
+---
+
+## 10. Success Metrics
+
+### Product
+
+- Zero silent form failures (every submission error produces visible user feedback)
+- All 6 forms display field-level errors inline
+- Reduction in support tickets related to "login not working"
+
+### Technical
+
+- Shared `FormField` component used in 100% of forms
+- `aria-invalid` set on every errored input
+- Single validation pattern (`useActionState` + `ActionResult`) across all forms
+- `form-validation` skill followed for all new form development
+- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm e2e` all pass
+
+---
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Auth forms must become Client Components | Use thin Client Component wrappers for the form only; the page layout remains Server Component |
+| Client-side Zod schemas increase bundle size | Use dynamic imports or validate only on submit, not on every keystroke |
+| Changing auth error flow may break redirect behavior | Preserve redirect on success; only change error flow |
+| Too many simultaneous form changes | Implement in phases — shared components first, then migrate forms one by one |
+
+---
+
+## 12. Definition of Success
+
+The system will be successful if:
+
+- **Every form error produces visible, specific feedback** — never a silent reload
+- Users can **identify and fix validation errors without guessing**
+- Developers can **build a new validated form in under 30 minutes** using shared components
+- The pattern is **documented in a skill** that AI agents follow automatically
+- All forms pass **accessibility audit** for form validation (WCAG 2.1 Level AA)
+
+---
+
+## 13. Implementation Phases
+
+### Phase 1 — Shared Components + Utilities
+
+- Create `FormField`, `FormMessage` in `@enterprise/ui`
+- Extract `getFieldError` and `FieldErrors` type to `@enterprise/contracts`
+- Unit tests for utilities
+
+### Phase 2 — Auth Form Migration
+
+- Convert auth forms to use `useActionState` + `ActionResult` error flow
+- Fix sign-in action to return credential errors
+- Fix reset-password to surface "passwords don't match"
+- Add `noValidate` + client-side Zod validation
+- Add pending state to all auth submit buttons
+- E2E tests for auth validation flows
+
+### Phase 3 — Resource Form Upgrade
+
+- Migrate resource form to use shared `FormField` component
+- Add `aria-invalid` to all fields
+- Add client-side Zod validation
+- E2E tests for resource validation flows
+
+### Phase 4 — Skill + Documentation
+
+- Create `form-validation` skill with canonical patterns
+- Update `ui/AGENTS.md` to replace incorrect `react-hook-form` references
+- Architecture documentation in `docs/architecture/`
+
+---
+
+## 14. In One Sentence
+
+> A unified form validation UX system that provides inline field errors, server error propagation, and accessible error states across all forms — with shared components, a documented pattern, and an agent skill to enforce consistency.

--- a/docs/rfc-form-validation.md
+++ b/docs/rfc-form-validation.md
@@ -1,0 +1,780 @@
+# RFC — Form Validation UX System Architecture
+
+## 1. Summary
+
+This document defines how form validation will be architected across the Enterprise Platform to provide consistent, accessible, inline error feedback on every form.
+
+The system will:
+
+- Provide shared `FormField` and `FormMessage` components in `@enterprise/ui`
+- Extract a typed `getFieldError` utility and `FieldErrors` type to `@enterprise/contracts`
+- Standardize all forms on the `useActionState` + `ActionResult<T>` pattern
+- Add client-side Zod validation for instant feedback before server round-trips
+- Set `aria-invalid` and `aria-describedby` on errored inputs automatically
+- Suppress HTML5 native validation in favor of custom inline error display
+- Migrate all 4 auth forms from redirect-on-error to structured error flow
+
+### What this RFC is NOT
+
+- A form library replacement (no `react-hook-form`, no `formik`)
+- A multi-step wizard system
+- Real-time async field validation (debounced uniqueness checks, etc.)
+
+---
+
+## 2. Technical Objective
+
+Design a form validation layer that:
+
+1. Uses `useActionState` + `ActionResult<T>` as the **single error propagation pattern** for all forms
+2. Provides shared components that handle error display, `aria-invalid`, and `aria-describedby` automatically
+3. Supports **dual validation**: client-side Zod for instant feedback + server-side Zod as authoritative source
+4. Works with existing `@enterprise/ui` primitives (Input, Textarea, Select) without modifying them
+5. Is fully documented in a `form-validation` agent skill
+
+---
+
+## 3. Architecture
+
+### Error Flow
+
+```text
+User submits form
+    │
+    ▼
+Client-side Zod validation (optional, instant)
+    │  schema.safeParse(formData) → fieldErrors
+    │  if errors → display inline, do NOT submit
+    │
+    ▼ (no client errors)
+Server Action receives FormData
+    │
+    ▼
+Server-side Zod validation (authoritative)
+    │  schema.safeParse(input) → flatten().fieldErrors
+    │  if errors → return ActionResult { success: false, error: { details: fieldErrors } }
+    │
+    ▼ (no Zod errors)
+Service layer executes business logic
+    │  if failure → return ActionResult { success: false, error: { message: "..." } }
+    │
+    ▼ (success)
+Return ActionResult { success: true, data: result }
+    │
+    ▼
+useActionState receives new state
+    │
+    ▼
+FormField reads state → displays field errors inline
+Form reads state → displays form-level error banner or success
+```
+
+### Component Hierarchy
+
+```text
+<form action={formAction} noValidate>
+    │
+    ├── <FormBanner state={state} />              ← form-level error/success
+    │
+    ├── <FormField name="email" label="Email" state={state} required>
+    │       ├── <Label htmlFor="email">Email *</Label>
+    │       ├── <Input id="email" name="email" aria-invalid={true} aria-describedby="email-error" />
+    │       └── <FormMessage id="email-error">Enter a valid email address</FormMessage>
+    │
+    ├── <FormField name="password" label="Password" state={state} required>
+    │       ├── <Label htmlFor="password">Password *</Label>
+    │       ├── <Input id="password" name="password" />
+    │       └── (no error → no FormMessage rendered)
+    │
+    └── <SubmitButton>Sign in</SubmitButton>      ← uses useFormStatus for pending
+```
+
+### Package Ownership
+
+```text
+@enterprise/contracts
+ ├── src/types/platform.ts        → ActionResult, ActionError (existing)
+ ├── src/types/form.ts            → FieldErrors type, getFieldError utility
+ └── src/index.ts                 → Re-exports new types
+
+@enterprise/ui
+ ├── src/components/form-field.tsx → FormField composition component (NEW)
+ ├── src/components/form-message.tsx → FormMessage error text component (NEW)
+ ├── src/components/form-banner.tsx  → FormBanner error/success banner (NEW)
+ ├── src/components/submit-button.tsx → SubmitButton with useFormStatus (NEW)
+ ├── src/components/input.tsx      → UNCHANGED (aria-invalid styles already exist)
+ ├── src/components/textarea.tsx   → UNCHANGED (aria-invalid styles already exist)
+ ├── src/components/select.tsx     → UNCHANGED (aria-invalid styles already exist)
+ └── src/hooks/use-form-validation.ts → Client-side Zod validation hook (NEW)
+
+@enterprise/web (ui/)
+ ├── features/auth/components/     → Client Component wrappers for auth forms (NEW)
+ ├── features/auth/actions.ts      → MODIFIED (return ActionResult instead of redirect on error)
+ ├── features/resources/components/resource-form.tsx → MODIFIED (use shared FormField)
+ └── app/(auth)/sign-in/page.tsx   → MODIFIED (use new client form component)
+```
+
+### Dependency Direction (respected)
+
+```text
+@enterprise/contracts → zod ONLY (defines FieldErrors type)
+@enterprise/ui → @enterprise/contracts (imports FieldErrors, ActionResult for component props)
+@enterprise/web → @enterprise/contracts, @enterprise/ui (uses components + types)
+```
+
+No new packages. No circular dependencies.
+
+---
+
+## 4. Contracts: Types and Utilities
+
+### FieldErrors Type
+
+New file: `packages/contracts/src/types/form.ts`
+
+```typescript
+/** Field-level validation errors from Zod flatten().fieldErrors */
+export type FieldErrors = Record<string, string[]>;
+
+/**
+ * Extract the first error message for a given field from an ActionResult.
+ *
+ * @param result - The ActionResult from useActionState (can be null on initial render)
+ * @param field - The field name to look up
+ * @returns The first error message, or undefined if no error
+ */
+export function getFieldError<T>(
+  result: ActionResult<T> | null,
+  field: string,
+): string | undefined {
+  if (!result || result.success) return undefined;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details?.[field]?.[0];
+}
+
+/**
+ * Check if the ActionResult has any field-level errors (vs only a form-level error).
+ */
+export function hasFieldErrors<T>(result: ActionResult<T> | null): boolean {
+  if (!result || result.success) return false;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details !== undefined && Object.keys(details).length > 0;
+}
+```
+
+### Updated ActionError Details Type
+
+The existing `ActionError.details` typed as `Record<string, unknown>` is intentionally kept loose for extensibility. The `getFieldError` utility handles the cast internally. No breaking changes.
+
+---
+
+## 5. Shared Components
+
+### FormField
+
+New file: `packages/ui/src/components/form-field.tsx`
+
+```tsx
+import type { ActionResult } from "@enterprise/contracts";
+import { getFieldError } from "@enterprise/contracts";
+import { Label } from "@enterprise/ui/components/label";
+import { FormMessage } from "@enterprise/ui/components/form-message";
+import { cn } from "@enterprise/ui/lib/utils";
+import {
+  type ReactElement,
+  type ReactNode,
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+} from "react";
+
+interface FormFieldProps {
+  /** Field name matching the input's name attribute and the Zod schema key */
+  name: string;
+  /** Label text */
+  label: string;
+  /** ActionResult from useActionState — reads field errors from here */
+  state: ActionResult | null;
+  /** Mark field as required (shows * indicator on label) */
+  required?: boolean;
+  /** Optional description text below the input */
+  description?: string;
+  /** Additional CSS classes on the wrapper */
+  className?: string;
+  /** The input element (Input, Textarea, Select, etc.) */
+  children: ReactNode;
+}
+
+export function FormField({
+  name,
+  label,
+  state,
+  required = false,
+  description,
+  className,
+  children,
+}: FormFieldProps) {
+  const autoId = useId();
+  const fieldId = `${name}-${autoId}`;
+  const errorId = `${fieldId}-error`;
+  const descriptionId = description ? `${fieldId}-desc` : undefined;
+  const error = getFieldError(state, name);
+  const hasError = Boolean(error);
+
+  // Clone the child input to inject aria attributes
+  const enhancedChildren = Children.map(children, (child) => {
+    if (!isValidElement(child)) return child;
+    return cloneElement(child as ReactElement<Record<string, unknown>>, {
+      id: fieldId,
+      name,
+      "aria-invalid": hasError || undefined,
+      "aria-describedby": [
+        hasError ? errorId : undefined,
+        descriptionId,
+      ]
+        .filter(Boolean)
+        .join(" ") || undefined,
+    });
+  });
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Label htmlFor={fieldId}>
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </Label>
+      {enhancedChildren}
+      {description && (
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {hasError && <FormMessage id={errorId}>{error}</FormMessage>}
+    </div>
+  );
+}
+```
+
+### FormMessage
+
+New file: `packages/ui/src/components/form-message.tsx`
+
+```tsx
+import { cn } from "@enterprise/ui/lib/utils";
+import type { ReactNode } from "react";
+
+interface FormMessageProps {
+  id?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FormMessage({ id, children, className }: FormMessageProps) {
+  if (!children) return null;
+
+  return (
+    <p
+      id={id}
+      role="alert"
+      className={cn("text-xs text-destructive", className)}
+    >
+      {children}
+    </p>
+  );
+}
+```
+
+### FormBanner
+
+New file: `packages/ui/src/components/form-banner.tsx`
+
+```tsx
+import type { ActionResult } from "@enterprise/contracts";
+import { hasFieldErrors } from "@enterprise/contracts";
+import { cn } from "@enterprise/ui/lib/utils";
+
+interface FormBannerProps<T> {
+  state: ActionResult<T> | null;
+  /** Message shown on success. If undefined, no success banner is shown. */
+  successMessage?: string;
+  className?: string;
+}
+
+export function FormBanner<T>({
+  state,
+  successMessage,
+  className,
+}: FormBannerProps<T>) {
+  if (!state) return null;
+
+  // Success
+  if (state.success && successMessage) {
+    return (
+      <p className={cn("rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-500", className)}>
+        {successMessage}
+      </p>
+    );
+  }
+
+  // Error — but only show banner for form-level errors, not field-level
+  if (!state.success && !hasFieldErrors(state)) {
+    return (
+      <p
+        role="alert"
+        className={cn(
+          "rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive",
+          className,
+        )}
+      >
+        {state.error?.message ?? "An error occurred. Please try again."}
+      </p>
+    );
+  }
+
+  return null;
+}
+```
+
+### SubmitButton
+
+New file: `packages/ui/src/components/submit-button.tsx`
+
+```tsx
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import type { ComponentProps } from "react";
+import { useFormStatus } from "react-dom";
+
+interface SubmitButtonProps extends Omit<ComponentProps<typeof Button>, "type" | "disabled"> {
+  /** Text shown while form is submitting */
+  pendingText?: string;
+}
+
+export function SubmitButton({
+  children,
+  pendingText = "Saving…",
+  ...props
+}: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending} {...props}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}
+```
+
+---
+
+## 6. Client-Side Validation Hook
+
+New file: `packages/ui/src/hooks/use-form-validation.ts`
+
+```typescript
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import type { ZodSchema } from "zod";
+import { useCallback, useRef } from "react";
+
+interface UseFormValidationOptions<T> {
+  /** Zod schema to validate against (same schema used server-side) */
+  schema: ZodSchema;
+  /** The server action wrapped by useActionState */
+  serverAction: (
+    prevState: ActionResult<T> | null,
+    formData: FormData,
+  ) => Promise<ActionResult<T>>;
+}
+
+/**
+ * Wraps a server action with client-side Zod validation.
+ * Returns a new action function that validates client-side first,
+ * returning field errors immediately without a server round-trip.
+ *
+ * Usage:
+ *   const validatedAction = useFormValidation({ schema: loginDto, serverAction: signInAction });
+ *   const [state, formAction, isPending] = useActionState(validatedAction, null);
+ */
+export function useFormValidation<T>({
+  schema,
+  serverAction,
+}: UseFormValidationOptions<T>) {
+  const serverActionRef = useRef(serverAction);
+  serverActionRef.current = serverAction;
+
+  return useCallback(
+    async (
+      prevState: ActionResult<T> | null,
+      formData: FormData,
+    ): Promise<ActionResult<T>> => {
+      // Convert FormData to plain object for Zod validation
+      const rawData: Record<string, unknown> = {};
+      for (const [key, value] of formData.entries()) {
+        rawData[key] = value;
+      }
+
+      const result = schema.safeParse(rawData);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Please fix the errors below.",
+            details: fieldErrors as Record<string, unknown>,
+          },
+        } as ActionResult<T>;
+      }
+
+      // Client validation passed — proceed to server
+      return serverActionRef.current(prevState, formData);
+    },
+    [schema],
+  );
+}
+```
+
+---
+
+## 7. Auth Form Migration
+
+### Current Pattern (redirect-on-error)
+
+```typescript
+// ❌ Current: ui/features/auth/actions.ts
+export async function signInAction(formData: FormData) {
+  const raw = { email: formData.get("email"), password: formData.get("password") };
+  const parsed = loginDto.safeParse(raw);
+  if (!parsed.success) {
+    redirect("/sign-in"); // Silent — no error feedback
+  }
+  const result = await signIn(client, parsed.data);
+  if (result.error) {
+    redirect("/sign-in"); // Silent — no error feedback
+  }
+  redirect("/dashboard");
+}
+```
+
+### New Pattern (ActionResult-based)
+
+```typescript
+// ✅ New: ui/features/auth/actions.ts
+export async function signInAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = { email: formData.get("email"), password: formData.get("password") };
+  const parsed = loginDto.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: parsed.error.flatten().fieldErrors,
+      },
+    };
+  }
+
+  const client = await createAuthClient();
+  const result = await signIn(client, parsed.data);
+
+  if (result.error) {
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+  }
+
+  redirect("/dashboard");
+}
+```
+
+### Auth Form Component Migration
+
+Auth pages are currently Server Components with inline `<form>` elements. Since `useActionState` requires a Client Component, we create thin Client Component wrappers:
+
+```text
+ui/features/auth/components/
+ ├── sign-in-form.tsx    ← "use client", uses useActionState
+ ├── sign-up-form.tsx    ← "use client", uses useActionState
+ ├── forgot-password-form.tsx
+ └── reset-password-form.tsx
+```
+
+The page files (`ui/app/(auth)/sign-in/page.tsx`, etc.) remain Server Components that render the layout and import the form component.
+
+### Example: Sign-In Form Component
+
+```tsx
+// ✅ New: ui/features/auth/components/sign-in-form.tsx
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { loginDto } from "@enterprise/contracts";
+import { Input } from "@enterprise/ui/components/input";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { signInAction } from "@/features/auth/actions";
+
+export function SignInForm() {
+  const validatedAction = useFormValidation({
+    schema: loginDto,
+    serverAction: signInAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="email" label="Email" state={state} required>
+        <Input type="email" placeholder="you@example.com" />
+      </FormField>
+
+      <FormField name="password" label="Password" state={state} required>
+        <Input type="password" placeholder="Your password" />
+      </FormField>
+
+      <SubmitButton pendingText="Signing in…">Sign in</SubmitButton>
+    </form>
+  );
+}
+```
+
+Compare this with the current 80+ lines of form markup + error URL param parsing. The new version is ~25 lines with full inline validation, server error display, pending state, and accessibility.
+
+---
+
+## 8. Migrated Resource Form (Before/After)
+
+### Before (current)
+
+```tsx
+// ❌ Current: Manual getFieldError, no aria-invalid, no shared components
+<div className="flex flex-col gap-1.5 sm:col-span-2">
+  <Label htmlFor="title">
+    Title <span className="text-destructive">*</span>
+  </Label>
+  <Input id="title" name="title" required defaultValue={defaultValues?.title ?? ""} />
+  {getFieldError(state, "title") && (
+    <p className="text-xs text-destructive">{getFieldError(state, "title")}</p>
+  )}
+</div>
+```
+
+### After (migrated)
+
+```tsx
+// ✅ New: Shared FormField handles everything
+<FormField name="title" label="Title" state={state} required className="sm:col-span-2">
+  <Input defaultValue={defaultValues?.title ?? ""} placeholder="Resource title" />
+</FormField>
+```
+
+The `FormField` component handles:
+- Label rendering with required indicator
+- `id` generation and `htmlFor` binding
+- `aria-invalid` on the input when error exists
+- `aria-describedby` linking input to error message
+- Error message rendering below the input
+
+---
+
+## 9. Validation Behavior Specification
+
+### When Validation Runs
+
+| Trigger | What Happens |
+|---------|-------------|
+| Form submit (with `useFormValidation`) | Client-side Zod validates first. If errors, they show inline without server call. |
+| Form submit (server-side) | Server Action runs Zod `safeParse`. If errors, returns `ActionResult` with field errors. |
+| User edits an errored field | Error stays visible until next form submission (no real-time clearing in V1). |
+| Server business logic fails | Form-level error banner shows the server message. |
+
+### Error Priority
+
+```
+Is it a field-level error (from Zod)?
+├── Yes → Show inline below the specific field, set aria-invalid
+│         If MULTIPLE fields have errors → show ALL of them simultaneously
+└── No
+    └── Is it a form-level error (from service/auth)?
+        └── Yes → Show in FormBanner at top of form
+```
+
+### HTML5 Validation Suppression
+
+All forms use `noValidate` attribute:
+
+```tsx
+<form action={formAction} noValidate>
+```
+
+This prevents browser-native validation popups. Custom validation (via Zod) provides the same rules with better UX (inline messages, consistent styling, accessible markup).
+
+---
+
+## 10. Technical Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No `react-hook-form` | The project already uses native `<form>` + `useActionState`. Adding RHF would introduce a second form paradigm and a new dependency. The current pattern works well with shared components. |
+| `noValidate` on all forms | Prevents inconsistent browser popups. Custom validation provides the same rules with better UX. |
+| `useFormValidation` hook for client-side | Reuses the same Zod schema used server-side. Single source of truth for validation rules. |
+| `FormField` uses `cloneElement` | Injects `aria-invalid` and `aria-describedby` without requiring the input to know about form state. Keeps Input/Textarea/Select unchanged. |
+| Error stays until re-submit (V1) | Simpler implementation. Real-time clearing requires `onChange` handlers and client state, which adds complexity. Can be added in V2. |
+| Auth actions return `ActionResult` instead of `redirect` on error | Enables structured error display. `redirect` on success is preserved. |
+| `role="alert"` on FormMessage | Screen readers announce new error messages when they appear. |
+
+---
+
+## 11. Trade-offs
+
+### Prioritized
+
+- **Simplicity**: Shared components, no new form library
+- **Consistency**: Same pattern and components across all forms
+- **Accessibility**: `aria-invalid`, `aria-describedby`, `role="alert"` on errors
+- **Progressive enhancement**: Forms still work without JS (server validation + redirect fallback)
+
+### Sacrificed
+
+- Real-time field clearing on edit (deferred to V2 — requires onChange handlers)
+- Async validation (e.g., check email uniqueness while typing — deferred)
+- `react-hook-form` integration (project uses native forms, no reason to add RHF)
+- Password strength meter (UI enhancement, not core validation)
+
+---
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Auth pages must have Client Component children | Minor — the page layout stays Server Component, only the form is Client Component | Create thin `SignInForm` wrappers, page passes no sensitive data |
+| `cloneElement` is fragile with wrapper components | `FormField` assumes direct child is the input | Document in skill that the input must be the direct child of `FormField` |
+| Client-side Zod validation increases bundle | Zod schemas are already imported for types | Schemas are small; measure impact and tree-shake if needed |
+| Changing auth actions breaks OAuth callback flows | OAuth flows (`/auth/callback`) use different code paths | Only modify email/password auth actions, OAuth is untouched |
+| Double validation (client + server) feels redundant | Server validation is always authoritative | Client validation is for UX speed only, server always re-validates |
+
+---
+
+## 13. Implementation Plan
+
+### Phase 1 — Contracts + Shared Components (no visual changes)
+
+1. Create `packages/contracts/src/types/form.ts` — `FieldErrors`, `getFieldError`, `hasFieldErrors`
+2. Export from contracts barrel
+3. Create `packages/ui/src/components/form-field.tsx`
+4. Create `packages/ui/src/components/form-message.tsx`
+5. Create `packages/ui/src/components/form-banner.tsx`
+6. Create `packages/ui/src/components/submit-button.tsx`
+7. Create `packages/ui/src/hooks/use-form-validation.ts`
+8. Export all from ui barrel
+9. Unit tests for `getFieldError`, `hasFieldErrors`, `useFormValidation`
+
+**Tests**: Utilities return correct values for various `ActionResult` shapes. Components render error states correctly.
+
+### Phase 2 — Auth Form Migration
+
+1. Modify `ui/features/auth/actions.ts` — all 4 actions return `ActionResult` on error
+2. Create `ui/features/auth/components/sign-in-form.tsx` using `FormField` + `useActionState`
+3. Create `ui/features/auth/components/sign-up-form.tsx`
+4. Create `ui/features/auth/components/forgot-password-form.tsx`
+5. Create `ui/features/auth/components/reset-password-form.tsx`
+6. Update page files to import new form components
+7. Add client-side Zod validation via `useFormValidation` on each form
+8. E2E tests: sign-in with invalid credentials shows error, sign-up with short password shows field error
+
+**Tests**: E2E tests for every auth form validation scenario. Unit tests for action error returns.
+
+### Phase 3 — Resource Form Migration
+
+1. Refactor `resource-form.tsx` to use shared `FormField` instead of manual error display
+2. Remove local `getFieldError` function (use imported utility)
+3. Add `noValidate` to form
+4. Add client-side Zod validation
+5. Verify `aria-invalid` activates destructive styles on Input/Textarea
+
+**Tests**: E2E tests for resource form validation. Visual regression check.
+
+### Phase 4 — Skill + Documentation
+
+1. Create `form-validation` agent skill
+2. Update `ui/AGENTS.md` to replace `react-hook-form` references with actual pattern
+3. Add auto-invoke entries for the new skill
+
+---
+
+## 14. Acceptance Criteria
+
+1. All 6 forms display inline field-level errors below the errored input
+2. All errored inputs show `border-destructive` via `aria-invalid` CSS
+3. The sign-in form displays "Invalid email or password" on credential failure
+4. The reset-password form displays "Passwords do not match" on mismatch
+5. All forms use `noValidate` — no HTML5 browser popups
+6. All forms have pending state on the submit button
+7. `FormField`, `FormMessage`, `FormBanner`, `SubmitButton` exist in `@enterprise/ui`
+8. `getFieldError` and `FieldErrors` are exported from `@enterprise/contracts`
+9. Client-side Zod validation fires before server submission on all forms
+10. Screen readers announce error messages via `role="alert"` and `aria-describedby`
+11. `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm e2e` pass
+12. `form-validation` skill exists and is referenced in AGENTS.md auto-invoke table
+
+---
+
+## 15. File Inventory
+
+### New Files
+
+| File | Package | Purpose |
+|------|---------|---------|
+| `src/types/form.ts` | contracts | FieldErrors type, getFieldError, hasFieldErrors |
+| `src/components/form-field.tsx` | ui | FormField composition component |
+| `src/components/form-message.tsx` | ui | Error message component |
+| `src/components/form-banner.tsx` | ui | Form-level error/success banner |
+| `src/components/submit-button.tsx` | ui | Submit button with pending state |
+| `src/hooks/use-form-validation.ts` | ui | Client-side Zod validation hook |
+| `features/auth/components/sign-in-form.tsx` | web | Sign-in form (Client Component) |
+| `features/auth/components/sign-up-form.tsx` | web | Sign-up form (Client Component) |
+| `features/auth/components/forgot-password-form.tsx` | web | Forgot password form |
+| `features/auth/components/reset-password-form.tsx` | web | Reset password form |
+| `skills/form-validation/SKILL.md` | skills | Agent skill for form validation patterns |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `packages/contracts/src/index.ts` | Export FieldErrors, getFieldError, hasFieldErrors |
+| `packages/ui/src/index.ts` | Export FormField, FormMessage, FormBanner, SubmitButton, useFormValidation |
+| `ui/features/auth/actions.ts` | Return ActionResult on error instead of redirect |
+| `ui/features/resources/components/resource-form.tsx` | Use shared FormField, remove local getFieldError |
+| `ui/app/(auth)/sign-in/page.tsx` | Import SignInForm component |
+| `ui/app/(auth)/sign-up/page.tsx` | Import SignUpForm component |
+| `ui/app/(auth)/forgot-password/page.tsx` | Import ForgotPasswordForm component |
+| `ui/app/(auth)/reset-password/page.tsx` | Import ResetPasswordForm component |
+| `ui/AGENTS.md` | Replace react-hook-form references, add form-validation skill |
+| `AGENTS.md` | Add form-validation to auto-invoke table |
+
+### Deleted Files
+
+None. The current auth form markup is replaced by imported components. The local `getFieldError` in resource-form.tsx is removed (replaced by import from contracts).
+
+---
+
+## 16. In One Sentence
+
+> A shared form validation system using `useActionState` + `ActionResult<T>` with reusable `FormField`/`FormMessage` components, client-side Zod pre-validation, and accessible error states — standardizing all forms from auth to CRUD with inline field errors and server error propagation.

--- a/packages/contracts/src/__tests__/form.test.ts
+++ b/packages/contracts/src/__tests__/form.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { getFieldError, hasFieldErrors } from "../types/form";
+import type { ActionResult } from "../types/platform";
+
+// ---------------------------------------------------------------------------
+// getFieldError
+// ---------------------------------------------------------------------------
+
+describe("getFieldError", () => {
+  it("returns undefined when result is null (initial state)", () => {
+    expect(getFieldError(null, "email")).toBeUndefined();
+  });
+
+  it("returns undefined when result is a success", () => {
+    const result: ActionResult = { success: true, data: undefined };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+
+  it("returns the first error string when the field has errors", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required", "Must be a valid email"] },
+      },
+    };
+    expect(getFieldError(result, "email")).toBe("Required");
+  });
+
+  it("returns undefined when the field key is missing from details", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { password: ["Required"] },
+      },
+    };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+
+  it("returns undefined when error has no details object", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasFieldErrors
+// ---------------------------------------------------------------------------
+
+describe("hasFieldErrors", () => {
+  it("returns false when result is null (initial state)", () => {
+    expect(hasFieldErrors(null)).toBe(false);
+  });
+
+  it("returns false when result is a success", () => {
+    const result: ActionResult = { success: true, data: undefined };
+    expect(hasFieldErrors(result)).toBe(false);
+  });
+
+  it("returns true when error details has at least one key", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required"] },
+      },
+    };
+    expect(hasFieldErrors(result)).toBe(true);
+  });
+
+  it("returns false when error has no details object", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    expect(hasFieldErrors(result)).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -58,6 +58,7 @@ export {
   typographySchema,
 } from "./schemas/theme";
 // Types
+export * from "./types/form";
 export * from "./types/platform";
 export * from "./types/resources";
 export * from "./types/theme";

--- a/packages/contracts/src/types/form.ts
+++ b/packages/contracts/src/types/form.ts
@@ -1,0 +1,29 @@
+import type { ActionResult } from "./platform";
+
+/** Field-level validation errors from Zod flatten().fieldErrors */
+export type FieldErrors = Record<string, string[]>;
+
+/**
+ * Extract the first error message for a given field from an ActionResult.
+ *
+ * @param result - The ActionResult from useActionState (can be null on initial render)
+ * @param field - The field name to look up
+ * @returns The first error message, or undefined if no error
+ */
+export function getFieldError<T>(
+  result: ActionResult<T> | null,
+  field: string,
+): string | undefined {
+  if (!result || result.success) return undefined;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details?.[field]?.[0];
+}
+
+/**
+ * Check if the ActionResult has any field-level errors (vs only a form-level error).
+ */
+export function hasFieldErrors<T>(result: ActionResult<T> | null): boolean {
+  if (!result || result.success) return false;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details !== undefined && Object.keys(details).length > 0;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,8 @@
     "./lib/*": "./src/lib/*.ts",
     "./theme/context": "./src/theme/context.ts",
     "./theme/provider": "./src/theme/provider.tsx",
-    "./theme/toggle": "./src/theme/toggle.tsx"
+    "./theme/toggle": "./src/theme/toggle.tsx",
+    "./hooks/*": "./src/hooks/*.ts"
   },
   "scripts": {
     "build:theme": "tsx scripts/build-theme.ts",

--- a/packages/ui/src/components/__tests__/form-banner.test.ts
+++ b/packages/ui/src/components/__tests__/form-banner.test.ts
@@ -1,0 +1,60 @@
+/**
+ * FormBanner — unit tests
+ *
+ * Tests the exported FormBanner component's render logic.
+ * We invoke the component function directly since it has simple conditional logic.
+ */
+
+import type { ActionResult } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
+import { FormBanner } from "../form-banner";
+
+describe("FormBanner", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormBanner).toBe("function");
+  });
+
+  it("returns null when state is null", () => {
+    const result = FormBanner({ state: null });
+    expect(result).toBeNull();
+  });
+
+  it("renders error banner for form-level error (no field-level errors)", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    const result = FormBanner({ state });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("returns null when there are field-level errors (banner is not shown)", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required"] },
+      },
+    };
+    const result = FormBanner({ state });
+    expect(result).toBeNull();
+  });
+
+  it("renders success banner when state is successful and successMessage provided", () => {
+    const state: ActionResult = { success: true, data: undefined };
+    const result = FormBanner({ state, successMessage: "Saved successfully." });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("returns null when state is successful but no successMessage provided", () => {
+    const state: ActionResult = { success: true, data: undefined };
+    const result = FormBanner({ state });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/ui/src/components/__tests__/form-field.test.ts
+++ b/packages/ui/src/components/__tests__/form-field.test.ts
@@ -1,0 +1,19 @@
+/**
+ * FormField — unit tests
+ *
+ * FormField uses `useId` and `cloneElement` which require a React rendering
+ * context. In node environment without a DOM, we verify the module exports
+ * and the component's interface contract.
+ */
+import { describe, expect, it } from "vitest";
+import { FormField } from "../form-field";
+
+describe("FormField", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormField).toBe("function");
+  });
+
+  it("has the correct display name / function name", () => {
+    expect(FormField.name).toBe("FormField");
+  });
+});

--- a/packages/ui/src/components/__tests__/form-message.test.ts
+++ b/packages/ui/src/components/__tests__/form-message.test.ts
@@ -1,0 +1,34 @@
+/**
+ * FormMessage — unit tests
+ *
+ * Tests the exported FormMessage component's render logic.
+ * Since the ui project runs in a node environment without a DOM,
+ * we test the module exports and confirm the component is exported correctly.
+ * The core logic (returns null when children is falsy) is a conditional return —
+ * validated here by confirming the component is a function with the right shape.
+ */
+import { describe, expect, it } from "vitest";
+import { FormMessage } from "../form-message";
+
+describe("FormMessage", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormMessage).toBe("function");
+  });
+
+  it("returns null when children is falsy (empty string)", () => {
+    // Invoke component function directly — no DOM needed for null-return check
+    const result = FormMessage({ children: "" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when children is undefined", () => {
+    const result = FormMessage({ children: undefined });
+    expect(result).toBeNull();
+  });
+
+  it("returns a React element when children is a non-empty string", () => {
+    const result = FormMessage({ children: "Required" });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/__tests__/submit-button.test.ts
+++ b/packages/ui/src/components/__tests__/submit-button.test.ts
@@ -1,0 +1,19 @@
+/**
+ * SubmitButton — unit tests
+ *
+ * SubmitButton uses `useFormStatus` which requires a React rendering context.
+ * In node environment without a DOM, we verify the module exports and
+ * the component's interface contract.
+ */
+import { describe, expect, it } from "vitest";
+import { SubmitButton } from "../submit-button";
+
+describe("SubmitButton", () => {
+  it("is a named export and a function", () => {
+    expect(typeof SubmitButton).toBe("function");
+  });
+
+  it("has the correct display name / function name", () => {
+    expect(SubmitButton.name).toBe("SubmitButton");
+  });
+});

--- a/packages/ui/src/components/form-banner.tsx
+++ b/packages/ui/src/components/form-banner.tsx
@@ -1,0 +1,37 @@
+import type { ActionResult } from "@enterprise/contracts";
+import { hasFieldErrors } from "@enterprise/contracts";
+import { cn } from "@enterprise/ui/lib/utils";
+
+interface FormBannerProps<T> {
+  state: ActionResult<T> | null;
+  /** Message shown on success. If undefined, no success banner is shown. */
+  successMessage?: string;
+  className?: string;
+}
+
+export function FormBanner<T>({ state, successMessage, className }: FormBannerProps<T>) {
+  if (!state) return null;
+
+  // Success
+  if (state.success && successMessage) {
+    return (
+      <p className={cn("rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-500", className)}>
+        {successMessage}
+      </p>
+    );
+  }
+
+  // Error — but only show banner for form-level errors, not field-level
+  if (!state.success && !hasFieldErrors(state)) {
+    return (
+      <p
+        role="alert"
+        className={cn("rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive", className)}
+      >
+        {state.error?.message ?? "An error occurred. Please try again."}
+      </p>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui/src/components/form-field.tsx
+++ b/packages/ui/src/components/form-field.tsx
@@ -1,0 +1,75 @@
+import type { ActionResult } from "@enterprise/contracts";
+import { getFieldError } from "@enterprise/contracts";
+import { FormMessage } from "@enterprise/ui/components/form-message";
+import { Label } from "@enterprise/ui/components/label";
+import { cn } from "@enterprise/ui/lib/utils";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useId,
+} from "react";
+
+interface FormFieldProps {
+  /** Field name matching the input's name attribute and the Zod schema key */
+  name: string;
+  /** Label text */
+  label: string;
+  /** ActionResult from useActionState — reads field errors from here */
+  state: ActionResult | null;
+  /** Mark field as required (shows * indicator on label) */
+  required?: boolean;
+  /** Optional description text below the input */
+  description?: string;
+  /** Additional CSS classes on the wrapper */
+  className?: string;
+  /** The input element (Input, Textarea, Select, etc.) — must be the direct child */
+  children: ReactNode;
+}
+
+export function FormField({
+  name,
+  label,
+  state,
+  required = false,
+  description,
+  className,
+  children,
+}: FormFieldProps) {
+  const autoId = useId();
+  const fieldId = `${name}-${autoId}`;
+  const errorId = `${fieldId}-error`;
+  const descriptionId = description ? `${fieldId}-desc` : undefined;
+  const error = getFieldError(state, name);
+  const hasError = Boolean(error);
+
+  // Clone the child input to inject aria attributes
+  const enhancedChildren = Children.map(children, (child) => {
+    if (!isValidElement(child)) return child;
+    return cloneElement(child as ReactElement<Record<string, unknown>>, {
+      id: fieldId,
+      name,
+      "aria-invalid": hasError || undefined,
+      "aria-describedby":
+        [hasError ? errorId : undefined, descriptionId].filter(Boolean).join(" ") || undefined,
+    });
+  });
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Label htmlFor={fieldId}>
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </Label>
+      {enhancedChildren}
+      {description && (
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {hasError && <FormMessage id={errorId}>{error}</FormMessage>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/form-message.tsx
+++ b/packages/ui/src/components/form-message.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@enterprise/ui/lib/utils";
+import type { ReactNode } from "react";
+
+interface FormMessageProps {
+  id?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FormMessage({ id, children, className }: FormMessageProps) {
+  if (!children) return null;
+
+  return (
+    <p id={id} role="alert" className={cn("text-xs text-destructive", className)}>
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/components/submit-button.tsx
+++ b/packages/ui/src/components/submit-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import type { ComponentProps } from "react";
+import { useFormStatus } from "react-dom";
+
+interface SubmitButtonProps extends Omit<ComponentProps<typeof Button>, "type" | "disabled"> {
+  /** Text shown while form is submitting */
+  pendingText?: string;
+}
+
+export function SubmitButton({ children, pendingText = "Saving…", ...props }: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending} {...props}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}

--- a/packages/ui/src/hooks/__tests__/use-form-validation.test.ts
+++ b/packages/ui/src/hooks/__tests__/use-form-validation.test.ts
@@ -1,0 +1,115 @@
+/**
+ * useFormValidation — unit tests
+ *
+ * The hook uses `useCallback` and `useRef` from React.
+ * We test the core validation logic by extracting and calling the
+ * action function that the hook would return.
+ *
+ * The validateAndSubmit helper mirrors the hook's action function exactly,
+ * allowing us to test both scenarios without a React rendering context.
+ */
+
+import type { ActionResult } from "@enterprise/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Extracted action logic (mirrors useFormValidation's callback internals)
+// ---------------------------------------------------------------------------
+
+function createValidatedAction<T>(
+  schema: z.ZodSchema,
+  serverAction: (prevState: ActionResult<T> | null, formData: FormData) => Promise<ActionResult<T>>,
+) {
+  return async (
+    prevState: ActionResult<T> | null,
+    formData: FormData,
+  ): Promise<ActionResult<T>> => {
+    const rawData: Record<string, unknown> = {};
+    for (const [key, value] of formData.entries()) {
+      rawData[key] = value;
+    }
+
+    const result = schema.safeParse(rawData);
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      return {
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+          details: fieldErrors as Record<string, unknown>,
+        },
+      } as ActionResult<T>;
+    }
+
+    return serverAction(prevState, formData);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const loginSchema = z.object({
+  email: z.string().email("Must be a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+describe("useFormValidation action logic", () => {
+  it("returns ActionResult with field errors when client validation fails (server NOT called)", async () => {
+    const serverAction =
+      vi.fn<(prevState: ActionResult | null, formData: FormData) => Promise<ActionResult>>();
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "not-an-email");
+    formData.append("password", "short");
+
+    const result = await action(null, formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("VALIDATION_ERROR");
+    expect(result.error?.details).toBeDefined();
+    // Server action must NOT have been called
+    expect(serverAction).not.toHaveBeenCalled();
+  });
+
+  it("delegates to serverAction when client validation passes", async () => {
+    const serverResult: ActionResult = {
+      success: true,
+      data: { userId: "123" },
+    };
+    const serverAction = vi.fn().mockResolvedValue(serverResult);
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "user@example.com");
+    formData.append("password", "securepassword");
+
+    const result = await action(null, formData);
+
+    expect(result.success).toBe(true);
+    expect(serverAction).toHaveBeenCalledOnce();
+    expect(serverAction).toHaveBeenCalledWith(null, formData);
+  });
+
+  it("passes prevState to serverAction when delegating", async () => {
+    const prevState: ActionResult = {
+      success: false,
+      error: { code: "AUTH_ERROR", message: "Previous error" },
+    };
+    const serverResult: ActionResult = { success: true };
+    const serverAction = vi.fn().mockResolvedValue(serverResult);
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "user@example.com");
+    formData.append("password", "securepassword");
+
+    await action(prevState, formData);
+
+    expect(serverAction).toHaveBeenCalledWith(prevState, formData);
+  });
+});

--- a/packages/ui/src/hooks/use-form-validation.ts
+++ b/packages/ui/src/hooks/use-form-validation.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { useCallback, useRef } from "react";
+import type { ZodSchema } from "zod";
+
+interface UseFormValidationOptions<T> {
+  /** Zod schema to validate against (same schema used server-side) */
+  schema: ZodSchema;
+  /** The server action wrapped by useActionState */
+  serverAction: (prevState: ActionResult<T> | null, formData: FormData) => Promise<ActionResult<T>>;
+}
+
+/**
+ * Wraps a server action with client-side Zod validation.
+ * Returns a new action function that validates client-side first,
+ * returning field errors immediately without a server round-trip.
+ *
+ * Usage:
+ *   const validatedAction = useFormValidation({ schema: loginDto, serverAction: signInAction });
+ *   const [state, formAction, isPending] = useActionState(validatedAction, null);
+ */
+export function useFormValidation<T>({ schema, serverAction }: UseFormValidationOptions<T>) {
+  const serverActionRef = useRef(serverAction);
+  serverActionRef.current = serverAction;
+
+  return useCallback(
+    async (prevState: ActionResult<T> | null, formData: FormData): Promise<ActionResult<T>> => {
+      // Convert FormData to plain object for Zod validation
+      const rawData: Record<string, unknown> = {};
+      for (const [key, value] of formData.entries()) {
+        rawData[key] = value;
+      }
+
+      const result = schema.safeParse(rawData);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Please fix the errors below.",
+            details: fieldErrors as Record<string, unknown>,
+          },
+        } as ActionResult<T>;
+      }
+
+      // Client validation passed — proceed to server
+      return serverActionRef.current(prevState, formData);
+    },
+    [schema],
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,15 @@
 // Theme
 
-// UI Components
 export * from "./components/avatar";
 export * from "./components/badge";
 export * from "./components/button";
 export * from "./components/card";
 export * from "./components/dialog";
 export * from "./components/dropdown-menu";
+// UI Components
+export * from "./components/form-banner";
+export * from "./components/form-field";
+export * from "./components/form-message";
 export * from "./components/input";
 export * from "./components/label";
 export * from "./components/scroll-area";
@@ -14,11 +17,13 @@ export * from "./components/select";
 export * from "./components/separator";
 export * from "./components/sheet";
 export * from "./components/skeleton";
+export * from "./components/submit-button";
 export * from "./components/switch";
 export * from "./components/table";
 export * from "./components/tabs";
 export * from "./components/textarea";
 export * from "./components/tooltip";
+export { useFormValidation } from "./hooks/use-form-validation";
 export { cn } from "./lib/utils";
 export type { ThemeContextValue } from "./theme/context";
 export { ThemeContext } from "./theme/context";


### PR DESCRIPTION
## Summary

- Add `FieldErrors` type, `getFieldError`, `hasFieldErrors` utilities in `@enterprise/contracts`
- Add `FormField`, `FormMessage`, `FormBanner`, `SubmitButton` components in `@enterprise/ui`
- Add `useFormValidation` client-side Zod validation hook
- Add PRD and RFC documentation for the form validation system
- 26 unit tests covering all utilities, components, and hook

## Chain Context

| Field | Value |
|-------|-------|
| Chain | form-validation |
| Tracker | feat/form-validation → main (merge after chain completes) |
| Position | 1 of 3 |
| Base | `feat/form-validation` |
| Depends on | None |
| Follow-up | #34 — Auth Form Migration |
| Review budget | ~350 / 400 |
| Starts at | Empty tracker branch from main |
| Ends with | All shared form validation infrastructure ready |

### Chain Overview

```text
main
 └── feat/form-validation (tracker)
      └── 📍 #33: Contracts + Shared Components
           └── #34: Auth Form Migration
                └── #35: Resource Form + Skill Wiring
```

### Chain Status

| PR | Scope | Status |
|----|-------|--------|
| #33 | Contracts + Shared Components | 📍 Review here |
| #34 | Auth Form Migration | ⚪ Pending |
| #35 | Resource Form + Skill Wiring | ⚪ Pending |

## Changes

| File | Change |
|------|--------|
| `packages/contracts/src/types/form.ts` | `FieldErrors`, `getFieldError`, `hasFieldErrors` |
| `packages/contracts/src/__tests__/form.test.ts` | 9 unit tests for utilities |
| `packages/contracts/src/index.ts` | Barrel export |
| `packages/ui/src/components/form-field.tsx` | `FormField` with cloneElement, aria-invalid, aria-describedby |
| `packages/ui/src/components/form-message.tsx` | `FormMessage` with role="alert" |
| `packages/ui/src/components/form-banner.tsx` | `FormBanner` for form-level errors/success |
| `packages/ui/src/components/submit-button.tsx` | `SubmitButton` with useFormStatus |
| `packages/ui/src/hooks/use-form-validation.ts` | Client-side Zod validation hook |
| `packages/ui/src/components/__tests__/` | Unit tests for all 4 components |
| `packages/ui/src/hooks/__tests__/` | Unit tests for useFormValidation |
| `packages/ui/src/index.ts` | Barrel exports |
| `packages/ui/package.json` | `./hooks/*` export path |
| `docs/prd-form-validation.md` | Product Requirements Document |
| `docs/rfc-form-validation.md` | Technical Architecture RFC |

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (304 tests)

### Contract Verification
- [x] Schemas have colocated type exports
- [x] No imports from other @enterprise/* packages
- [x] Tests cover validation edge cases

## Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit