### PR TITLE
feat: unified form validation UX system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Use these skills for detailed patterns on-demand. The runtime resolves them auto
 | `enterprise-commit` | Conventional commits with project scopes |
 | `enterprise-docs` | Documentation style guide and writing standards |
 | `enterprise-pr` | PR creation workflow and template |
+| `form-validation` | Form validation patterns — useActionState, ActionResult, inline errors, accessibility |
 | `skill-creator` | Create new AI agent skills |
 | `skill-sync` | Sync skill metadata to AGENTS.md tables |
 
@@ -128,18 +129,22 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
+| Adding form validation or error handling | `form-validation` |
+| Adding developer guides | `enterprise-docs` |
 | Adding error tracking to Server Actions | `sentry` |
 | After creating/modifying a skill | `skill-sync` |
 | App Router / Server Actions | `nextjs-15` |
 | Committing changes | `enterprise-commit` |
-| Creating a git commit | `enterprise-commit` |
-| Creating a pull request | `enterprise-pr` |
-| Writing documentation | `enterprise-docs` |
 | Configuring RLS at client level | `supabase` |
 | Configuring database connections | `supabase-postgres-best-practices` |
+| Creating MDX pages | `enterprise-docs` |
+| Creating a git commit | `enterprise-commit` |
+| Creating a pull request | `enterprise-pr` |
 | Creating new skills | `skill-creator` |
 | Implementing auth flows | `supabase` |
+| Opening a PR | `enterprise-pr` |
 | Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Preparing changes for review | `enterprise-pr` |
 | Regenerate AGENTS.md Auto-invoke tables (sync.sh) | `skill-sync` |
 | Reviewing schema performance | `supabase-postgres-best-practices` |
 | Setting up Supabase SSR cookies | `supabase` |
@@ -153,6 +158,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Writing Playwright E2E tests | `playwright` |
 | Writing React components | `react-19` |
 | Writing TypeScript types/interfaces | `typescript` |
+| Writing documentation | `enterprise-docs` |
 
 ## Language Policy (ENFORCED)
 

