### PR TITLE
fix(ci): ignore major version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@
 # Opens PRs monthly for outdated dependencies.
 # Each ecosystem gets its own labels for easy filtering.
 #
+# IMPORTANT: Major version bumps of framework-level dependencies are IGNORED.
+# These require dedicated migration planning, not automated PRs.
+#
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 
 version: 2
@@ -27,6 +30,34 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Framework-level — major bumps require migration planning
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # Schema/validation — major bumps have breaking API changes
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      # UI primitives — major bumps change component APIs
+      - dependency-name: "tailwind-merge"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "lucide-react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@radix-ui/*"
+        update-types: ["version-update:semver-major"]
+      # ORM — major bumps change schema/query APIs
+      - dependency-name: "drizzle-orm"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "drizzle-kit"
+        update-types: ["version-update:semver-major"]
+      # Auth/DB — major bumps change client APIs
+      - dependency-name: "@supabase/*"
+        update-types: ["version-update:semver-major"]
 
   # ── GitHub Actions ───────────────────────────────────────────
   - package-ecosystem: "github-actions"
@@ -40,3 +71,15 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # Major bumps on core actions need SHA-pin validation
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/setup-node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/upload-artifact"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "supabase/setup-cli"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Prevent Dependabot from opening PRs for major version bumps that require migration planning
- Closes the gap that caused 12 noisy PRs (#41-#53) on first Dependabot run

## Context

After Sprint 1 added `dependabot.yml`, the first run opened PRs for **every** outdated dependency — including dangerous major bumps like Next.js 15→16, TypeScript 5→6, and Zod 3→4. These are NOT safe to auto-merge and create noise.

## Changes

| Section | What's Ignored |
|---------|---------------|
| **npm majors** | next, react, react-dom, typescript, zod, tailwind-merge, lucide-react, @radix-ui/*, drizzle-orm, drizzle-kit, @supabase/* |
| **Actions majors** | actions/checkout, actions/setup-node, actions/upload-artifact, pnpm/action-setup, supabase/setup-cli |

Minor and patch updates will still flow through normally and get grouped.

## PRs Cleaned Up

| PR | What | Action |
|----|------|--------|
| #41-#45 | GitHub Actions major bumps | Closed with explanation |
| #47 | npm production group | Closed (will regenerate) |
| #48-#53 | npm major bumps | Closed with explanation |

## Verification

- [x] `dependabot.yml` is valid YAML
- [x] Ignore rules use correct `update-types` syntax
- [x] Minor/patch grouping preserved