### PR TITLE
fix(ci): use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,12 @@ jobs:
         uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Uses a PAT instead of GITHUB_TOKEN so the release PR triggers CI workflows.
+          # GITHUB_TOKEN-created PRs cannot trigger other workflows (GitHub security rule).
+          # Create a fine-grained PAT with: contents:write + pull-requests:write
+          # Then add it as a repository secret named RELEASE_PLEASE_TOKEN.
+          # Falls back to GITHUB_TOKEN if the secret is not set (CI won't trigger on the PR).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

- Fix release-please PRs never getting CI checks (blocked forever)
- Use a PAT (`RELEASE_PLEASE_TOKEN`) instead of `GITHUB_TOKEN`

## Root Cause

GitHub's security model prevents workflows triggered by `GITHUB_TOKEN` from triggering other workflows. This means:

1. `release.yml` runs on push to main (using `GITHUB_TOKEN`)
2. It creates/updates a release PR
3. The PR requires "Quality Checks" to pass (branch protection)
4. **CI never triggers** because the PR was created by `GITHUB_TOKEN`
5. PR is stuck forever with "Expected — Waiting for status to be reported"

This affected PR #38 and PR #60.

## Fix

Replace `GITHUB_TOKEN` with `RELEASE_PLEASE_TOKEN` (a PAT). PRs created by a PAT are treated as user actions, so CI triggers normally.

Falls back to `GITHUB_TOKEN` if the secret is not configured (for forks/new setups).

## Setup Required

After merging, create the PAT and add it as a secret:

1. Go to https://github.com/settings/personal-access-tokens/new
2. Create a **fine-grained token** scoped to this repo with permissions:
   - `contents: write`
   - `pull-requests: write`
3. Go to repo **Settings → Secrets → Actions**
4. Add secret: `RELEASE_PLEASE_TOKEN` = the token value

## Verification

- [x] Workflow falls back gracefully if secret is missing
- [x] No other workflow changes needed