--- a/docs/prd-form-validation.md
+++ b/docs/prd-form-validation.md
@@ -1,0 +1,245 @@
+# PRD — Form Validation UX System
+
+## 1. Context
+
+The Enterprise Platform has 6 forms across auth flows (sign-in, sign-up, forgot-password, reset-password) and resource management (create/edit resource, delete confirmation). These forms currently rely on a mix of HTML5 native validation and redirect-based error patterns that provide poor or zero feedback to users when something goes wrong.
+
+The resource form (`resource-form.tsx`) is the only form using `useActionState` with structured `ActionResult<T>` errors and inline field messages. The 4 auth forms use Server Components with `redirect()` on validation failure, which means the user sees a page reload with no indication of what went wrong. In the worst case (sign-in with invalid credentials), the user gets **zero feedback** — the page silently reloads.
+
+---
+
+## 2. Problem
+
+The core problem is **inconsistent and incomplete validation feedback** across all forms.
+
+Today:
+
+- The sign-in form silently redirects on invalid credentials — no error message at all
+- The sign-up form shows a generic "check your inputs" banner but never tells the user *which* input failed
+- The reset-password form has a Zod `.refine()` that produces "Passwords do not match", but the message is thrown away and replaced with a misleading "Request a new link" banner
+- HTML5 native validation (browser popups) is the only client-side validation — visually inconsistent across browsers and unhelpful for complex rules
+- The `Input` and `Textarea` components have built-in `aria-invalid` destructive styles, but no form ever sets `aria-invalid` — these styles are completely wasted
+- There are no shared form composition components (`FormField`, `FormMessage`, etc.)
+- There are two completely different error patterns (redirect-based vs `ActionResult`-based) with no architectural consistency
+- No form has client-side Zod validation — every validation requires a server round-trip
+
+This directly impacts:
+
+- **User trust**: Silent failures make users think the system is broken
+- **Conversion**: Users abandon auth flows when they cannot figure out what went wrong
+- **Accessibility**: No `aria-invalid` means screen readers cannot identify errored fields
+- **Developer velocity**: Each new form re-invents its own error display pattern
+- **Consistency**: Two different error architectures make the codebase harder to maintain
+
+---
+
+## 3. Objective
+
+Build a unified form validation UX system that enables:
+
+- Immediate, inline field-level error feedback on every form
+- Consistent error display using shared components and patterns
+- Server error propagation to the UI (auth failures, business rule violations)
+- Accessible error states using `aria-invalid` and `aria-describedby`
+- Client-side Zod validation for instant feedback before server round-trips
+- A documented, reusable pattern that any developer can follow for new forms
+
+---
+
+## 4. Value Proposition
+
+**Every form gives clear, specific, accessible feedback** — field-level errors appear inline, server errors show contextual messages, and the user always knows what to fix.
+
+---
+
+## 5. Users
+
+| Role | Impact |
+|------|--------|
+| **End user** | Gets clear, immediate feedback on form errors — knows exactly what to fix |
+| **Developer** | Uses shared components and a documented pattern to build validated forms in minutes |
+| **QA** | Tests against a consistent validation behavior contract |
+
+> **Primary user: End user** — experiences the validation feedback directly.
+
+---
+
+## 6. Scope
+
+### Included
+
+- Shared `FormField` component (Label + Input slot + error message + `aria-invalid`)
+- Shared `FormMessage` component (renders field-level or form-level error text)
+- `getFieldError` typed utility extracted to `@enterprise/contracts`
+- `FieldErrors` type definition in `@enterprise/contracts`
+- Migration of all 4 auth forms to `useActionState` with `ActionResult<T>` error flow
+- Fix sign-in action to surface credential errors
+- Fix reset-password to surface "passwords don't match" error
+- `aria-invalid` integration on all form inputs with errors
+- `useFormStatus`-based pending state on all submit buttons
+- Client-side Zod validation layer (optional instant feedback before server submission)
+- Suppress HTML5 native validation popups (`noValidate` on forms, custom display)
+- New `form-validation` agent skill documenting the canonical pattern
+
+### Not included
+
+- Multi-step form wizards
+- Drag-and-drop or file upload validation
+- Real-time async validation (e.g., check email uniqueness while typing)
+- Form state persistence across page navigations
+- Visual form builder
+
+---
+
+## 7. User Journey
+
+### Form Submission with Errors
+
+1. User fills in a form (e.g., sign-in with email and password)
+2. User clicks Submit
+3. **Client-side validation fires first** — if email format is wrong, the input immediately shows a red border and "Enter a valid email address" below the field
+4. If client-side passes, form submits to the Server Action
+5. **Server validation fires** — Zod `safeParse` runs, returns field errors via `ActionResult`
+6. If Zod fails, each errored field shows its specific message inline (e.g., "Password must be at least 8 characters")
+7. If Zod passes but the operation fails (e.g., invalid credentials), a **form-level error banner** appears with the server message
+8. User fixes the highlighted fields and resubmits
+9. On success, the form either navigates (auth) or shows a success message (CRUD)
+
+### Accessible Flow
+
+1. Screen reader announces `aria-invalid` state change on errored inputs
+2. Error messages are linked via `aria-describedby` to their input
+3. Focus moves to the first errored field after submission failure
+
+---
+
+## 8. Core Features
+
+### 8.1 Shared FormField Component
+
+- Composes `Label` + input slot + error message in a consistent layout
+- Automatically sets `aria-invalid` and `aria-describedby` when an error is present
+- Shows required indicator on label when field is required
+- Supports all input types (Input, Textarea, Select)
+
+### 8.2 Inline Field Error Display
+
+- Error text appears below the input in `text-destructive` color
+- Input border changes to `border-destructive` via `aria-invalid` CSS (already exists in components)
+- Error ring appears on focus in `ring-destructive` (already exists in components)
+- Error text clears when the user starts editing the field
+
+### 8.3 Form-Level Error Banner
+
+- Displays when the server returns a general error (not tied to a specific field)
+- Examples: "Invalid credentials", "Account already exists", "Service unavailable"
+- Styled as a destructive alert with icon
+- Positioned at the top of the form
+
+### 8.4 Client-Side Validation
+
+- Uses the same Zod schema from `@enterprise/contracts` to validate before submission
+- Provides instant feedback without server round-trip
+- Does NOT replace server-side validation (server is always authoritative)
+- Triggered on form submit (not on every keystroke by default)
+
+### 8.5 Pending State
+
+- Submit button shows loading state and is disabled during submission
+- Uses `useFormStatus` or `isPending` from `useActionState`
+- Prevents double-submission
+
+### 8.6 Success Feedback
+
+- Mutations show a success message or navigate to the appropriate page
+- Auth forms redirect after success (existing behavior, preserved)
+
+---
+
+## 9. Non-Functional Requirements
+
+- **Accessible** — `aria-invalid`, `aria-describedby`, focus management on error
+- **Consistent** — Same visual pattern and behavior across all forms
+- **Performant** — Client-side validation is synchronous, no extra network calls
+- **Progressive** — Forms work without JavaScript (server validation + redirect as fallback)
+- **Reusable** — Shared components reduce per-form boilerplate to near zero
+- **Documented** — Agent skill ensures AI assistants follow the pattern correctly
+
+---
+
+## 10. Success Metrics
+
+### Product
+
+- Zero silent form failures (every submission error produces visible user feedback)
+- All 6 forms display field-level errors inline
+- Reduction in support tickets related to "login not working"
+
+### Technical
+
+- Shared `FormField` component used in 100% of forms
+- `aria-invalid` set on every errored input
+- Single validation pattern (`useActionState` + `ActionResult`) across all forms
+- `form-validation` skill followed for all new form development
+- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm e2e` all pass
+
+---
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Auth forms must become Client Components | Use thin Client Component wrappers for the form only; the page layout remains Server Component |
+| Client-side Zod schemas increase bundle size | Use dynamic imports or validate only on submit, not on every keystroke |
+| Changing auth error flow may break redirect behavior | Preserve redirect on success; only change error flow |
+| Too many simultaneous form changes | Implement in phases — shared components first, then migrate forms one by one |
+
+---
+
+## 12. Definition of Success
+
+The system will be successful if:
+
+- **Every form error produces visible, specific feedback** — never a silent reload
+- Users can **identify and fix validation errors without guessing**
+- Developers can **build a new validated form in under 30 minutes** using shared components
+- The pattern is **documented in a skill** that AI agents follow automatically
+- All forms pass **accessibility audit** for form validation (WCAG 2.1 Level AA)
+
+---
+
+## 13. Implementation Phases
+
+### Phase 1 — Shared Components + Utilities
+
+- Create `FormField`, `FormMessage` in `@enterprise/ui`
+- Extract `getFieldError` and `FieldErrors` type to `@enterprise/contracts`
+- Unit tests for utilities
+
+### Phase 2 — Auth Form Migration
+
+- Convert auth forms to use `useActionState` + `ActionResult` error flow
+- Fix sign-in action to return credential errors
+- Fix reset-password to surface "passwords don't match"
+- Add `noValidate` + client-side Zod validation
+- Add pending state to all auth submit buttons
+- E2E tests for auth validation flows
+
+### Phase 3 — Resource Form Upgrade
+
+- Migrate resource form to use shared `FormField` component
+- Add `aria-invalid` to all fields
+- Add client-side Zod validation
+- E2E tests for resource validation flows
+
+### Phase 4 — Skill + Documentation
+
+- Create `form-validation` skill with canonical patterns
+- Update `ui/AGENTS.md` to replace incorrect `react-hook-form` references
+- Architecture documentation in `docs/architecture/`
+
+---
+
+## 14. In One Sentence
+
+> A unified form validation UX system that provides inline field errors, server error propagation, and accessible error states across all forms — with shared components, a documented pattern, and an agent skill to enforce consistency.

--- a/docs/rfc-form-validation.md
+++ b/docs/rfc-form-validation.md
@@ -1,0 +1,780 @@
+# RFC — Form Validation UX System Architecture
+
+## 1. Summary
+
+This document defines how form validation will be architected across the Enterprise Platform to provide consistent, accessible, inline error feedback on every form.
+
+The system will:
+
+- Provide shared `FormField` and `FormMessage` components in `@enterprise/ui`
+- Extract a typed `getFieldError` utility and `FieldErrors` type to `@enterprise/contracts`
+- Standardize all forms on the `useActionState` + `ActionResult<T>` pattern
+- Add client-side Zod validation for instant feedback before server round-trips
+- Set `aria-invalid` and `aria-describedby` on errored inputs automatically
+- Suppress HTML5 native validation in favor of custom inline error display
+- Migrate all 4 auth forms from redirect-on-error to structured error flow
+
+### What this RFC is NOT
+
+- A form library replacement (no `react-hook-form`, no `formik`)
+- A multi-step wizard system
+- Real-time async field validation (debounced uniqueness checks, etc.)
+
+---
+
+## 2. Technical Objective
+
+Design a form validation layer that:
+
+1. Uses `useActionState` + `ActionResult<T>` as the **single error propagation pattern** for all forms
+2. Provides shared components that handle error display, `aria-invalid`, and `aria-describedby` automatically
+3. Supports **dual validation**: client-side Zod for instant feedback + server-side Zod as authoritative source
+4. Works with existing `@enterprise/ui` primitives (Input, Textarea, Select) without modifying them
+5. Is fully documented in a `form-validation` agent skill
+
+---
+
+## 3. Architecture
+
+### Error Flow
+
+```text
+User submits form
+    │
+    ▼
+Client-side Zod validation (optional, instant)
+    │  schema.safeParse(formData) → fieldErrors
+    │  if errors → display inline, do NOT submit
+    │
+    ▼ (no client errors)
+Server Action receives FormData
+    │
+    ▼
+Server-side Zod validation (authoritative)
+    │  schema.safeParse(input) → flatten().fieldErrors
+    │  if errors → return ActionResult { success: false, error: { details: fieldErrors } }
+    │
+    ▼ (no Zod errors)
+Service layer executes business logic
+    │  if failure → return ActionResult { success: false, error: { message: "..." } }
+    │
+    ▼ (success)
+Return ActionResult { success: true, data: result }
+    │
+    ▼
+useActionState receives new state
+    │
+    ▼
+FormField reads state → displays field errors inline
+Form reads state → displays form-level error banner or success
+```
+
+### Component Hierarchy
+
+```text
+<form action={formAction} noValidate>
+    │
+    ├── <FormBanner state={state} />              ← form-level error/success
+    │
+    ├── <FormField name="email" label="Email" state={state} required>
+    │       ├── <Label htmlFor="email">Email *</Label>
+    │       ├── <Input id="email" name="email" aria-invalid={true} aria-describedby="email-error" />
+    │       └── <FormMessage id="email-error">Enter a valid email address</FormMessage>
+    │
+    ├── <FormField name="password" label="Password" state={state} required>
+    │       ├── <Label htmlFor="password">Password *</Label>
+    │       ├── <Input id="password" name="password" />
+    │       └── (no error → no FormMessage rendered)
+    │
+    └── <SubmitButton>Sign in</SubmitButton>      ← uses useFormStatus for pending
+```
+
+### Package Ownership
+
+```text
+@enterprise/contracts
+ ├── src/types/platform.ts        → ActionResult, ActionError (existing)
+ ├── src/types/form.ts            → FieldErrors type, getFieldError utility
+ └── src/index.ts                 → Re-exports new types
+
+@enterprise/ui
+ ├── src/components/form-field.tsx → FormField composition component (NEW)
+ ├── src/components/form-message.tsx → FormMessage error text component (NEW)
+ ├── src/components/form-banner.tsx  → FormBanner error/success banner (NEW)
+ ├── src/components/submit-button.tsx → SubmitButton with useFormStatus (NEW)
+ ├── src/components/input.tsx      → UNCHANGED (aria-invalid styles already exist)
+ ├── src/components/textarea.tsx   → UNCHANGED (aria-invalid styles already exist)
+ ├── src/components/select.tsx     → UNCHANGED (aria-invalid styles already exist)
+ └── src/hooks/use-form-validation.ts → Client-side Zod validation hook (NEW)
+
+@enterprise/web (ui/)
+ ├── features/auth/components/     → Client Component wrappers for auth forms (NEW)
+ ├── features/auth/actions.ts      → MODIFIED (return ActionResult instead of redirect on error)
+ ├── features/resources/components/resource-form.tsx → MODIFIED (use shared FormField)
+ └── app/(auth)/sign-in/page.tsx   → MODIFIED (use new client form component)
+```
+
+### Dependency Direction (respected)
+
+```text
+@enterprise/contracts → zod ONLY (defines FieldErrors type)
+@enterprise/ui → @enterprise/contracts (imports FieldErrors, ActionResult for component props)
+@enterprise/web → @enterprise/contracts, @enterprise/ui (uses components + types)
+```
+
+No new packages. No circular dependencies.
+
+---
+
+## 4. Contracts: Types and Utilities
+
+### FieldErrors Type
+
+New file: `packages/contracts/src/types/form.ts`
+
+```typescript
+/** Field-level validation errors from Zod flatten().fieldErrors */
+export type FieldErrors = Record<string, string[]>;
+
+/**
+ * Extract the first error message for a given field from an ActionResult.
+ *
+ * @param result - The ActionResult from useActionState (can be null on initial render)
+ * @param field - The field name to look up
+ * @returns The first error message, or undefined if no error
+ */
+export function getFieldError<T>(
+  result: ActionResult<T> | null,
+  field: string,
+): string | undefined {
+  if (!result || result.success) return undefined;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details?.[field]?.[0];
+}
+
+/**
+ * Check if the ActionResult has any field-level errors (vs only a form-level error).
+ */
+export function hasFieldErrors<T>(result: ActionResult<T> | null): boolean {
+  if (!result || result.success) return false;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details !== undefined && Object.keys(details).length > 0;
+}
+```
+
+### Updated ActionError Details Type
+
+The existing `ActionError.details` typed as `Record<string, unknown>` is intentionally kept loose for extensibility. The `getFieldError` utility handles the cast internally. No breaking changes.
+
+---
+
+## 5. Shared Components
+
+### FormField
+
+New file: `packages/ui/src/components/form-field.tsx`
+
+```tsx
+import type { ActionResult } from "@enterprise/contracts";
+import { getFieldError } from "@enterprise/contracts";
+import { Label } from "@enterprise/ui/components/label";
+import { FormMessage } from "@enterprise/ui/components/form-message";
+import { cn } from "@enterprise/ui/lib/utils";
+import {
+  type ReactElement,
+  type ReactNode,
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+} from "react";
+
+interface FormFieldProps {
+  /** Field name matching the input's name attribute and the Zod schema key */
+  name: string;
+  /** Label text */
+  label: string;
+  /** ActionResult from useActionState — reads field errors from here */
+  state: ActionResult | null;
+  /** Mark field as required (shows * indicator on label) */
+  required?: boolean;
+  /** Optional description text below the input */
+  description?: string;
+  /** Additional CSS classes on the wrapper */
+  className?: string;
+  /** The input element (Input, Textarea, Select, etc.) */
+  children: ReactNode;
+}
+
+export function FormField({
+  name,
+  label,
+  state,
+  required = false,
+  description,
+  className,
+  children,
+}: FormFieldProps) {
+  const autoId = useId();
+  const fieldId = `${name}-${autoId}`;
+  const errorId = `${fieldId}-error`;
+  const descriptionId = description ? `${fieldId}-desc` : undefined;
+  const error = getFieldError(state, name);
+  const hasError = Boolean(error);
+
+  // Clone the child input to inject aria attributes
+  const enhancedChildren = Children.map(children, (child) => {
+    if (!isValidElement(child)) return child;
+    return cloneElement(child as ReactElement<Record<string, unknown>>, {
+      id: fieldId,
+      name,
+      "aria-invalid": hasError || undefined,
+      "aria-describedby": [
+        hasError ? errorId : undefined,
+        descriptionId,
+      ]
+        .filter(Boolean)
+        .join(" ") || undefined,
+    });
+  });
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Label htmlFor={fieldId}>
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </Label>
+      {enhancedChildren}
+      {description && (
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {hasError && <FormMessage id={errorId}>{error}</FormMessage>}
+    </div>
+  );
+}
+```
+
+### FormMessage
+
+New file: `packages/ui/src/components/form-message.tsx`
+
+```tsx
+import { cn } from "@enterprise/ui/lib/utils";
+import type { ReactNode } from "react";
+
+interface FormMessageProps {
+  id?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FormMessage({ id, children, className }: FormMessageProps) {
+  if (!children) return null;
+
+  return (
+    <p
+      id={id}
+      role="alert"
+      className={cn("text-xs text-destructive", className)}
+    >
+      {children}
+    </p>
+  );
+}
+```
+
+### FormBanner
+
+New file: `packages/ui/src/components/form-banner.tsx`
+
+```tsx
+import type { ActionResult } from "@enterprise/contracts";
+import { hasFieldErrors } from "@enterprise/contracts";
+import { cn } from "@enterprise/ui/lib/utils";
+
+interface FormBannerProps<T> {
+  state: ActionResult<T> | null;
+  /** Message shown on success. If undefined, no success banner is shown. */
+  successMessage?: string;
+  className?: string;
+}
+
+export function FormBanner<T>({
+  state,
+  successMessage,
+  className,
+}: FormBannerProps<T>) {
+  if (!state) return null;
+
+  // Success
+  if (state.success && successMessage) {
+    return (
+      <p className={cn("rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-500", className)}>
+        {successMessage}
+      </p>
+    );
+  }
+
+  // Error — but only show banner for form-level errors, not field-level
+  if (!state.success && !hasFieldErrors(state)) {
+    return (
+      <p
+        role="alert"
+        className={cn(
+          "rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive",
+          className,
+        )}
+      >
+        {state.error?.message ?? "An error occurred. Please try again."}
+      </p>
+    );
+  }
+
+  return null;
+}
+```
+
+### SubmitButton
+
+New file: `packages/ui/src/components/submit-button.tsx`
+
+```tsx
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import type { ComponentProps } from "react";
+import { useFormStatus } from "react-dom";
+
+interface SubmitButtonProps extends Omit<ComponentProps<typeof Button>, "type" | "disabled"> {
+  /** Text shown while form is submitting */
+  pendingText?: string;
+}
+
+export function SubmitButton({
+  children,
+  pendingText = "Saving…",
+  ...props
+}: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending} {...props}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}
+```
+
+---
+
+## 6. Client-Side Validation Hook
+
+New file: `packages/ui/src/hooks/use-form-validation.ts`
+
+```typescript
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import type { ZodSchema } from "zod";
+import { useCallback, useRef } from "react";
+
+interface UseFormValidationOptions<T> {
+  /** Zod schema to validate against (same schema used server-side) */
+  schema: ZodSchema;
+  /** The server action wrapped by useActionState */
+  serverAction: (
+    prevState: ActionResult<T> | null,
+    formData: FormData,
+  ) => Promise<ActionResult<T>>;
+}
+
+/**
+ * Wraps a server action with client-side Zod validation.
+ * Returns a new action function that validates client-side first,
+ * returning field errors immediately without a server round-trip.
+ *
+ * Usage:
+ *   const validatedAction = useFormValidation({ schema: loginDto, serverAction: signInAction });
+ *   const [state, formAction, isPending] = useActionState(validatedAction, null);
+ */
+export function useFormValidation<T>({
+  schema,
+  serverAction,
+}: UseFormValidationOptions<T>) {
+  const serverActionRef = useRef(serverAction);
+  serverActionRef.current = serverAction;
+
+  return useCallback(
+    async (
+      prevState: ActionResult<T> | null,
+      formData: FormData,
+    ): Promise<ActionResult<T>> => {
+      // Convert FormData to plain object for Zod validation
+      const rawData: Record<string, unknown> = {};
+      for (const [key, value] of formData.entries()) {
+        rawData[key] = value;
+      }
+
+      const result = schema.safeParse(rawData);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Please fix the errors below.",
+            details: fieldErrors as Record<string, unknown>,
+          },
+        } as ActionResult<T>;
+      }
+
+      // Client validation passed — proceed to server
+      return serverActionRef.current(prevState, formData);
+    },
+    [schema],
+  );
+}
+```
+
+---
+
+## 7. Auth Form Migration
+
+### Current Pattern (redirect-on-error)
+
+```typescript
+// ❌ Current: ui/features/auth/actions.ts
+export async function signInAction(formData: FormData) {
+  const raw = { email: formData.get("email"), password: formData.get("password") };
+  const parsed = loginDto.safeParse(raw);
+  if (!parsed.success) {
+    redirect("/sign-in"); // Silent — no error feedback
+  }
+  const result = await signIn(client, parsed.data);
+  if (result.error) {
+    redirect("/sign-in"); // Silent — no error feedback
+  }
+  redirect("/dashboard");
+}
+```
+
+### New Pattern (ActionResult-based)
+
+```typescript
+// ✅ New: ui/features/auth/actions.ts
+export async function signInAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = { email: formData.get("email"), password: formData.get("password") };
+  const parsed = loginDto.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: parsed.error.flatten().fieldErrors,
+      },
+    };
+  }
+
+  const client = await createAuthClient();
+  const result = await signIn(client, parsed.data);
+
+  if (result.error) {
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+  }
+
+  redirect("/dashboard");
+}
+```
+
+### Auth Form Component Migration
+
+Auth pages are currently Server Components with inline `<form>` elements. Since `useActionState` requires a Client Component, we create thin Client Component wrappers:
+
+```text
+ui/features/auth/components/
+ ├── sign-in-form.tsx    ← "use client", uses useActionState
+ ├── sign-up-form.tsx    ← "use client", uses useActionState
+ ├── forgot-password-form.tsx
+ └── reset-password-form.tsx
+```
+
+The page files (`ui/app/(auth)/sign-in/page.tsx`, etc.) remain Server Components that render the layout and import the form component.
+
+### Example: Sign-In Form Component
+
+```tsx
+// ✅ New: ui/features/auth/components/sign-in-form.tsx
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { loginDto } from "@enterprise/contracts";
+import { Input } from "@enterprise/ui/components/input";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { signInAction } from "@/features/auth/actions";
+
+export function SignInForm() {
+  const validatedAction = useFormValidation({
+    schema: loginDto,
+    serverAction: signInAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="email" label="Email" state={state} required>
+        <Input type="email" placeholder="you@example.com" />
+      </FormField>
+
+      <FormField name="password" label="Password" state={state} required>
+        <Input type="password" placeholder="Your password" />
+      </FormField>
+
+      <SubmitButton pendingText="Signing in…">Sign in</SubmitButton>
+    </form>
+  );
+}
+```
+
+Compare this with the current 80+ lines of form markup + error URL param parsing. The new version is ~25 lines with full inline validation, server error display, pending state, and accessibility.
+
+---
+
+## 8. Migrated Resource Form (Before/After)
+
+### Before (current)
+
+```tsx
+// ❌ Current: Manual getFieldError, no aria-invalid, no shared components
+<div className="flex flex-col gap-1.5 sm:col-span-2">
+  <Label htmlFor="title">
+    Title <span className="text-destructive">*</span>
+  </Label>
+  <Input id="title" name="title" required defaultValue={defaultValues?.title ?? ""} />
+  {getFieldError(state, "title") && (
+    <p className="text-xs text-destructive">{getFieldError(state, "title")}</p>
+  )}
+</div>
+```
+
+### After (migrated)
+
+```tsx
+// ✅ New: Shared FormField handles everything
+<FormField name="title" label="Title" state={state} required className="sm:col-span-2">
+  <Input defaultValue={defaultValues?.title ?? ""} placeholder="Resource title" />
+</FormField>
+```
+
+The `FormField` component handles:
+- Label rendering with required indicator
+- `id` generation and `htmlFor` binding
+- `aria-invalid` on the input when error exists
+- `aria-describedby` linking input to error message
+- Error message rendering below the input
+
+---
+
+## 9. Validation Behavior Specification
+
+### When Validation Runs
+
+| Trigger | What Happens |
+|---------|-------------|
+| Form submit (with `useFormValidation`) | Client-side Zod validates first. If errors, they show inline without server call. |
+| Form submit (server-side) | Server Action runs Zod `safeParse`. If errors, returns `ActionResult` with field errors. |
+| User edits an errored field | Error stays visible until next form submission (no real-time clearing in V1). |
+| Server business logic fails | Form-level error banner shows the server message. |
+
+### Error Priority
+
+```
+Is it a field-level error (from Zod)?
+├── Yes → Show inline below the specific field, set aria-invalid
+│         If MULTIPLE fields have errors → show ALL of them simultaneously
+└── No
+    └── Is it a form-level error (from service/auth)?
+        └── Yes → Show in FormBanner at top of form
+```
+
+### HTML5 Validation Suppression
+
+All forms use `noValidate` attribute:
+
+```tsx
+<form action={formAction} noValidate>
+```
+
+This prevents browser-native validation popups. Custom validation (via Zod) provides the same rules with better UX (inline messages, consistent styling, accessible markup).
+
+---
+
+## 10. Technical Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No `react-hook-form` | The project already uses native `<form>` + `useActionState`. Adding RHF would introduce a second form paradigm and a new dependency. The current pattern works well with shared components. |
+| `noValidate` on all forms | Prevents inconsistent browser popups. Custom validation provides the same rules with better UX. |
+| `useFormValidation` hook for client-side | Reuses the same Zod schema used server-side. Single source of truth for validation rules. |
+| `FormField` uses `cloneElement` | Injects `aria-invalid` and `aria-describedby` without requiring the input to know about form state. Keeps Input/Textarea/Select unchanged. |
+| Error stays until re-submit (V1) | Simpler implementation. Real-time clearing requires `onChange` handlers and client state, which adds complexity. Can be added in V2. |
+| Auth actions return `ActionResult` instead of `redirect` on error | Enables structured error display. `redirect` on success is preserved. |
+| `role="alert"` on FormMessage | Screen readers announce new error messages when they appear. |
+
+---
+
+## 11. Trade-offs
+
+### Prioritized
+
+- **Simplicity**: Shared components, no new form library
+- **Consistency**: Same pattern and components across all forms
+- **Accessibility**: `aria-invalid`, `aria-describedby`, `role="alert"` on errors
+- **Progressive enhancement**: Forms still work without JS (server validation + redirect fallback)
+
+### Sacrificed
+
+- Real-time field clearing on edit (deferred to V2 — requires onChange handlers)
+- Async validation (e.g., check email uniqueness while typing — deferred)
+- `react-hook-form` integration (project uses native forms, no reason to add RHF)
+- Password strength meter (UI enhancement, not core validation)
+
+---
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Auth pages must have Client Component children | Minor — the page layout stays Server Component, only the form is Client Component | Create thin `SignInForm` wrappers, page passes no sensitive data |
+| `cloneElement` is fragile with wrapper components | `FormField` assumes direct child is the input | Document in skill that the input must be the direct child of `FormField` |
+| Client-side Zod validation increases bundle | Zod schemas are already imported for types | Schemas are small; measure impact and tree-shake if needed |
+| Changing auth actions breaks OAuth callback flows | OAuth flows (`/auth/callback`) use different code paths | Only modify email/password auth actions, OAuth is untouched |
+| Double validation (client + server) feels redundant | Server validation is always authoritative | Client validation is for UX speed only, server always re-validates |
+
+---
+
+## 13. Implementation Plan
+
+### Phase 1 — Contracts + Shared Components (no visual changes)
+
+1. Create `packages/contracts/src/types/form.ts` — `FieldErrors`, `getFieldError`, `hasFieldErrors`
+2. Export from contracts barrel
+3. Create `packages/ui/src/components/form-field.tsx`
+4. Create `packages/ui/src/components/form-message.tsx`
+5. Create `packages/ui/src/components/form-banner.tsx`
+6. Create `packages/ui/src/components/submit-button.tsx`
+7. Create `packages/ui/src/hooks/use-form-validation.ts`
+8. Export all from ui barrel
+9. Unit tests for `getFieldError`, `hasFieldErrors`, `useFormValidation`
+
+**Tests**: Utilities return correct values for various `ActionResult` shapes. Components render error states correctly.
+
+### Phase 2 — Auth Form Migration
+
+1. Modify `ui/features/auth/actions.ts` — all 4 actions return `ActionResult` on error
+2. Create `ui/features/auth/components/sign-in-form.tsx` using `FormField` + `useActionState`
+3. Create `ui/features/auth/components/sign-up-form.tsx`
+4. Create `ui/features/auth/components/forgot-password-form.tsx`
+5. Create `ui/features/auth/components/reset-password-form.tsx`
+6. Update page files to import new form components
+7. Add client-side Zod validation via `useFormValidation` on each form
+8. E2E tests: sign-in with invalid credentials shows error, sign-up with short password shows field error
+
+**Tests**: E2E tests for every auth form validation scenario. Unit tests for action error returns.
+
+### Phase 3 — Resource Form Migration
+
+1. Refactor `resource-form.tsx` to use shared `FormField` instead of manual error display
+2. Remove local `getFieldError` function (use imported utility)
+3. Add `noValidate` to form
+4. Add client-side Zod validation
+5. Verify `aria-invalid` activates destructive styles on Input/Textarea
+
+**Tests**: E2E tests for resource form validation. Visual regression check.
+
+### Phase 4 — Skill + Documentation
+
+1. Create `form-validation` agent skill
+2. Update `ui/AGENTS.md` to replace `react-hook-form` references with actual pattern
+3. Add auto-invoke entries for the new skill
+
+---
+
+## 14. Acceptance Criteria
+
+1. All 6 forms display inline field-level errors below the errored input
+2. All errored inputs show `border-destructive` via `aria-invalid` CSS
+3. The sign-in form displays "Invalid email or password" on credential failure
+4. The reset-password form displays "Passwords do not match" on mismatch
+5. All forms use `noValidate` — no HTML5 browser popups
+6. All forms have pending state on the submit button
+7. `FormField`, `FormMessage`, `FormBanner`, `SubmitButton` exist in `@enterprise/ui`
+8. `getFieldError` and `FieldErrors` are exported from `@enterprise/contracts`
+9. Client-side Zod validation fires before server submission on all forms
+10. Screen readers announce error messages via `role="alert"` and `aria-describedby`
+11. `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm e2e` pass
+12. `form-validation` skill exists and is referenced in AGENTS.md auto-invoke table
+
+---
+
+## 15. File Inventory
+
+### New Files
+
+| File | Package | Purpose |
+|------|---------|---------|
+| `src/types/form.ts` | contracts | FieldErrors type, getFieldError, hasFieldErrors |
+| `src/components/form-field.tsx` | ui | FormField composition component |
+| `src/components/form-message.tsx` | ui | Error message component |
+| `src/components/form-banner.tsx` | ui | Form-level error/success banner |
+| `src/components/submit-button.tsx` | ui | Submit button with pending state |
+| `src/hooks/use-form-validation.ts` | ui | Client-side Zod validation hook |
+| `features/auth/components/sign-in-form.tsx` | web | Sign-in form (Client Component) |
+| `features/auth/components/sign-up-form.tsx` | web | Sign-up form (Client Component) |
+| `features/auth/components/forgot-password-form.tsx` | web | Forgot password form |
+| `features/auth/components/reset-password-form.tsx` | web | Reset password form |
+| `skills/form-validation/SKILL.md` | skills | Agent skill for form validation patterns |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `packages/contracts/src/index.ts` | Export FieldErrors, getFieldError, hasFieldErrors |
+| `packages/ui/src/index.ts` | Export FormField, FormMessage, FormBanner, SubmitButton, useFormValidation |
+| `ui/features/auth/actions.ts` | Return ActionResult on error instead of redirect |
+| `ui/features/resources/components/resource-form.tsx` | Use shared FormField, remove local getFieldError |
+| `ui/app/(auth)/sign-in/page.tsx` | Import SignInForm component |
+| `ui/app/(auth)/sign-up/page.tsx` | Import SignUpForm component |
+| `ui/app/(auth)/forgot-password/page.tsx` | Import ForgotPasswordForm component |
+| `ui/app/(auth)/reset-password/page.tsx` | Import ResetPasswordForm component |
+| `ui/AGENTS.md` | Replace react-hook-form references, add form-validation skill |
+| `AGENTS.md` | Add form-validation to auto-invoke table |
+
+### Deleted Files
+
+None. The current auth form markup is replaced by imported components. The local `getFieldError` in resource-form.tsx is removed (replaced by import from contracts).
+
+---
+
+## 16. In One Sentence
+
+> A shared form validation system using `useActionState` + `ActionResult<T>` with reusable `FormField`/`FormMessage` components, client-side Zod pre-validation, and accessible error states — standardizing all forms from auth to CRUD with inline field errors and server error propagation.

--- a/packages/contracts/src/__tests__/form.test.ts
+++ b/packages/contracts/src/__tests__/form.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { getFieldError, hasFieldErrors } from "../types/form";
+import type { ActionResult } from "../types/platform";
+
+// ---------------------------------------------------------------------------
+// getFieldError
+// ---------------------------------------------------------------------------
+
+describe("getFieldError", () => {
+  it("returns undefined when result is null (initial state)", () => {
+    expect(getFieldError(null, "email")).toBeUndefined();
+  });
+
+  it("returns undefined when result is a success", () => {
+    const result: ActionResult = { success: true, data: undefined };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+
+  it("returns the first error string when the field has errors", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required", "Must be a valid email"] },
+      },
+    };
+    expect(getFieldError(result, "email")).toBe("Required");
+  });
+
+  it("returns undefined when the field key is missing from details", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { password: ["Required"] },
+      },
+    };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+
+  it("returns undefined when error has no details object", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    expect(getFieldError(result, "email")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasFieldErrors
+// ---------------------------------------------------------------------------
+
+describe("hasFieldErrors", () => {
+  it("returns false when result is null (initial state)", () => {
+    expect(hasFieldErrors(null)).toBe(false);
+  });
+
+  it("returns false when result is a success", () => {
+    const result: ActionResult = { success: true, data: undefined };
+    expect(hasFieldErrors(result)).toBe(false);
+  });
+
+  it("returns true when error details has at least one key", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required"] },
+      },
+    };
+    expect(hasFieldErrors(result)).toBe(true);
+  });
+
+  it("returns false when error has no details object", () => {
+    const result: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    expect(hasFieldErrors(result)).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -58,6 +58,7 @@ export {
   typographySchema,
 } from "./schemas/theme";
 // Types
+export * from "./types/form";
 export * from "./types/platform";
 export * from "./types/resources";
 export * from "./types/theme";

--- a/packages/contracts/src/types/form.ts
+++ b/packages/contracts/src/types/form.ts
@@ -1,0 +1,29 @@
+import type { ActionResult } from "./platform";
+
+/** Field-level validation errors from Zod flatten().fieldErrors */
+export type FieldErrors = Record<string, string[]>;
+
+/**
+ * Extract the first error message for a given field from an ActionResult.
+ *
+ * @param result - The ActionResult from useActionState (can be null on initial render)
+ * @param field - The field name to look up
+ * @returns The first error message, or undefined if no error
+ */
+export function getFieldError<T>(
+  result: ActionResult<T> | null,
+  field: string,
+): string | undefined {
+  if (!result || result.success) return undefined;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details?.[field]?.[0];
+}
+
+/**
+ * Check if the ActionResult has any field-level errors (vs only a form-level error).
+ */
+export function hasFieldErrors<T>(result: ActionResult<T> | null): boolean {
+  if (!result || result.success) return false;
+  const details = result.error?.details as FieldErrors | undefined;
+  return details !== undefined && Object.keys(details).length > 0;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,8 @@
     "./lib/*": "./src/lib/*.ts",
     "./theme/context": "./src/theme/context.ts",
     "./theme/provider": "./src/theme/provider.tsx",
-    "./theme/toggle": "./src/theme/toggle.tsx"
+    "./theme/toggle": "./src/theme/toggle.tsx",
+    "./hooks/*": "./src/hooks/*.ts"
   },
   "scripts": {
     "build:theme": "tsx scripts/build-theme.ts",

--- a/packages/ui/src/components/__tests__/form-banner.test.ts
+++ b/packages/ui/src/components/__tests__/form-banner.test.ts
@@ -1,0 +1,60 @@
+/**
+ * FormBanner — unit tests
+ *
+ * Tests the exported FormBanner component's render logic.
+ * We invoke the component function directly since it has simple conditional logic.
+ */
+
+import type { ActionResult } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
+import { FormBanner } from "../form-banner";
+
+describe("FormBanner", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormBanner).toBe("function");
+  });
+
+  it("returns null when state is null", () => {
+    const result = FormBanner({ state: null });
+    expect(result).toBeNull();
+  });
+
+  it("renders error banner for form-level error (no field-level errors)", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
+    const result = FormBanner({ state });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("returns null when there are field-level errors (banner is not shown)", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Required"] },
+      },
+    };
+    const result = FormBanner({ state });
+    expect(result).toBeNull();
+  });
+
+  it("renders success banner when state is successful and successMessage provided", () => {
+    const state: ActionResult = { success: true, data: undefined };
+    const result = FormBanner({ state, successMessage: "Saved successfully." });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+
+  it("returns null when state is successful but no successMessage provided", () => {
+    const state: ActionResult = { success: true, data: undefined };
+    const result = FormBanner({ state });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/ui/src/components/__tests__/form-field.test.ts
+++ b/packages/ui/src/components/__tests__/form-field.test.ts
@@ -1,0 +1,19 @@
+/**
+ * FormField — unit tests
+ *
+ * FormField uses `useId` and `cloneElement` which require a React rendering
+ * context. In node environment without a DOM, we verify the module exports
+ * and the component's interface contract.
+ */
+import { describe, expect, it } from "vitest";
+import { FormField } from "../form-field";
+
+describe("FormField", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormField).toBe("function");
+  });
+
+  it("has the correct display name / function name", () => {
+    expect(FormField.name).toBe("FormField");
+  });
+});

--- a/packages/ui/src/components/__tests__/form-message.test.ts
+++ b/packages/ui/src/components/__tests__/form-message.test.ts
@@ -1,0 +1,34 @@
+/**
+ * FormMessage — unit tests
+ *
+ * Tests the exported FormMessage component's render logic.
+ * Since the ui project runs in a node environment without a DOM,
+ * we test the module exports and confirm the component is exported correctly.
+ * The core logic (returns null when children is falsy) is a conditional return —
+ * validated here by confirming the component is a function with the right shape.
+ */
+import { describe, expect, it } from "vitest";
+import { FormMessage } from "../form-message";
+
+describe("FormMessage", () => {
+  it("is a named export and a function", () => {
+    expect(typeof FormMessage).toBe("function");
+  });
+
+  it("returns null when children is falsy (empty string)", () => {
+    // Invoke component function directly — no DOM needed for null-return check
+    const result = FormMessage({ children: "" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when children is undefined", () => {
+    const result = FormMessage({ children: undefined });
+    expect(result).toBeNull();
+  });
+
+  it("returns a React element when children is a non-empty string", () => {
+    const result = FormMessage({ children: "Required" });
+    expect(result).not.toBeNull();
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/ui/src/components/__tests__/submit-button.test.ts
+++ b/packages/ui/src/components/__tests__/submit-button.test.ts
@@ -1,0 +1,19 @@
+/**
+ * SubmitButton — unit tests
+ *
+ * SubmitButton uses `useFormStatus` which requires a React rendering context.
+ * In node environment without a DOM, we verify the module exports and
+ * the component's interface contract.
+ */
+import { describe, expect, it } from "vitest";
+import { SubmitButton } from "../submit-button";
+
+describe("SubmitButton", () => {
+  it("is a named export and a function", () => {
+    expect(typeof SubmitButton).toBe("function");
+  });
+
+  it("has the correct display name / function name", () => {
+    expect(SubmitButton.name).toBe("SubmitButton");
+  });
+});

--- a/packages/ui/src/components/form-banner.tsx
+++ b/packages/ui/src/components/form-banner.tsx
@@ -1,0 +1,37 @@
+import type { ActionResult } from "@enterprise/contracts";
+import { hasFieldErrors } from "@enterprise/contracts";
+import { cn } from "@enterprise/ui/lib/utils";
+
+interface FormBannerProps<T> {
+  state: ActionResult<T> | null;
+  /** Message shown on success. If undefined, no success banner is shown. */
+  successMessage?: string;
+  className?: string;
+}
+
+export function FormBanner<T>({ state, successMessage, className }: FormBannerProps<T>) {
+  if (!state) return null;
+
+  // Success
+  if (state.success && successMessage) {
+    return (
+      <p className={cn("rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-500", className)}>
+        {successMessage}
+      </p>
+    );
+  }
+
+  // Error — but only show banner for form-level errors, not field-level
+  if (!state.success && !hasFieldErrors(state)) {
+    return (
+      <p
+        role="alert"
+        className={cn("rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive", className)}
+      >
+        {state.error?.message ?? "An error occurred. Please try again."}
+      </p>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui/src/components/form-field.tsx
+++ b/packages/ui/src/components/form-field.tsx
@@ -1,0 +1,75 @@
+import type { ActionResult } from "@enterprise/contracts";
+import { getFieldError } from "@enterprise/contracts";
+import { FormMessage } from "@enterprise/ui/components/form-message";
+import { Label } from "@enterprise/ui/components/label";
+import { cn } from "@enterprise/ui/lib/utils";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useId,
+} from "react";
+
+interface FormFieldProps {
+  /** Field name matching the input's name attribute and the Zod schema key */
+  name: string;
+  /** Label text */
+  label: string;
+  /** ActionResult from useActionState — reads field errors from here */
+  state: ActionResult | null;
+  /** Mark field as required (shows * indicator on label) */
+  required?: boolean;
+  /** Optional description text below the input */
+  description?: string;
+  /** Additional CSS classes on the wrapper */
+  className?: string;
+  /** The input element (Input, Textarea, Select, etc.) — must be the direct child */
+  children: ReactNode;
+}
+
+export function FormField({
+  name,
+  label,
+  state,
+  required = false,
+  description,
+  className,
+  children,
+}: FormFieldProps) {
+  const autoId = useId();
+  const fieldId = `${name}-${autoId}`;
+  const errorId = `${fieldId}-error`;
+  const descriptionId = description ? `${fieldId}-desc` : undefined;
+  const error = getFieldError(state, name);
+  const hasError = Boolean(error);
+
+  // Clone the child input to inject aria attributes
+  const enhancedChildren = Children.map(children, (child) => {
+    if (!isValidElement(child)) return child;
+    return cloneElement(child as ReactElement<Record<string, unknown>>, {
+      id: fieldId,
+      name,
+      "aria-invalid": hasError || undefined,
+      "aria-describedby":
+        [hasError ? errorId : undefined, descriptionId].filter(Boolean).join(" ") || undefined,
+    });
+  });
+
+  return (
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <Label htmlFor={fieldId}>
+        {label}
+        {required && <span className="text-destructive"> *</span>}
+      </Label>
+      {enhancedChildren}
+      {description && (
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {hasError && <FormMessage id={errorId}>{error}</FormMessage>}
+    </div>
+  );
+}

--- a/packages/ui/src/components/form-message.tsx
+++ b/packages/ui/src/components/form-message.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@enterprise/ui/lib/utils";
+import type { ReactNode } from "react";
+
+interface FormMessageProps {
+  id?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FormMessage({ id, children, className }: FormMessageProps) {
+  if (!children) return null;
+
+  return (
+    <p id={id} role="alert" className={cn("text-xs text-destructive", className)}>
+      {children}
+    </p>
+  );
+}

--- a/packages/ui/src/components/submit-button.tsx
+++ b/packages/ui/src/components/submit-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import type { ComponentProps } from "react";
+import { useFormStatus } from "react-dom";
+
+interface SubmitButtonProps extends Omit<ComponentProps<typeof Button>, "type" | "disabled"> {
+  /** Text shown while form is submitting */
+  pendingText?: string;
+}
+
+export function SubmitButton({ children, pendingText = "Saving…", ...props }: SubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending} {...props}>
+      {pending ? pendingText : children}
+    </Button>
+  );
+}

--- a/packages/ui/src/hooks/__tests__/use-form-validation.test.ts
+++ b/packages/ui/src/hooks/__tests__/use-form-validation.test.ts
@@ -1,0 +1,115 @@
+/**
+ * useFormValidation — unit tests
+ *
+ * The hook uses `useCallback` and `useRef` from React.
+ * We test the core validation logic by extracting and calling the
+ * action function that the hook would return.
+ *
+ * The validateAndSubmit helper mirrors the hook's action function exactly,
+ * allowing us to test both scenarios without a React rendering context.
+ */
+
+import type { ActionResult } from "@enterprise/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Extracted action logic (mirrors useFormValidation's callback internals)
+// ---------------------------------------------------------------------------
+
+function createValidatedAction<T>(
+  schema: z.ZodSchema,
+  serverAction: (prevState: ActionResult<T> | null, formData: FormData) => Promise<ActionResult<T>>,
+) {
+  return async (
+    prevState: ActionResult<T> | null,
+    formData: FormData,
+  ): Promise<ActionResult<T>> => {
+    const rawData: Record<string, unknown> = {};
+    for (const [key, value] of formData.entries()) {
+      rawData[key] = value;
+    }
+
+    const result = schema.safeParse(rawData);
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      return {
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+          details: fieldErrors as Record<string, unknown>,
+        },
+      } as ActionResult<T>;
+    }
+
+    return serverAction(prevState, formData);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const loginSchema = z.object({
+  email: z.string().email("Must be a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+describe("useFormValidation action logic", () => {
+  it("returns ActionResult with field errors when client validation fails (server NOT called)", async () => {
+    const serverAction =
+      vi.fn<(prevState: ActionResult | null, formData: FormData) => Promise<ActionResult>>();
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "not-an-email");
+    formData.append("password", "short");
+
+    const result = await action(null, formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("VALIDATION_ERROR");
+    expect(result.error?.details).toBeDefined();
+    // Server action must NOT have been called
+    expect(serverAction).not.toHaveBeenCalled();
+  });
+
+  it("delegates to serverAction when client validation passes", async () => {
+    const serverResult: ActionResult = {
+      success: true,
+      data: { userId: "123" },
+    };
+    const serverAction = vi.fn().mockResolvedValue(serverResult);
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "user@example.com");
+    formData.append("password", "securepassword");
+
+    const result = await action(null, formData);
+
+    expect(result.success).toBe(true);
+    expect(serverAction).toHaveBeenCalledOnce();
+    expect(serverAction).toHaveBeenCalledWith(null, formData);
+  });
+
+  it("passes prevState to serverAction when delegating", async () => {
+    const prevState: ActionResult = {
+      success: false,
+      error: { code: "AUTH_ERROR", message: "Previous error" },
+    };
+    const serverResult: ActionResult = { success: true };
+    const serverAction = vi.fn().mockResolvedValue(serverResult);
+    const action = createValidatedAction(loginSchema, serverAction);
+
+    const formData = new FormData();
+    formData.append("email", "user@example.com");
+    formData.append("password", "securepassword");
+
+    await action(prevState, formData);
+
+    expect(serverAction).toHaveBeenCalledWith(prevState, formData);
+  });
+});

--- a/packages/ui/src/hooks/use-form-validation.ts
+++ b/packages/ui/src/hooks/use-form-validation.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { useCallback, useRef } from "react";
+import type { ZodSchema } from "zod";
+
+interface UseFormValidationOptions<T> {
+  /** Zod schema to validate against (same schema used server-side) */
+  schema: ZodSchema;
+  /** The server action wrapped by useActionState */
+  serverAction: (prevState: ActionResult<T> | null, formData: FormData) => Promise<ActionResult<T>>;
+}
+
+/**
+ * Wraps a server action with client-side Zod validation.
+ * Returns a new action function that validates client-side first,
+ * returning field errors immediately without a server round-trip.
+ *
+ * Usage:
+ *   const validatedAction = useFormValidation({ schema: loginDto, serverAction: signInAction });
+ *   const [state, formAction, isPending] = useActionState(validatedAction, null);
+ */
+export function useFormValidation<T>({ schema, serverAction }: UseFormValidationOptions<T>) {
+  const serverActionRef = useRef(serverAction);
+  serverActionRef.current = serverAction;
+
+  return useCallback(
+    async (prevState: ActionResult<T> | null, formData: FormData): Promise<ActionResult<T>> => {
+      // Convert FormData to plain object for Zod validation
+      const rawData: Record<string, unknown> = {};
+      for (const [key, value] of formData.entries()) {
+        rawData[key] = value;
+      }
+
+      const result = schema.safeParse(rawData);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Please fix the errors below.",
+            details: fieldErrors as Record<string, unknown>,
+          },
+        } as ActionResult<T>;
+      }
+
+      // Client validation passed — proceed to server
+      return serverActionRef.current(prevState, formData);
+    },
+    [schema],
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,15 @@
 // Theme
 
-// UI Components
 export * from "./components/avatar";
 export * from "./components/badge";
 export * from "./components/button";
 export * from "./components/card";
 export * from "./components/dialog";
 export * from "./components/dropdown-menu";
+// UI Components
+export * from "./components/form-banner";
+export * from "./components/form-field";
+export * from "./components/form-message";
 export * from "./components/input";
 export * from "./components/label";
 export * from "./components/scroll-area";
@@ -14,11 +17,13 @@ export * from "./components/select";
 export * from "./components/separator";
 export * from "./components/sheet";
 export * from "./components/skeleton";
+export * from "./components/submit-button";
 export * from "./components/switch";
 export * from "./components/table";
 export * from "./components/tabs";
 export * from "./components/textarea";
 export * from "./components/tooltip";
+export { useFormValidation } from "./hooks/use-form-validation";
 export { cn } from "./lib/utils";
 export type { ThemeContextValue } from "./theme/context";
 export { ThemeContext } from "./theme/context";

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -18,9 +18,11 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Building mobile-first UI | `design-components` |
 | Choosing between border and tonal shift | `design-rules` |
 | Choosing colors for components | `design-tokens` |
+| Committing changes | `enterprise-commit` |
 | Composing layout structure | `design-rules` |
 | Composing shadcn components for a screen | `design-components` |
 | Configuring RLS at client level | `supabase` |
+| Creating a git commit | `enterprise-commit` |
 | Creating cards, panels, or containers | `design-rules` |
 | Creating database relations | `drizzle` |
 | Creating database schemas | `drizzle` |
@@ -145,11 +147,45 @@ export async function createResource(formData: FormData): Promise<ActionResult<R
 
 ### Form + Zod Validation
 
-```typescript
+> See the `form-validation` skill for the full pattern, shared components, and accessibility rules.
+
+```tsx
+// ✅ Correct — useActionState + ActionResult + FormField
+"use client";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { createResourceSchema } from "@enterprise/contracts";
+import { Input } from "@enterprise/ui/components/input";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { createResourceAction } from "@/features/resources/actions";
+
+export function ResourceForm() {
+  const validatedAction = useFormValidation({
+    schema: createResourceSchema,
+    serverAction: createResourceAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} successMessage="Resource created." />
+      <FormField name="title" label="Title" state={state} required>
+        <Input placeholder="Resource title" />
+      </FormField>
+      <SubmitButton>Create Resource</SubmitButton>
+    </form>
+  );
+}
+```
+
+```tsx
+// ❌ Wrong — react-hook-form is NOT used in this project
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { createResourceSchema } from "@enterprise/contracts";
-
 const form = useForm({ resolver: zodResolver(createResourceSchema) });
 ```
 

--- a/ui/app/(auth)/forgot-password/page.tsx
+++ b/ui/app/(auth)/forgot-password/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@enterprise/ui/components/button";
 import {
   Card,
   CardContent,
@@ -6,15 +5,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@enterprise/ui/components/card";
-import { Input } from "@enterprise/ui/components/input";
-import { Label } from "@enterprise/ui/components/label";
 import Link from "next/link";
-import { forgotPasswordAction } from "@/features/auth/actions";
+import { ForgotPasswordForm } from "@/features/auth/components/forgot-password-form";
 
 export const metadata = { title: "Forgot Password" };
 
 interface ForgotPasswordPageProps {
-  searchParams?: Promise<{ sent?: string; error?: string }>;
+  searchParams?: Promise<{ sent?: string }>;
 }
 
 export default async function ForgotPasswordPage({ searchParams }: ForgotPasswordPageProps) {
@@ -32,22 +29,8 @@ export default async function ForgotPasswordPage({ searchParams }: ForgotPasswor
             If the account exists, a reset link has been sent to the provided email.
           </p>
         ) : null}
-        {params.error ? (
-          <p className="mb-4 rounded-md bg-surface-container-high px-3 py-2 text-sm text-foreground">
-            We could not process your request. Please try again.
-          </p>
-        ) : null}
 
-        <form action={forgotPasswordAction} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="email">Email</Label>
-            <Input id="email" name="email" type="email" placeholder="you@example.com" required />
-          </div>
-
-          <Button type="submit" className="w-full">
-            Send reset link
-          </Button>
-        </form>
+        <ForgotPasswordForm />
 
         <p className="mt-4 text-center text-sm text-muted-foreground">
           Remembered your password?{" "}

--- a/ui/app/(auth)/reset-password/page.tsx
+++ b/ui/app/(auth)/reset-password/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@enterprise/ui/components/button";
 import {
   Card,
   CardContent,
@@ -6,20 +5,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@enterprise/ui/components/card";
-import { Input } from "@enterprise/ui/components/input";
-import { Label } from "@enterprise/ui/components/label";
 import Link from "next/link";
-import { updatePasswordAction } from "@/features/auth/actions";
+import { ResetPasswordForm } from "@/features/auth/components/reset-password-form";
 
 export const metadata = { title: "Reset Password" };
 
-interface ResetPasswordPageProps {
-  searchParams?: Promise<{ error?: string }>;
-}
-
-export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
-  const params = (await searchParams) ?? {};
-
+export default async function ResetPasswordPage() {
   return (
     <Card>
       <CardHeader>
@@ -27,33 +18,7 @@ export default async function ResetPasswordPage({ searchParams }: ResetPasswordP
         <CardDescription>Choose a new password to secure your account</CardDescription>
       </CardHeader>
       <CardContent>
-        {params.error ? (
-          <p className="mb-4 rounded-md bg-surface-container-high px-3 py-2 text-sm text-foreground">
-            We could not update your password. Request a new link and try again.
-          </p>
-        ) : null}
-
-        <form action={updatePasswordAction} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="password">New password</Label>
-            <Input id="password" name="password" type="password" minLength={8} required />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="confirmPassword">Confirm password</Label>
-            <Input
-              id="confirmPassword"
-              name="confirmPassword"
-              type="password"
-              minLength={8}
-              required
-            />
-          </div>
-
-          <Button type="submit" className="w-full">
-            Update password
-          </Button>
-        </form>
+        <ResetPasswordForm />
 
         <p className="mt-4 text-center text-sm text-muted-foreground">
           Return to{" "}

--- a/ui/app/(auth)/sign-in/page.tsx
+++ b/ui/app/(auth)/sign-in/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@enterprise/ui/components/button";
 import {
   Card,
   CardContent,
@@ -6,10 +5,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@enterprise/ui/components/card";
-import { Input } from "@enterprise/ui/components/input";
-import { Label } from "@enterprise/ui/components/label";
 import Link from "next/link";
-import { signInAction } from "@/features/auth/actions";
+import { SignInForm } from "@/features/auth/components/sign-in-form";
 
 export const metadata = { title: "Sign In" };
 
@@ -48,32 +45,16 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
           </p>
         ) : null}
 
-        <form action={signInAction} className="flex flex-col gap-4">
-          <input type="hidden" name="redirectTo" value={params.redirectTo ?? ""} />
+        <SignInForm redirectTo={params.redirectTo} />
 
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="email">Email</Label>
-            <Input id="email" name="email" type="email" placeholder="you@example.com" required />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="password">Password</Label>
-            <Input id="password" name="password" type="password" required />
-          </div>
-
-          <Button type="submit" className="w-full">
-            Sign In
-          </Button>
-
-          <div className="flex items-center justify-between text-sm">
-            <Link href="/forgot-password" className="text-primary hover:underline">
-              Forgot password?
-            </Link>
-            <Link href="/sign-up" className="text-primary hover:underline">
-              Create account
-            </Link>
-          </div>
-        </form>
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <Link href="/forgot-password" className="text-primary hover:underline">
+            Forgot password?
+          </Link>
+          <Link href="/sign-up" className="text-primary hover:underline">
+            Create account
+          </Link>
+        </div>
       </CardContent>
     </Card>
   );

--- a/ui/app/(auth)/sign-up/page.tsx
+++ b/ui/app/(auth)/sign-up/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@enterprise/ui/components/button";
 import {
   Card,
   CardContent,
@@ -6,20 +5,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@enterprise/ui/components/card";
-import { Input } from "@enterprise/ui/components/input";
-import { Label } from "@enterprise/ui/components/label";
 import Link from "next/link";
-import { signUpAction } from "@/features/auth/actions";
+import { SignUpForm } from "@/features/auth/components/sign-up-form";
 
 export const metadata = { title: "Sign Up" };
 
-interface SignUpPageProps {
-  searchParams?: Promise<{ error?: string }>;
-}
-
-export default async function SignUpPage({ searchParams }: SignUpPageProps) {
-  const params = (await searchParams) ?? {};
-
+export default async function SignUpPage() {
   return (
     <Card>
       <CardHeader>
@@ -27,39 +18,14 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
         <CardDescription>Get started with the platform starter in minutes</CardDescription>
       </CardHeader>
       <CardContent>
-        {params.error ? (
-          <p className="mb-4 rounded-md bg-surface-container-high px-3 py-2 text-sm text-foreground">
-            We could not create your account. Check your inputs and try again.
-          </p>
-        ) : null}
+        <SignUpForm />
 
-        <form action={signUpAction} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="name">Full name</Label>
-            <Input id="name" name="name" type="text" placeholder="Jane Doe" />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="email">Email</Label>
-            <Input id="email" name="email" type="email" placeholder="you@example.com" required />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="password">Password</Label>
-            <Input id="password" name="password" type="password" minLength={8} required />
-          </div>
-
-          <Button type="submit" className="w-full">
-            Create account
-          </Button>
-
-          <p className="text-center text-sm text-muted-foreground">
-            Already have an account?{" "}
-            <Link href="/sign-in" className="text-primary hover:underline">
-              Sign in
-            </Link>
-          </p>
-        </form>
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/sign-in" className="text-primary hover:underline">
+            Sign in
+          </Link>
+        </p>
       </CardContent>
     </Card>
   );

--- a/ui/e2e/auth/auth-page.ts
+++ b/ui/e2e/auth/auth-page.ts
@@ -59,8 +59,8 @@ export class AuthPage {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       await this.waitForHydratedForm("Sign In");
 
-      await this.page.getByLabel("Email").fill(email);
-      await this.page.getByLabel("Password").fill(password);
+      await this.page.getByLabel("Email *").fill(email);
+      await this.page.getByLabel("Password *").fill(password);
       await this.page.getByRole("button", { name: "Sign In" }).click();
 
       try {
@@ -75,10 +75,15 @@ export class AuthPage {
     }
   }
 
+  async submitEmptySignIn(): Promise<void> {
+    await this.waitForHydratedForm("Sign In");
+    await this.page.getByRole("button", { name: "Sign In" }).click();
+  }
+
   async signUp(name: string, email: string, password: string): Promise<void> {
     await this.page.getByLabel("Full name").fill(name);
-    await this.page.getByLabel("Email").fill(email);
-    await this.page.getByLabel("Password").fill(password);
+    await this.page.getByLabel("Email *").fill(email);
+    await this.page.getByLabel("Password *").fill(password);
     await this.page.getByRole("button", { name: "Create account" }).click();
   }
 
@@ -88,21 +93,27 @@ export class AuthPage {
     password: string,
   ): Promise<void> {
     await this.page.getByLabel("Full name").fill(name);
-    await this.page.getByLabel("Email").fill(email);
-    await this.page.getByLabel("Password").fill(password);
+    await this.page.getByLabel("Email *").fill(email);
+    await this.page.getByLabel("Password *").fill(password);
     await this.page.locator("form").evaluate((form) => {
       (form as HTMLFormElement).submit();
     });
   }
 
   async requestPasswordReset(email: string): Promise<void> {
-    await this.page.getByLabel("Email").fill(email);
+    await this.page.getByLabel("Email *").fill(email);
     await this.page.getByRole("button", { name: "Send reset link" }).click();
   }
 
+  async submitMismatchedPasswords(password: string, confirmPassword: string): Promise<void> {
+    await this.page.getByLabel("New password *").fill(password);
+    await this.page.getByLabel("Confirm password *").fill(confirmPassword);
+    await this.page.getByRole("button", { name: "Update password" }).click();
+  }
+
   async completePasswordReset(password: string): Promise<void> {
-    await this.page.getByLabel("New password").fill(password);
-    await this.page.getByLabel("Confirm password").fill(password);
+    await this.page.getByLabel("New password *").fill(password);
+    await this.page.getByLabel("Confirm password *").fill(password);
     await this.page.getByRole("button", { name: "Update password" }).click();
   }
 

--- a/ui/e2e/auth/auth.spec.ts
+++ b/ui/e2e/auth/auth.spec.ts
@@ -17,7 +17,7 @@ test.describe("Auth flows", () => {
     await authPage.expectDashboardFacts(OWNER_EMAIL, "owner");
   });
 
-  test("sign-in failure with invalid credentials remains on /sign-in and does not enter dashboard", async ({
+  test("sign-in failure with invalid credentials shows error banner and does not enter dashboard", async ({
     page,
   }) => {
     const authPage = new AuthPage(page);
@@ -27,6 +27,17 @@ test.describe("Auth flows", () => {
 
     await authPage.expectOnSignIn();
     await expect(page.getByRole("heading", { name: "Dashboard" })).toHaveCount(0);
+    await expect(page.getByText("Invalid email or password.")).toBeVisible();
+  });
+
+  test("sign-in with empty fields shows inline field errors", async ({ page }) => {
+    const authPage = new AuthPage(page);
+
+    await authPage.gotoSignIn();
+    await authPage.submitEmptySignIn();
+
+    await authPage.expectOnSignIn();
+    await expect(page.getByRole("alert").first()).toBeVisible();
   });
 
   test("sign-in with redirectTo=/dashboard/settings lands on /dashboard/settings", async ({
@@ -64,7 +75,7 @@ test.describe("Auth flows", () => {
     await authPage.expectRegistrationSuccessNotice();
   });
 
-  test("sign-up validation failure (password < 8) keeps user on /sign-up and shows error state", async ({
+  test("sign-up validation failure (password < 8) stays on /sign-up and shows inline field error", async ({
     page,
   }) => {
     const authPage = new AuthPage(page);
@@ -73,10 +84,8 @@ test.describe("Auth flows", () => {
     await authPage.gotoSignUp();
     await authPage.signUpWithoutNativeValidation("Invalid User", email, "short");
 
-    await expect(page).toHaveURL(/\/sign-up\?error=validation/);
-    await expect(
-      page.getByText("We could not create your account. Check your inputs and try again."),
-    ).toBeVisible();
+    await expect(page).toHaveURL(/\/sign-up/);
+    await expect(page.getByRole("alert").first()).toBeVisible();
   });
 
   test("forgot-password request with valid email redirects to /forgot-password?sent=1 and shows sent notice", async ({
@@ -89,6 +98,18 @@ test.describe("Auth flows", () => {
 
     await expect(page).toHaveURL(/\/forgot-password\?sent=1/);
     await authPage.expectResetRequestSentNotice();
+  });
+
+  test("reset-password with mismatched passwords shows confirmPassword field error", async ({
+    page,
+  }) => {
+    const authPage = new AuthPage(page);
+
+    await page.goto("/reset-password");
+    await authPage.submitMismatchedPasswords("password123", "different456");
+
+    await expect(page).toHaveURL(/\/reset-password/);
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
   });
 
   test("authenticated dashboard access shows user email, role, and workspace facts", async ({

--- a/ui/e2e/resources/resources.spec.ts
+++ b/ui/e2e/resources/resources.spec.ts
@@ -164,5 +164,22 @@ test.describe("Resources", () => {
       await resourcesPage.deleteResource(deleteTitle);
       await resourcesPage.expectResourceNotInTable(deleteTitle);
     });
+
+    test("validation: submitting blank title shows inline field error", async ({ page }) => {
+      const resourcesPage = new ResourcesPage(page);
+
+      await login(page);
+      await resourcesPage.gotoNew();
+
+      // Submit with no title — leave title blank
+      await resourcesPage.submitForm();
+
+      // Inline field error should appear below the title input (Zod min(1) message)
+      await expect(page.getByText("String must contain at least 1 character(s)")).toBeVisible();
+
+      // Title input should have aria-invalid="true" (injected by FormField)
+      const titleInput = page.getByRole("textbox", { name: /title/i });
+      await expect(titleInput).toHaveAttribute("aria-invalid", "true");
+    });
   });
 });

--- a/ui/features/auth/actions.test.ts
+++ b/ui/features/auth/actions.test.ts
@@ -134,17 +134,23 @@ describe("actions", () => {
   });
 
   describe("signInAction", () => {
-    it("invalid FormData redirects to /sign-in", async () => {
+    it("invalid FormData returns ActionResult with field errors", async () => {
       const { signInAction } = await loadActions();
       const formData = buildFormData({ email: "invalid" });
 
-      await expect(signInAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/sign-in");
-        return true;
+      const result = await signInAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+        },
       });
+      expect(result.error?.details).toBeDefined();
     });
 
-    it("valid credentials call signIn", async () => {
+    it("valid credentials call signIn and redirect on success", async () => {
       const { signInAction } = await loadActions();
 
       mockSignInWithPasswordService.mockResolvedValue({ success: true, data: { role: "member" } });
@@ -154,7 +160,7 @@ describe("actions", () => {
         password: "password123",
       });
 
-      await expect(signInAction(formData)).rejects.toSatisfy((error: unknown) => {
+      await expect(signInAction(null, formData)).rejects.toSatisfy((error: unknown) => {
         expect(mockSignInWithPasswordService).toHaveBeenCalledWith(mockClient, {
           email: "member@enterprise.dev",
           password: "password123",
@@ -164,7 +170,32 @@ describe("actions", () => {
       });
     });
 
-    it("when signIn returns error, redirects to /sign-in with preserved normalized redirectTo when present", async () => {
+    it("when signIn returns error, returns ActionResult with AUTH_ERROR", async () => {
+      const { signInAction } = await loadActions();
+
+      mockSignInWithPasswordService.mockResolvedValue({
+        success: false,
+        error: "Invalid credentials",
+        code: "INVALID_CREDENTIALS",
+      });
+
+      const formData = buildFormData({
+        email: "member@enterprise.dev",
+        password: "wrong-password",
+      });
+
+      const result = await signInAction(null, formData);
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: "AUTH_ERROR",
+          message: "Invalid email or password.",
+        },
+      });
+    });
+
+    it("when signIn returns error with redirectTo, returns ActionResult with AUTH_ERROR", async () => {
       const { signInAction } = await loadActions();
 
       mockSignInWithPasswordService.mockResolvedValue({
@@ -180,30 +211,41 @@ describe("actions", () => {
         redirectTo: "/dashboard/settings",
       });
 
-      await expect(signInAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/sign-in?redirectTo=%2Fdashboard%2Fsettings");
-        return true;
+      const result = await signInAction(null, formData);
+
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: "AUTH_ERROR",
+          message: "Invalid email or password.",
+        },
       });
     });
   });
 
   describe("signUpAction", () => {
-    it("invalid payload redirects to /sign-up?error=validation", async () => {
+    it("invalid payload returns ActionResult with field errors", async () => {
       const { signUpAction } = await loadActions();
       const formData = buildFormData({ email: "invalid", password: "short" });
 
-      await expect(signUpAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/sign-up?error=validation");
-        return true;
+      const result = await signUpAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+        },
       });
+      expect(result.error?.details).toBeDefined();
     });
 
-    it("service failure redirects to /sign-up?error=failed", async () => {
+    it("service failure returns ActionResult with AUTH_ERROR", async () => {
       const { signUpAction } = await loadActions();
 
       mockSignUpService.mockResolvedValue({
         success: false,
-        error: "failed",
+        error: "Email already in use.",
         code: "SIGN_UP_FAILED",
       });
 
@@ -213,9 +255,13 @@ describe("actions", () => {
         password: "password123",
       });
 
-      await expect(signUpAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/sign-up?error=failed");
-        return true;
+      const result = await signUpAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "AUTH_ERROR",
+        },
       });
     });
 
@@ -233,7 +279,7 @@ describe("actions", () => {
         password: "password123",
       });
 
-      await expect(signUpAction(formData)).rejects.toSatisfy((error: unknown) => {
+      await expect(signUpAction(null, formData)).rejects.toSatisfy((error: unknown) => {
         expect(mockSignOutService).toHaveBeenCalledWith(mockClient);
         expectRedirectDigest(error, "/sign-in?registered=1");
         return true;
@@ -242,17 +288,23 @@ describe("actions", () => {
   });
 
   describe("forgotPasswordAction", () => {
-    it("invalid payload redirects to /forgot-password?error=validation", async () => {
+    it("invalid payload returns ActionResult with field errors", async () => {
       const { forgotPasswordAction } = await loadActions();
       const formData = buildFormData({ email: "invalid" });
 
-      await expect(forgotPasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/forgot-password?error=validation");
-        return true;
+      const result = await forgotPasswordAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+        },
       });
+      expect(result.error?.details).toBeDefined();
     });
 
-    it("service failure redirects to /forgot-password?error=failed", async () => {
+    it("service failure returns ActionResult with AUTH_ERROR", async () => {
       const { forgotPasswordAction } = await loadActions();
       mockRequestPasswordResetService.mockResolvedValue({
         success: false,
@@ -262,9 +314,13 @@ describe("actions", () => {
 
       const formData = buildFormData({ email: "member@enterprise.dev" });
 
-      await expect(forgotPasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/forgot-password?error=failed");
-        return true;
+      const result = await forgotPasswordAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "AUTH_ERROR",
+        },
       });
     });
 
@@ -274,7 +330,7 @@ describe("actions", () => {
 
       const formData = buildFormData({ email: "member@enterprise.dev" });
 
-      await expect(forgotPasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
+      await expect(forgotPasswordAction(null, formData)).rejects.toSatisfy((error: unknown) => {
         expectRedirectDigest(error, "/forgot-password?sent=1");
         return true;
       });
@@ -300,17 +356,43 @@ describe("actions", () => {
   });
 
   describe("updatePasswordAction", () => {
-    it("invalid payload redirects to /reset-password?error=validation", async () => {
+    it("missing confirmPassword returns ActionResult with field errors", async () => {
       const { updatePasswordAction } = await loadActions();
       const formData = buildFormData({ password: "password123" });
 
-      await expect(updatePasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/reset-password?error=validation");
-        return true;
+      const result = await updatePasswordAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+        },
       });
+      expect(result.error?.details).toBeDefined();
     });
 
-    it("service failure redirects to /reset-password?error=failed", async () => {
+    it("mismatched passwords returns ActionResult with confirmPassword field error", async () => {
+      const { updatePasswordAction } = await loadActions();
+      const formData = buildFormData({
+        password: "password123",
+        confirmPassword: "different456",
+      });
+
+      const result = await updatePasswordAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Please fix the errors below.",
+        },
+      });
+      const details = result.error?.details as Record<string, string[]> | undefined;
+      expect(details?.["confirmPassword"]).toBeDefined();
+    });
+
+    it("service failure returns ActionResult with AUTH_ERROR", async () => {
       const { updatePasswordAction } = await loadActions();
       mockUpdatePasswordService.mockResolvedValue({
         success: false,
@@ -323,9 +405,13 @@ describe("actions", () => {
         confirmPassword: "password123",
       });
 
-      await expect(updatePasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
-        expectRedirectDigest(error, "/reset-password?error=failed");
-        return true;
+      const result = await updatePasswordAction(null, formData);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          code: "AUTH_ERROR",
+        },
       });
     });
 
@@ -339,7 +425,7 @@ describe("actions", () => {
         confirmPassword: "password123",
       });
 
-      await expect(updatePasswordAction(formData)).rejects.toSatisfy((error: unknown) => {
+      await expect(updatePasswordAction(null, formData)).rejects.toSatisfy((error: unknown) => {
         expect(mockSignOutService).toHaveBeenCalledWith(mockClient);
         expectRedirectDigest(error, "/sign-in?passwordUpdated=1");
         return true;

--- a/ui/features/auth/actions.ts
+++ b/ui/features/auth/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import {
+  type ActionResult,
   loginDto,
   registrationMetadataSchema,
   resetPasswordDto,
@@ -39,7 +40,10 @@ export async function signIn(email: string, password: string, redirectTo?: strin
   redirect(normalizeSafeRedirectPath(redirectTo, resolveRoleRedirect(result.data.role)));
 }
 
-export async function signInAction(formData: FormData) {
+export async function signInAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const parsedInput = loginDto.safeParse({
     email: formData.get("email"),
     password: formData.get("password"),
@@ -51,21 +55,37 @@ export async function signInAction(formData: FormData) {
       : null;
 
   if (!parsedInput.success) {
-    redirect("/sign-in");
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: parsedInput.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
   }
 
   const { email, password } = parsedInput.data;
   const result = await signIn(email, password, redirectTo);
 
   if (result?.error) {
-    const fallbackPath = redirectTo
-      ? `/sign-in?redirectTo=${encodeURIComponent(redirectTo)}`
-      : "/sign-in";
-    redirect(fallbackPath);
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Invalid email or password.",
+      },
+    };
   }
+
+  // signIn redirects on success — this is unreachable but satisfies TS
+  return { success: true };
 }
 
-export async function signUpAction(formData: FormData) {
+export async function signUpAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const parsedInput = signUpDto.safeParse({
     name: formData.get("name") || undefined,
     email: formData.get("email"),
@@ -73,7 +93,14 @@ export async function signUpAction(formData: FormData) {
   });
 
   if (!parsedInput.success) {
-    redirect("/sign-up?error=validation");
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: parsedInput.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
   }
 
   const metadata = registrationMetadataSchema.parse({
@@ -89,7 +116,13 @@ export async function signUpAction(formData: FormData) {
   });
 
   if (!result.success) {
-    redirect("/sign-up?error=failed");
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: result.error ?? "We could not create your account. Please try again.",
+      },
+    };
   }
 
   await signOutService(supabase);
@@ -97,13 +130,23 @@ export async function signUpAction(formData: FormData) {
   redirect("/sign-in?registered=1");
 }
 
-export async function forgotPasswordAction(formData: FormData) {
+export async function forgotPasswordAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const parsedInput = resetPasswordDto.safeParse({
     email: formData.get("email"),
   });
 
   if (!parsedInput.success) {
-    redirect("/forgot-password?error=validation");
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: parsedInput.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
   }
 
   const supabase = await getServerClient();
@@ -115,7 +158,13 @@ export async function forgotPasswordAction(formData: FormData) {
   });
 
   if (!result.success) {
-    redirect("/forgot-password?error=failed");
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "We could not process your request. Please try again.",
+      },
+    };
   }
 
   redirect("/forgot-password?sent=1");
@@ -128,14 +177,25 @@ export async function signOut() {
   redirect("/sign-in");
 }
 
-export async function updatePasswordAction(formData: FormData) {
+export async function updatePasswordAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const parsedInput = updatePasswordDto.safeParse({
     password: formData.get("password"),
     confirmPassword: formData.get("confirmPassword"),
   });
 
   if (!parsedInput.success) {
-    redirect("/reset-password?error=validation");
+    const fieldErrors = parsedInput.error.flatten().fieldErrors;
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: fieldErrors as Record<string, unknown>,
+      },
+    };
   }
 
   const supabase = await getServerClient();
@@ -144,7 +204,13 @@ export async function updatePasswordAction(formData: FormData) {
   });
 
   if (!result.success) {
-    redirect("/reset-password?error=failed");
+    return {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "We could not update your password. Please request a new link and try again.",
+      },
+    };
   }
 
   await signOutService(supabase);

--- a/ui/features/auth/components/forgot-password-form.tsx
+++ b/ui/features/auth/components/forgot-password-form.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { resetPasswordDto } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { Input } from "@enterprise/ui/components/input";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { forgotPasswordAction } from "@/features/auth/actions";
+
+export function ForgotPasswordForm() {
+  const validatedAction = useFormValidation({
+    schema: resetPasswordDto,
+    serverAction: forgotPasswordAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="email" label="Email" state={state} required>
+        <Input type="email" placeholder="you@example.com" />
+      </FormField>
+
+      <SubmitButton pendingText="Sending…" className="w-full">
+        Send reset link
+      </SubmitButton>
+    </form>
+  );
+}

--- a/ui/features/auth/components/reset-password-form.tsx
+++ b/ui/features/auth/components/reset-password-form.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { updatePasswordDto } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { Input } from "@enterprise/ui/components/input";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { updatePasswordAction } from "@/features/auth/actions";
+
+export function ResetPasswordForm() {
+  const validatedAction = useFormValidation({
+    schema: updatePasswordDto,
+    serverAction: updatePasswordAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="password" label="New password" state={state} required>
+        <Input type="password" />
+      </FormField>
+
+      <FormField name="confirmPassword" label="Confirm password" state={state} required>
+        <Input type="password" />
+      </FormField>
+
+      <SubmitButton pendingText="Updating…" className="w-full">
+        Update password
+      </SubmitButton>
+    </form>
+  );
+}

--- a/ui/features/auth/components/sign-in-form.tsx
+++ b/ui/features/auth/components/sign-in-form.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { loginDto } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { Input } from "@enterprise/ui/components/input";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { signInAction } from "@/features/auth/actions";
+
+interface SignInFormProps {
+  redirectTo?: string;
+}
+
+export function SignInForm({ redirectTo }: SignInFormProps) {
+  const validatedAction = useFormValidation({
+    schema: loginDto,
+    serverAction: signInAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <input type="hidden" name="redirectTo" value={redirectTo ?? ""} />
+
+      <FormBanner state={state} />
+
+      <FormField name="email" label="Email" state={state} required>
+        <Input type="email" placeholder="you@example.com" />
+      </FormField>
+
+      <FormField name="password" label="Password" state={state} required>
+        <Input type="password" placeholder="Your password" />
+      </FormField>
+
+      <SubmitButton pendingText="Signing in…" className="w-full">
+        Sign In
+      </SubmitButton>
+    </form>
+  );
+}

--- a/ui/features/auth/components/sign-up-form.tsx
+++ b/ui/features/auth/components/sign-up-form.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { signUpDto } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { Input } from "@enterprise/ui/components/input";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useActionState } from "react";
+import { signUpAction } from "@/features/auth/actions";
+
+export function SignUpForm() {
+  const validatedAction = useFormValidation({
+    schema: signUpDto,
+    serverAction: signUpAction,
+  });
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="name" label="Full name" state={state}>
+        <Input type="text" placeholder="Jane Doe" />
+      </FormField>
+
+      <FormField name="email" label="Email" state={state} required>
+        <Input type="email" placeholder="you@example.com" />
+      </FormField>
+
+      <FormField name="password" label="Password" state={state} required>
+        <Input type="password" />
+      </FormField>
+
+      <SubmitButton pendingText="Creating account…" className="w-full">
+        Create account
+      </SubmitButton>
+    </form>
+  );
+}

--- a/ui/features/resources/components/resource-form.tsx
+++ b/ui/features/resources/components/resource-form.tsx
@@ -6,8 +6,10 @@ import type {
   ResourceStatus,
   ResourceType,
 } from "@enterprise/contracts";
-import { RESOURCE_STATUS, RESOURCE_TYPE } from "@enterprise/contracts";
-import { Button } from "@enterprise/ui/components/button";
+import { getFieldError, RESOURCE_STATUS, RESOURCE_TYPE } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { FormMessage } from "@enterprise/ui/components/form-message";
 import { Input } from "@enterprise/ui/components/input";
 import { Label } from "@enterprise/ui/components/label";
 import {
@@ -17,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@enterprise/ui/components/select";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
 import { Textarea } from "@enterprise/ui/components/textarea";
 import { useActionState } from "react";
 import { createResourceAction, updateResourceAction } from "@/features/resources/actions";
@@ -39,15 +42,6 @@ const RESOURCE_STATUS_LABELS: Record<ResourceStatus, string> = {
   archived: "Archived",
   suspended: "Suspended",
 };
-
-function getFieldError(
-  result: ActionResult<ResourceEntity> | null,
-  field: string,
-): string | undefined {
-  if (!result || result.success) return undefined;
-  const details = result.error?.details as Record<string, string[]> | undefined;
-  return details?.[field]?.[0];
-}
 
 function parseJsonString(value: string | null): Record<string, unknown> | undefined {
   if (!value) return undefined;
@@ -96,7 +90,7 @@ export function ResourceForm({ defaultValues }: ResourceFormProps) {
     return createResourceAction(input);
   }
 
-  const [state, formAction, isPending] = useActionState(boundAction, null);
+  const [state, formAction] = useActionState(boundAction, null);
 
   const existingImageUrlsText = (() => {
     if (!defaultValues?.imageUrls) return "";
@@ -119,43 +113,31 @@ export function ResourceForm({ defaultValues }: ResourceFormProps) {
     }
   })();
 
-  return (
-    <form action={formAction} className="flex flex-col gap-6">
-      {state && !state.success && !state.error?.details && (
-        <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {state.error?.message ?? "An error occurred. Please try again."}
-        </p>
-      )}
+  // Select fields cannot use FormField's cloneElement injection because the
+  // Select primitive wraps the trigger in its own context — aria attributes
+  // must be passed directly to SelectTrigger instead.
+  const typeError = getFieldError(state, "type");
+  const statusError = getFieldError(state, "status");
 
-      {state?.success && !isEdit && (
-        <p className="rounded-md bg-green-100 px-3 py-2 text-sm text-green-800">
-          Resource created successfully.
-        </p>
-      )}
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-6">
+      <FormBanner
+        state={state}
+        successMessage={isEdit ? undefined : "Resource created successfully."}
+      />
 
       <div className="grid gap-4 sm:grid-cols-2">
-        <div className="flex flex-col gap-1.5 sm:col-span-2">
-          <Label htmlFor="title">
-            Title <span className="text-destructive">*</span>
-          </Label>
-          <Input
-            id="title"
-            name="title"
-            required
-            defaultValue={defaultValues?.title ?? ""}
-            placeholder="Resource title"
-          />
-          {getFieldError(state, "title") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "title")}</p>
-          )}
-        </div>
+        <FormField name="title" label="Title" state={state} required className="sm:col-span-2">
+          <Input defaultValue={defaultValues?.title ?? ""} placeholder="Resource title" />
+        </FormField>
 
+        {/* Select fields: aria-invalid injected directly on SelectTrigger (cloneElement cannot pierce Select's context) */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="type">
             Type <span className="text-destructive">*</span>
           </Label>
           <Select name="type" defaultValue={defaultValues?.type ?? RESOURCE_TYPE.PRODUCT} required>
-            <SelectTrigger id="type">
+            <SelectTrigger id="type" aria-invalid={Boolean(typeError) || undefined}>
               <SelectValue placeholder="Select type" />
             </SelectTrigger>
             <SelectContent>
@@ -166,9 +148,7 @@ export function ResourceForm({ defaultValues }: ResourceFormProps) {
               ))}
             </SelectContent>
           </Select>
-          {getFieldError(state, "type") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "type")}</p>
-          )}
+          {typeError && <FormMessage>{typeError}</FormMessage>}
         </div>
 
         <div className="flex flex-col gap-1.5">
@@ -180,7 +160,7 @@ export function ResourceForm({ defaultValues }: ResourceFormProps) {
             defaultValue={defaultValues?.status ?? RESOURCE_STATUS.ACTIVE}
             required
           >
-            <SelectTrigger id="status">
+            <SelectTrigger id="status" aria-invalid={Boolean(statusError) || undefined}>
               <SelectValue placeholder="Select status" />
             </SelectTrigger>
             <SelectContent>
@@ -191,60 +171,50 @@ export function ResourceForm({ defaultValues }: ResourceFormProps) {
               ))}
             </SelectContent>
           </Select>
-          {getFieldError(state, "status") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "status")}</p>
-          )}
+          {statusError && <FormMessage>{statusError}</FormMessage>}
         </div>
 
-        <div className="flex flex-col gap-1.5 sm:col-span-2">
-          <Label htmlFor="description">Description</Label>
+        <FormField name="description" label="Description" state={state} className="sm:col-span-2">
           <Textarea
-            id="description"
-            name="description"
             defaultValue={defaultValues?.description ?? ""}
             placeholder="Resource description"
             rows={4}
           />
-          {getFieldError(state, "description") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "description")}</p>
-          )}
-        </div>
+        </FormField>
 
-        <div className="flex flex-col gap-1.5 sm:col-span-2">
-          <Label htmlFor="metadataText">Metadata (JSON)</Label>
+        <FormField
+          name="metadataText"
+          label="Metadata (JSON)"
+          state={state}
+          description="Use a valid JSON object."
+          className="sm:col-span-2"
+        >
           <Textarea
-            id="metadataText"
-            name="metadataText"
             defaultValue={existingMetadataText}
             placeholder='{"owner":"operations","tags":["internal"]}'
             rows={5}
           />
-          <p className="text-xs text-muted-foreground">Use a valid JSON object.</p>
-          {getFieldError(state, "metadata") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "metadata")}</p>
-          )}
-        </div>
+        </FormField>
 
-        <div className="flex flex-col gap-1.5 sm:col-span-2">
-          <Label htmlFor="imageUrlsText">Image URLs</Label>
+        <FormField
+          name="imageUrlsText"
+          label="Image URLs"
+          state={state}
+          description="Separate multiple URLs with commas."
+          className="sm:col-span-2"
+        >
           <Textarea
-            id="imageUrlsText"
-            name="imageUrlsText"
             defaultValue={existingImageUrlsText}
             placeholder="Comma-separated image URLs"
             rows={2}
           />
-          <p className="text-xs text-muted-foreground">Separate multiple URLs with commas.</p>
-          {getFieldError(state, "imageUrls") && (
-            <p className="text-xs text-destructive">{getFieldError(state, "imageUrls")}</p>
-          )}
-        </div>
+        </FormField>
       </div>
 
       <div className="flex justify-end gap-3">
-        <Button type="submit" disabled={isPending}>
-          {isPending ? "Saving…" : isEdit ? "Update Resource" : "Create Resource"}
-        </Button>
+        <SubmitButton pendingText="Saving…">
+          {isEdit ? "Update Resource" : "Create Resource"}
+        </SubmitButton>
       </div>
     </form>
   );


### PR DESCRIPTION
## Summary

- Unified form validation UX system with inline field errors, server error propagation, and accessible error states
- Shared `FormField`, `FormMessage`, `FormBanner`, `SubmitButton` components + `useFormValidation` hook
- All 4 auth forms migrated from silent redirect-on-error to `ActionResult` with inline errors
- Resource form migrated to shared components
- 304 tests passing (unit + E2E coverage)

## Chain (completed)

| PR | Scope | Status |
|----|-------|--------|
| #33 | Contracts + Shared Components | ✅ Merged |
| #34 | Auth Form Migration | ✅ Merged |
| #35 | Resource Form + Skill Wiring | ✅ Merged |

> `size:exception` — tracker aggregates 3 reviewed child PRs (~930 lines total).

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (304 tests)
- [x] All child PRs individually reviewed and merged