### PR TITLE
chore(ci): add CodeQL SAST analysis and zizmor GitHub Actions audit

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+name: Enterprise Platform CodeQL Config
+
+paths:
+  - ui/
+  - packages/
+
+paths-ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.md"
+  - "**/node_modules/**"
+  - "ui/.next/**"
+  - "ui/e2e/**"
+  - "playwright-report/**"
+  - "coverage/**"
+
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ui/**"
+      - "packages/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ui/**"
+      - "packages/**"
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,49 @@
+name: Zizmor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  schedule:
+    # Run daily at 06:30 UTC
+    - cron: "30 6 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: GitHub Actions Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          token: ${{ github.token }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  # pull_request_target is intentional for labeler and conflict checker
+  # — they need write access for labels/comments and don't checkout PR code unsafely
+  dangerous-triggers:
+    ignore:
+      - labeler.yml
+      - pr-conflict-checker.yml


### PR DESCRIPTION
## Summary

- Add static application security testing (SAST) via CodeQL
- Add GitHub Actions security audit via zizmor
- Final sprint of the Prowler-inspired `.github` governance plan

## Changes

| File | Purpose |
|------|---------|
| `.github/codeql/codeql-config.yml` | Scopes analysis to `ui/` + `packages/`, excludes tests/node_modules/.next/e2e. Uses `security-and-quality` query suite |
| `.github/workflows/codeql.yml` | CodeQL for JS/TS — runs on push/PR (source paths only) + weekly Monday schedule |
| `.github/workflows/zizmor.yml` | Audits all workflows for security issues — runs on `.github/**` changes + daily schedule + manual trigger |
| `.github/zizmor.yml` | Suppresses `dangerous-triggers` for `labeler.yml` and `pr-conflict-checker.yml` (intentional `pull_request_target`) |

## What This Enables

- **CodeQL**: GitHub's SAST engine analyzes source code for security vulnerabilities (XSS, injection, auth bypass, etc.) and code quality issues. Results appear in the Security tab
- **Zizmor**: Purpose-built tool for auditing GitHub Actions workflows. Catches: secrets outside env, superfluous actions, dangerous triggers, unpinned actions, artipacked credentials

## Verification

- [x] CodeQL scoped to only production source (no tests, no build artifacts)
- [x] Zizmor suppression config covers known-safe `pull_request_target` usage
- [x] All workflows SHA-pinned with harden-runner
- [x] `permissions: {}` at workflow level + minimal per-job grants
- [x] Schedule crons offset to avoid contention (CodeQL Mon 06:00, Zizmor daily 06:30)