### PR TITLE
fix(ci): disable dependabot for github-actions (SHA-pinned manually)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,26 +60,18 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # ── GitHub Actions ───────────────────────────────────────────
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
-    target-branch: main
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "chore(deps)"
-    ignore:
-      # Major bumps on core actions need SHA-pin validation
-      - dependency-name: "actions/checkout"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "actions/setup-node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "actions/upload-artifact"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "pnpm/action-setup"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "supabase/setup-cli"
-        update-types: ["version-update:semver-major"]
+  # DISABLED: We SHA-pin all actions manually as part of our supply chain
+  # hardening (Sprint 2). Dependabot can't update SHA pins correctly and
+  # generates noisy PRs. Re-enable if we switch back to tag-based pinning.
+  #
+  # - package-ecosystem: "github-actions"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "monthly"
+  #   open-pull-requests-limit: 5
+  #   target-branch: main
+  #   labels:
+  #     - "dependencies"
+  #     - "github-actions"
+  #   commit-message:
+  #     prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

- Disable Dependabot for `github-actions` ecosystem — we SHA-pin all actions manually
- Dependabot can't handle SHA-pinned actions correctly and keeps generating noisy PRs

## Why

After Sprint 2 SHA-pinned every action to immutable commit hashes, Dependabot:
1. Opened PRs #41-#45 for major version bumps (closed)
2. Opened PRs #55-#57 for SHA-to-SHA updates that don't match our pin format (closed)

Dependabot treats SHA-pinned actions as "outdated" whenever any newer commit exists upstream. Since we deliberately pin to audited SHAs, this is pure noise.

## What Changes

The `github-actions` section in `dependabot.yml` is commented out with an explanation. The npm section (minor/patch only) remains active.

## Verification

- [x] Valid YAML after edit
- [x] npm ecosystem config unchanged