### PR TITLE
docs: add feature-readiness convention and rewrite tenant team management specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Use these skills for detailed patterns on-demand. The runtime resolves them auto
 | `enterprise-commit` | Conventional commits with project scopes |
 | `enterprise-docs` | Documentation style guide and writing standards |
 | `enterprise-pr` | PR creation workflow and template |
+| `feature-readiness` | Feature traceability readiness — audit events, Sentry, seed data, E2E, adapters |
 | `form-validation` | Form validation patterns — useActionState, ActionResult, inline errors, accessibility |
 | `skill-creator` | Create new AI agent skills |
 | `skill-sync` | Sync skill metadata to AGENTS.md tables |
@@ -129,7 +130,6 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
-| Adding form validation or error handling | `form-validation` |
 | Adding developer guides | `enterprise-docs` |
 | Adding error tracking to Server Actions | `sentry` |
 | After creating/modifying a skill | `skill-sync` |
@@ -138,6 +138,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Configuring RLS at client level | `supabase` |
 | Configuring database connections | `supabase-postgres-best-practices` |
 | Creating MDX pages | `enterprise-docs` |
+| Creating SDD proposals for features | `feature-readiness` |
 | Creating a git commit | `enterprise-commit` |
 | Creating a pull request | `enterprise-pr` |
 | Creating new skills | `skill-creator` |
@@ -146,8 +147,10 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Optimizing Postgres queries | `supabase-postgres-best-practices` |
 | Preparing changes for review | `enterprise-pr` |
 | Regenerate AGENTS.md Auto-invoke tables (sync.sh) | `skill-sync` |
+| Reviewing a feature PRD or RFC | `feature-readiness` |
 | Reviewing schema performance | `supabase-postgres-best-practices` |
 | Setting up Supabase SSR cookies | `supabase` |
+| Starting feature implementation | `feature-readiness` |
 | Troubleshoot why a skill is missing from AGENTS.md auto-invoke | `skill-sync` |
 | Using Zustand stores | `zustand-5` |
 | Using captureException or captureActionError | `sentry` |
@@ -158,6 +161,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Writing Playwright E2E tests | `playwright` |
 | Writing React components | `react-19` |
 | Writing TypeScript types/interfaces | `typescript` |
+| Writing a feature PRD or RFC | `feature-readiness` |
 | Writing documentation | `enterprise-docs` |
 
 ## Language Policy (ENFORCED)
@@ -203,6 +207,7 @@ See `ui/AGENTS.md` for E2E test rules and conventions.
 - [ ] CUD operations use `AuditService.log()` or an equivalent audit abstraction
 - [ ] App URL uses `getAppUrl()`, NOT direct env var access
 - [ ] New skills are committed to `skills/` (verify with `pnpm skills:check`)
+- [ ] Features with mutations include traceability section in PRD/RFC (see `feature-readiness` skill)
 
 ## Commit & PR Conventions
 

--- a/docs/adr/005-feature-traceability-readiness.md
+++ b/docs/adr/005-feature-traceability-readiness.md
@@ -1,0 +1,91 @@
+# ADR 005: Feature Traceability Readiness Convention
+
+## Status
+Accepted
+
+## Context
+The platform template has individual rules for audit logging (AGENTS.md, packages/core/AGENTS.md), Sentry instrumentation (sentry skill), and testing (playwright skill, ui/AGENTS.md). However, these rules are fragmented: no single checklist forces every new feature to define its full traceability surface before implementation begins.
+
+This means traceability depends on the implementer remembering to wire audit events, Sentry tags, local seed data, E2E flows, and external provider adapters. In a template designed for production teams, that is unacceptable — conventions must be structural, not aspirational.
+
+## Decision
+
+Every feature that includes mutations (create, update, delete) or external integrations MUST complete a **Feature Traceability Readiness** checklist before implementation starts. This checklist is enforced through a reusable `feature-readiness` skill that agents auto-invoke when writing or reviewing PRD/RFC documents.
+
+### What the convention requires
+
+Each feature PRD/RFC MUST define:
+
+| Category | What to define |
+|----------|---------------|
+| **Audit events** | One named event per mutation (e.g., `tenant_member.invited`, `resource.archived`) |
+| **Sentry instrumentation** | Sentry area tag for Server Actions, which errors to capture, PII exclusions |
+| **Seed data** | Deterministic local users, entities, and state variations for E2E testing |
+| **E2E flows** | Minimum Playwright scenarios covering happy path, permission denied, and error states |
+| **External adapters** | Any external provider (email, storage, payment, webhook), with a local fake mode |
+| **Environment variables** | Required and optional env vars, with graceful degradation when optional vars are missing |
+| **Production readiness** | What must pass before the feature ships (tests, RLS verification, audit coverage) |
+
+### Audit event naming
+
+Audit events follow the pattern `{domain}.{action}`:
+
+```
+tenant_member.invited
+tenant_member.removed
+tenant_member.role_changed
+tenant_invitation.revoked
+tenant_invitation.accepted
+resource.created
+resource.archived
+```
+
+### Sentry area registration
+
+Each feature registers a Sentry area in `ui/lib/sentry.ts` by extending the `SentryArea` union type. Server Actions use `withServerActionInstrumentation` for tracing and `captureActionError` for error capture.
+
+### External adapter pattern
+
+External integrations use a port/adapter pattern:
+
+```
+Is there an external provider (email, storage, payment)?
+├── Yes → Define an adapter interface in @enterprise/core
+│         ├── Local: fake/stub implementation (logs to console or returns mock)
+│         └── Production: real provider implementation (Resend, Stripe, S3)
+│         └── Selection: based on env var presence, not NODE_ENV
+└── No  → Skip this category
+```
+
+### Seed data requirements
+
+Local seed data in `supabase/seed.sql` must include:
+- At least one entity per relevant state (e.g., pending invitation, expired invitation, active member)
+- Deterministic IDs and emails so Playwright tests can reference them without dynamic lookup
+- Alignment with existing seed users (`admin@enterprise.dev`, `member@enterprise.dev`, etc.)
+
+### When the convention applies
+
+```
+Does the feature include mutations (CUD)?
+├── Yes → Full checklist required
+└── No
+    ├── Does it integrate with an external provider?
+    │   └── Yes → Adapter + env var sections required
+    └── No  → Convention does not apply (read-only, no external deps)
+```
+
+## Consequences
+- Every feature PRD/RFC has a traceability section before implementation starts
+- Agents auto-invoke the `feature-readiness` skill when creating or reviewing feature docs
+- Local development works without production provider credentials
+- E2E tests have predictable seed data
+- Audit log coverage is defined upfront, not retrofitted
+- Sentry instrumentation is planned, not forgotten
+
+## References
+- ADR 001: Platform Architecture
+- ADR 003: Service Layer Architecture
+- `sentry` skill: Server Action instrumentation patterns
+- `packages/core/AGENTS.md`: CUD audit logging rule
+- `ui/AGENTS.md`: E2E test requirements

--- a/docs/features/tenant-team-management/prd.md
+++ b/docs/features/tenant-team-management/prd.md
@@ -9,70 +9,316 @@ lastUpdated: "2026-05-07"
 
 ## Purpose
 
-Define roadmap-level product requirements for tenant-scoped team management in a multi-tenant SaaS template.
+Define implementation-ready product requirements for tenant-scoped team management in a multi-tenant SaaS template.
 
 ## Scope
 
-- Included: member lifecycle, role assignment, invitations, and governance at tenant level.
-- Excluded: low-level authorization architecture and RLS implementation details (covered in the RFC and shared architecture docs).
+- Included: member lifecycle, role assignment, invitations, governance, UX flows, permissions, and traceability.
+- Excluded: Row-Level Security (RLS) implementation details (see RFC), owner transfer (follow-up), SCIM, SSO enterprise, custom role builders.
 
 ---
 
 ## Problem
 
-Teams need a clear way to add, remove, and manage members per tenant without exposing cross-tenant data or overloading global admins.
+Teams need a clear way to add, remove, and manage members per tenant without exposing cross-tenant data or overloading global admins. Today there is no UI or workflow for inviting users, changing roles, or removing members from a tenant.
 
 ## Users and stakeholders
 
 | Role | Need |
 |------|------|
-| Tenant owner | Full control of membership and sensitive role changes |
-| Tenant admin | Day-to-day team operations |
-| Member | Predictable access and self-visibility |
+| Tenant owner | Full control of membership, roles, and sensitive operations |
+| Tenant admin | Day-to-day team operations: invite, role change, remove |
+| Member | View team list, see own role, accept invitations |
+| Guest | Limited visibility, cannot manage team |
 | Platform engineering | Consistent access model across features |
 
 ## Goals
 
-- Provide reliable tenant-scoped member management.
+- Provide reliable tenant-scoped member management with clear role boundaries.
 - Reduce manual support requests for role and access changes.
 - Keep role semantics consistent across the platform.
+- Ensure zero cross-tenant data leaks in all team operations.
+
+---
+
+## Permission matrix
+
+| Action | Owner | Admin | Member | Guest |
+|--------|-------|-------|--------|-------|
+| View team members list | Yes | Yes | Yes | No |
+| View pending invitations | Yes | Yes | No | No |
+| Invite member | Yes | Yes | No | No |
+| Revoke invitation | Yes | Yes (own invites) | No | No |
+| Accept invitation | N/A | N/A | N/A | N/A |
+| Change member role | Yes (any except owner) | Yes (member/guest only) | No | No |
+| Remove member | Yes (any except self) | Yes (member/guest only) | No | No |
+
+> **Important**: No one can create another owner in MVP. Admins cannot modify or remove owners. Owner transfer is a follow-up feature.
 
 ---
 
 ## MVP scope
 
-- List tenant members with role and status.
-- Invite member by email with expiration.
-- Accept or revoke invitations.
-- Change member role with owner/admin restrictions.
-- Remove member from tenant.
+### Member lifecycle
 
-## Out of scope
+- List all tenant members with name, email, avatar, role, status, and joined date.
+- Invite a new member by email with a role assignment (`admin`, `member`, `guest`).
+- Accept an invitation via a unique link, joining the tenant with the assigned role.
+- Revoke a pending invitation before acceptance.
+- Change an existing member's role within permission boundaries.
+- Remove a member from the tenant (preserving historical audit attribution).
 
+### Invitation lifecycle
+
+| State | Description |
+|-------|-------------|
+| `pending` | Invitation sent, awaiting acceptance |
+| `accepted` | User accepted and joined the tenant |
+| `revoked` | Owner/admin manually revoked before acceptance |
+| `expired` | Expiration time passed without acceptance |
+
+Rules:
+- Default expiration: 7 days from creation.
+- One pending invitation per email per tenant (duplicate sends are rejected).
+- Expired invitations cannot be accepted.
+- Revoked invitations cannot be accepted.
+- Removed users keep historical attribution in audit logs.
+
+### Out of scope (MVP)
+
+- Owner transfer.
 - Cross-tenant user directories.
 - SCIM or external identity provisioning.
 - Custom role builders and permission matrices.
+- Resend invitation (follow-up).
+- Bulk invite (follow-up).
+
+---
+
+## UX specification
+
+### Route
+
+`/dashboard/team`
+
+### Page layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Header: "Team" + description + [Invite member] CTA  │
+├─────────────────────────────────────────────────────┤
+│ Summary cards row:                                   │
+│   [Total members]  [Pending invitations]  [Admins]  │
+├─────────────────────────────────────────────────────┤
+│ Tab: Members | Invitations                           │
+├─────────────────────────────────────────────────────┤
+│ Members table (default tab):                         │
+│   Avatar | Name | Email | Role | Joined | Actions   │
+│   ...                                                │
+├─────────────────────────────────────────────────────┤
+│ Invitations table (second tab):                      │
+│   Email | Role | Invited by | Expires | Status |Act │
+│   ...                                                │
+└─────────────────────────────────────────────────────┘
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **Invite dialog** | Modal with email input + role selector (`admin`, `member`, `guest`). No `owner` option. Validates email format client-side. Shows duplicate error if pending invite exists. |
+| **Members table** | Sortable by name and role. Each row has an actions menu (dropdown). Owner/admin see role change and remove options. Members see no actions. |
+| **Invitations table** | Visible only to owner/admin. Shows email, assigned role, invited by, expiration date, status badge. Actions: revoke (if pending). |
+| **Role change** | Dropdown or select in action menu. Confirmation dialog when promoting to admin. Blocked for owner rows. |
+| **Remove member** | Confirmation dialog: "Remove {name} from this workspace? This action cannot be undone." Cannot remove self. Cannot remove owners (for admins). |
+| **Summary cards** | Total members count, pending invitations count, admins+owners count. |
+| **Invite acceptance page** | `/invite/accept?token=...` — validates token, shows tenant name, confirms acceptance or shows error (expired/revoked/invalid). |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Loading** | Skeleton rows in tables, skeleton cards in summary |
+| **Empty members** | Only owner exists — show "Invite your first team member" prompt |
+| **Empty invitations** | "No pending invitations" message in invitations tab |
+| **Duplicate invite error** | Inline form error: "An invitation for this email is already pending" |
+| **Expired invite** | Acceptance page shows: "This invitation has expired. Ask your team admin for a new one." |
+| **Revoked invite** | Acceptance page shows: "This invitation has been revoked." |
+| **Invalid token** | Acceptance page shows: "Invalid invitation link." |
+| **Permission denied** | Role change/remove actions hidden for unauthorized roles. If somehow triggered, Server Action returns error. |
+| **Success states** | Toast notification after invite sent, role changed, member removed, invitation revoked |
+
+### Role-specific visibility
+
+| Element | Owner | Admin | Member | Guest |
+|---------|-------|-------|--------|-------|
+| Members table | Full + actions | Full + actions (limited) | View only | Hidden (no access to page) |
+| Invitations tab | Visible | Visible | Hidden | Hidden |
+| Invite button | Visible | Visible | Hidden | Hidden |
+| Role change action | All except owners | Member/guest only | Hidden | Hidden |
+| Remove action | All except self | Member/guest only | Hidden | Hidden |
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: Owner invites a member
+
+**As** a tenant owner, **I want** to invite someone by email so they can join my workspace.
+
+Acceptance criteria:
+- Invite dialog opens with email field and role selector.
+- Selecting `admin`, `member`, or `guest` and submitting creates a pending invitation.
+- A second invite to the same email while one is pending shows a duplicate error.
+- The invitation appears in the invitations tab immediately.
+- An invitation email is sent (or logged locally in dev mode).
+
+### US-2: User accepts invitation
+
+**As** an invited user, **I want** to accept my invitation so I join the correct tenant with the right role.
+
+Acceptance criteria:
+- Clicking the invite link opens `/invite/accept?token=...`.
+- If the token is valid and not expired, the user sees tenant name and a confirm button.
+- After confirming, the user is added to the tenant with the assigned role.
+- If the user does not have an account, they are redirected to sign up first, then back to accept.
+- The invitation status changes to `accepted`.
+
+### US-3: Admin changes a member's role
+
+**As** a tenant admin, **I want** to change a member's role so I can adjust permissions.
+
+Acceptance criteria:
+- Admin sees role change option for `member` and `guest` rows only.
+- Selecting a new role and confirming updates the member's role.
+- The role change is reflected immediately in the members table.
+- Promoting to `admin` shows a confirmation dialog.
+- Admins cannot change owner roles.
+
+### US-4: Owner removes a member
+
+**As** a tenant owner, **I want** to remove a member so they lose access to the workspace.
+
+Acceptance criteria:
+- Remove action shows a confirmation dialog.
+- Confirming removes the member from the tenant.
+- The member disappears from the members table.
+- The removed user can no longer access tenant data.
+- Owner cannot remove themselves.
+- Audit log preserves historical attribution.
+
+### US-5: Owner revokes a pending invitation
+
+**As** a tenant owner, **I want** to revoke an invitation so the link becomes invalid.
+
+Acceptance criteria:
+- Revoke action is available on pending invitations only.
+- Confirming changes the invitation status to `revoked`.
+- The invite link no longer works.
+- The invitation row updates to show `revoked` status.
+
+### US-6: Member views team list
+
+**As** a tenant member, **I want** to see who is in my workspace so I know my team.
+
+Acceptance criteria:
+- Member sees the members table with name, email, role, and joined date.
+- Member does not see the invitations tab.
+- Member does not see action menus on any row.
+- Member does not see the invite button.
 
 ---
 
 ## Success metrics
 
-- Invitation acceptance rate per tenant.
-- Median time from invite to active membership.
-- Monthly support tickets related to team access.
+- Invitation acceptance rate per tenant (target: > 80%).
+- Median time from invite to active membership (target: < 24 hours).
+- Monthly support tickets related to team access (target: decrease by 50%).
 - Zero confirmed cross-tenant visibility incidents.
 
 ## Risks
 
-- Role confusion causes accidental privilege escalation.
-- Invitation links may be shared or misused.
-- Complex role transitions increase support burden.
+| Risk | Mitigation |
+|------|------------|
+| Role confusion causes privilege escalation | Permission matrix enforced in service layer + RLS |
+| Invitation links shared or misused | Hashed tokens, 7-day expiration, one-time use |
+| Stale JWT after role change | Role sync to `app_metadata` + document refresh behavior |
+| Complex role transitions increase support | Limited role set in MVP, no custom roles |
 
-## Open questions
+---
 
-- Should owner transfer be in MVP or follow-up?
-- Should removed users keep historical attribution in activity logs?
-- What invitation expiration default is safest for most teams?
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `tenant_member.invited` | Owner/admin creates invitation | `{ email, assignedRole, invitedBy }` |
+| `tenant_invitation.revoked` | Owner/admin revokes pending invitation | `{ email, revokedBy }` |
+| `tenant_invitation.accepted` | User accepts valid invitation | `{ email, acceptedBy, assignedRole }` |
+| `tenant_member.role_changed` | Owner/admin changes member role | `{ targetUserId, previousRole, newRole, changedBy }` |
+| `tenant_member.removed` | Owner/admin removes member | `{ targetUserId, removedBy, previousRole }` |
+| `tenant_invitation.email_delivery_failed` | Email adapter fails to send | `{ email, errorCode }` |
+
+### Sentry
+
+- Area: `team`
+- Instrumented actions: `inviteMemberAction`, `revokeTenantInvitationAction`, `acceptTenantInvitationAction`, `changeTenantMemberRoleAction`, `removeTenantMemberAction`
+- Captured errors: DB failures, role sync failures, email delivery failures
+- PII exclusions: email addresses, invitation tokens, form field values
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Invitation | `pending` | `invite-pending@enterprise.dev`, role `member`, expires in 7 days |
+| Invitation | `expired` | `invite-expired@enterprise.dev`, role `member`, expired yesterday |
+| Invitation | `revoked` | `invite-revoked@enterprise.dev`, role `guest`, revoked by admin |
+| Member | `active` | Existing seed users: `admin@enterprise.dev`, `member@enterprise.dev`, `guest@enterprise.dev` |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| Owner invites member by email | Owner | Invitation appears in invitations tab, email logged |
+| Admin invites guest | Admin | Invitation created successfully |
+| Member cannot see invite button | Member | Invite button and invitations tab hidden |
+| Owner changes member role to admin | Owner | Role updated, confirmation dialog shown |
+| Admin cannot modify owner role | Admin | Role change action hidden for owner rows |
+| Owner revokes pending invitation | Owner | Status changes to revoked |
+| User accepts valid invitation | New user | Joins tenant with correct role |
+| User tries expired invitation | New user | Error page: invitation expired |
+| Guest cannot access team page | Guest | Redirected or access denied |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Email (invitations) | `InvitationEmailPort` | Console adapter — logs invite URL | Resend adapter | `RESEND_API_KEY` |
+
+### Production readiness
+
+- [ ] All audit events verified in `audit_log` table
+- [ ] Sentry area `team` registered and Server Actions instrumented
+- [ ] Unit tests pass for service layer (all 7 service functions)
+- [ ] E2E tests pass for all defined flows
+- [ ] RLS policies verified (no cross-tenant leaks)
+- [ ] Seed data committed and `supabase db reset` works cleanly
+- [ ] `RESEND_API_KEY` documented in production deployment guide
+- [ ] Role change syncs `app_metadata` and audit logs the change
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Owner transfer in MVP? | No — follow-up | Simplifies permission rules significantly |
+| Removed users keep audit attribution? | Yes | Compliance and traceability requirement |
+| Invitation expiration default? | 7 days | Balances security and usability |
+| Resend invitation in MVP? | No — follow-up | Adds email complexity without core value |
+| Invitation token storage? | Hashed (SHA-256) | Security best practice, prevents DB leak exposure |
 
 ---
 

--- a/docs/features/tenant-team-management/rfc.md
+++ b/docs/features/tenant-team-management/rfc.md
@@ -9,70 +9,511 @@ lastUpdated: "2026-05-07"
 
 ## Purpose
 
-Define a technical approach for secure tenant-scoped team management aligned with the service layer and contracts patterns.
+Define an implementation-ready technical approach for secure tenant-scoped team management aligned with the service layer, contracts, and traceability conventions.
 
 ## Scope
 
-- Included: contracts, service APIs, Server Actions, data model updates, and RLS policy implications.
-- Excluded: external identity provider integrations and enterprise provisioning protocols.
+- Included: data model, RLS policies, contracts, service APIs, Server Actions, UI routes, role metadata synchronization, email adapter, seed data, and testing strategy.
+- Excluded: SCIM, SSO enterprise, owner transfer (follow-up), custom role builders.
 
 ---
 
 ## Summary
 
-Implement team management as a tenant-bounded module using Next.js Server Actions as thin wrappers, service functions in `@enterprise/core`, and Row-Level Security (RLS) enforced in Supabase.
+Implement team management as a tenant-bounded module using:
+- Drizzle schema for `tenant_invitations` table with RLS policies
+- Zod contracts in `@enterprise/contracts` for all inputs and outputs
+- Function-based services in `@enterprise/core/src/services/tenant-team-service.ts`
+- Thin Server Actions in `ui/features/tenant-team-management/actions.ts`
+- Port/adapter pattern for invitation email delivery
+- Sentry instrumentation for all Server Actions
+- Audit logging for all mutations
 
-## Technical objective
+## Technical objectives
 
-- Ensure role and membership mutations never bypass tenant boundaries.
-- Keep role checks centralized in service functions.
-- Use contracts as input/output source of truth.
+- Role and membership mutations never bypass tenant boundaries (RLS + service layer guards).
+- Role changes synchronize both `profiles.role` and `auth.users.raw_app_meta_data.role`.
+- Local development works without external email provider credentials.
+- All mutations are auditable and traceable in Sentry.
 
 ---
 
-## Proposed design
+## Data model
 
-| Layer | Design |
-|------|--------|
-| Contracts | Add invitation, member list, and role-change schemas in `@enterprise/contracts` |
-| Service layer | Add `tenant-team-service.ts` with invite, revoke, accept, role change, remove member |
-| App layer | Add thin actions under `ui/features/tenant-team-management/actions.ts` |
-| Database | Add `tenant_invitations` table and tenant-scoped relationships in Drizzle |
-| Audit | Log CUD operations with existing audit abstraction |
+### `tenant_invitations` table
 
-## Security and tenant isolation implications
+Location: `packages/db/src/schema/platform.ts`
 
-- Membership reads and writes remain tenant-scoped through RLS policies.
-- Owner-only transitions (for example owner transfer) are guarded in service layer and policy checks.
-- Invitation acceptance validates token ownership and tenant context before membership mutation.
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK to `tenants.id`, ON DELETE CASCADE |
+| `email` | `text` | NOT NULL, normalized lowercase |
+| `role` | `user_role` enum | NOT NULL |
+| `token_hash` | `text` | NOT NULL, UNIQUE |
+| `status` | `invitation_status` enum | NOT NULL, default `pending` |
+| `invited_by` | `uuid` | NOT NULL, FK to `profiles.id` |
+| `accepted_by` | `uuid` | NULLABLE, FK to `profiles.id` |
+| `expires_at` | `timestamptz` | NOT NULL |
+| `accepted_at` | `timestamptz` | NULLABLE |
+| `revoked_at` | `timestamptz` | NULLABLE |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### New enum
+
+```typescript
+export const invitationStatusEnum = pgEnum("invitation_status", [
+  "pending",
+  "accepted",
+  "revoked",
+  "expired",
+]);
+```
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `invitations_tenant_idx` | `tenant_id` | Tenant-scoped queries |
+| `invitations_email_tenant_idx` | `email`, `tenant_id` | Duplicate invitation check |
+| `invitations_token_hash_idx` | `token_hash` | Token lookup on acceptance |
+| `invitations_status_idx` | `status` | Filter by status |
+
+### Constraints
+
+- UNIQUE on `(tenant_id, email)` WHERE `status = 'pending'` — enforced in service layer (partial unique index if supported, otherwise service-level check).
+- `token_hash` is UNIQUE globally.
+- `email` is stored normalized to lowercase before insert.
+
+### Type exports
+
+```typescript
+export type TenantInvitation = typeof tenantInvitations.$inferSelect;
+export type NewTenantInvitation = typeof tenantInvitations.$inferInsert;
+```
+
+---
+
+## RLS policies
+
+### `tenant_invitations`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `invitations_select` | SELECT | `authenticated` | `tenant_id` matches JWT claim AND role IN (`owner`, `admin`) |
+| `invitations_insert` | INSERT | `authenticated` | `tenant_id` matches JWT claim AND role IN (`owner`, `admin`) AND `invited_by = auth.uid()` |
+| `invitations_update` | UPDATE | `authenticated` | `tenant_id` matches JWT claim AND role IN (`owner`, `admin`) |
+| `invitations_delete` | DELETE | — | No direct deletes — status transitions only |
+
+### Invitation acceptance
+
+Acceptance uses the **admin client** (`service_role`) because:
+1. The accepting user may not yet have a profile in the target tenant.
+2. RLS would block the insert into `profiles` since the user's JWT has no `tenant_id` claim for this tenant.
+3. After acceptance, the admin client updates `auth.users.raw_app_meta_data` with the new `tenant_id` and `role`.
+
+> **Warning**: The admin client is used ONLY in the acceptance service function, NEVER in request-driven user flows. The token hash validation and expiration check happen BEFORE any admin client operation.
+
+---
+
+## Role metadata synchronization
+
+### The problem
+
+RLS policies authorize against `auth.jwt()->'app_metadata'->>'role'`, not `profiles.role`. Changing only `profiles.role` leaves authorization stale until the JWT refreshes.
+
+### The solution
+
+Every role change in `tenant-team-service.ts` MUST:
+
+1. Update `profiles.role` via the authenticated Supabase client.
+2. Update `auth.users.raw_app_meta_data.role` via the admin client (`supabase.auth.admin.updateUserById`).
+3. Log the role change to the audit log.
+
+```
+Role change flow:
+  Service receives (client, adminClient, targetUserId, newRole)
+    │
+    ├─ 1. Verify caller has permission (owner for any, admin for member/guest)
+    ├─ 2. Update profiles.role via authenticated client (RLS enforced)
+    ├─ 3. Update auth.users.raw_app_meta_data.role via admin client
+    ├─ 4. Log audit event: tenant_member.role_changed
+    └─ 5. Return ServiceResult<ProfileRecord>
+```
+
+> **Note**: The user's JWT will reflect the new role on their next token refresh. For immediate enforcement, the UI should trigger a session refresh after a role change confirmation.
+
+### Invitation acceptance role assignment
+
+When a user accepts an invitation:
+
+1. Create or update the `profiles` row with the invited role and target `tenant_id`.
+2. Set `auth.users.raw_app_meta_data` with `{ tenant_id, role }` via admin client.
+3. Log audit event: `tenant_invitation.accepted`.
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/tenant-team.ts` and `packages/contracts/src/schemas/tenant-team.ts`
+
+### Input schemas
+
+```typescript
+// Invite member
+export const inviteTenantMemberSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["admin", "member", "guest"]),
+});
+
+// Change member role
+export const changeTenantMemberRoleSchema = z.object({
+  targetUserId: z.string().uuid(),
+  newRole: z.enum(["admin", "member", "guest"]),
+});
+
+// Revoke invitation
+export const revokeTenantInvitationSchema = z.object({
+  invitationId: z.string().uuid(),
+});
+
+// Accept invitation
+export const acceptTenantInvitationSchema = z.object({
+  token: z.string().min(1),
+});
+
+// Remove member
+export const removeTenantMemberSchema = z.object({
+  targetUserId: z.string().uuid(),
+});
+
+// Query schemas
+export const tenantMembersQuerySchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const tenantInvitationsQuerySchema = z.object({
+  status: z.enum(["pending", "accepted", "revoked", "expired"]).optional(),
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+```
+
+### Type exports
+
+All DTOs derive types via `z.infer<typeof schema>`.
+
+---
+
+## Service layer
+
+Location: `packages/core/src/services/tenant-team-service.ts`
+
+Pattern: function-based (per `packages/core/AGENTS.md`).
+
+### Service functions
+
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `listTenantMembers` | `client, tenantId, query` | `ServiceResult<ProfileRecord[]>` | RLS-scoped read |
+| `listTenantInvitations` | `client, tenantId, query` | `ServiceResult<TenantInvitation[]>` | Owner/admin only |
+| `inviteTenantMember` | `client, tenantId, userId, input` | `ServiceResult<TenantInvitation>` | Generates token, hashes it, creates invitation, calls email adapter |
+| `revokeTenantInvitation` | `client, tenantId, userId, invitationId` | `ServiceResult<null>` | Sets status to `revoked`, sets `revoked_at` |
+| `acceptTenantInvitation` | `client, adminClient, token` | `ServiceResult<ProfileRecord>` | Validates token hash, checks expiry, creates profile, syncs `app_metadata` |
+| `changeTenantMemberRole` | `client, adminClient, tenantId, userId, input` | `ServiceResult<ProfileRecord>` | Permission check, updates profile + `app_metadata` |
+| `removeTenantMember` | `client, adminClient, tenantId, userId, targetUserId` | `ServiceResult<null>` | Permission check, removes profile, clears `app_metadata` |
+
+### Token generation
+
+```
+1. Generate 32-byte random token via crypto.randomBytes(32)
+2. Encode as URL-safe base64
+3. Hash with SHA-256 before storing in DB
+4. Return plain token to the caller (for email link)
+5. On acceptance, hash the incoming token and compare against stored hash
+```
+
+### Dependency injection
+
+Services receive both `SupabaseClient` (authenticated, RLS-bound) and `AdminClient` (service role, for `app_metadata` mutations). The admin client is ONLY used for:
+- `auth.admin.updateUserById()` — role sync
+- Profile creation during invitation acceptance (when user has no tenant context)
+
+---
+
+## Server Actions
+
+Location: `ui/features/tenant-team-management/actions.ts`
+
+All actions follow the thin wrapper pattern:
+
+```
+validate input (Zod) → get authenticated client → call service → map to ActionResult → revalidatePath
+```
+
+### Actions list
+
+| Action | Schema | Service function | Sentry area |
+|--------|--------|------------------|-------------|
+| `inviteMemberAction` | `inviteTenantMemberSchema` | `inviteTenantMember` | `team` |
+| `revokeTenantInvitationAction` | `revokeTenantInvitationSchema` | `revokeTenantInvitation` | `team` |
+| `acceptTenantInvitationAction` | `acceptTenantInvitationSchema` | `acceptTenantInvitation` | `team` |
+| `changeTenantMemberRoleAction` | `changeTenantMemberRoleSchema` | `changeTenantMemberRole` | `team` |
+| `removeTenantMemberAction` | `removeTenantMemberSchema` | `removeTenantMember` | `team` |
+
+### Sentry instrumentation
+
+Every action wraps its body with `Sentry.withServerActionInstrumentation`. Non-validation errors call `captureActionError` with:
+- `actionName`: the action function name
+- `area`: `"team"`
+- `tenantId`, `userId`, `userRole` from auth context
+- `inputShape`: `Object.keys(parsed.data)` — NEVER values
+- `errorCode`: from `ServiceResult.code`
+
+---
+
+## Email adapter
+
+### Interface
+
+Location: `packages/core/src/services/ports/invitation-email-port.ts`
+
+```typescript
+export interface InvitationEmailPort {
+  sendInvitation(params: {
+    to: string;
+    inviterName: string;
+    tenantName: string;
+    inviteUrl: string;
+    role: string;
+    expiresAt: Date;
+  }): Promise<{ success: boolean; error?: string }>;
+}
+```
+
+### Implementations
+
+| Adapter | Location | Behavior | Selection |
+|---------|----------|----------|-----------|
+| `ConsoleInvitationEmailAdapter` | `packages/core/src/services/adapters/console-invitation-email.ts` | Logs invite URL to `console.info` | Default when `RESEND_API_KEY` is not set |
+| `ResendInvitationEmailAdapter` | `packages/core/src/services/adapters/resend-invitation-email.ts` | Sends via Resend API | When `RESEND_API_KEY` is set |
+
+### Adapter factory
+
+```typescript
+export function createInvitationEmailAdapter(): InvitationEmailPort {
+  const resendKey = process.env["RESEND_API_KEY"];
+  if (resendKey) {
+    return new ResendInvitationEmailAdapter(resendKey);
+  }
+  return new ConsoleInvitationEmailAdapter();
+}
+```
+
+Selection is based on env var presence, NOT `NODE_ENV`.
+
+---
+
+## UI routes and components
+
+### Routes
+
+| Route | Component | Auth | Description |
+|-------|-----------|------|-------------|
+| `/dashboard/team` | `TeamPage` | Required, owner/admin/member | Main team management page |
+| `/invite/accept` | `AcceptInvitePage` | Optional (may need signup first) | Invitation acceptance flow |
+
+### Feature module structure
+
+```
+ui/features/tenant-team-management/
+├── actions.ts                    # Server Actions (thin wrappers)
+├── queries.ts                    # Server-side data fetching
+├── types.ts                      # Feature-local types
+├── components/
+│   ├── team-page-header.tsx      # Header with title + invite CTA
+│   ├── team-summary-cards.tsx    # Stats cards row
+│   ├── members-table.tsx         # Members data table
+│   ├── invitations-table.tsx     # Invitations data table
+│   ├── invite-member-dialog.tsx  # Modal with email + role form
+│   ├── change-role-select.tsx    # Role change dropdown
+│   └── remove-member-dialog.tsx  # Confirmation dialog
+└── hooks/
+    └── (if needed)
+```
+
+### App routes
+
+```
+ui/app/(dashboard)/dashboard/team/
+├── page.tsx                      # Server Component — fetches data, passes to views
+└── error.tsx                     # Error boundary with Sentry
+
+ui/app/invite/
+└── accept/
+    └── page.tsx                  # Invitation acceptance page
+```
+
+---
+
+## Seed data
+
+Location: additions to `supabase/seed.sql`
+
+### Seed invitations
+
+```sql
+-- Pending invitation (valid, expires in 7 days)
+INSERT INTO public.tenant_invitations (
+  id, tenant_id, email, role, token_hash, status,
+  invited_by, expires_at, created_at, updated_at
+) VALUES (
+  'a1b2c3d4-0001-0001-0001-000000000001',
+  '<demo_tenant_id>',
+  'invite-pending@enterprise.dev',
+  'member',
+  encode(sha256('seed-token-pending'::bytea), 'hex'),
+  'pending',
+  '<owner_user_id>',
+  now() + interval '7 days',
+  now(), now()
+);
+
+-- Expired invitation
+INSERT INTO public.tenant_invitations (
+  id, tenant_id, email, role, token_hash, status,
+  invited_by, expires_at, created_at, updated_at
+) VALUES (
+  'a1b2c3d4-0001-0001-0001-000000000002',
+  '<demo_tenant_id>',
+  'invite-expired@enterprise.dev',
+  'member',
+  encode(sha256('seed-token-expired'::bytea), 'hex'),
+  'expired',
+  '<owner_user_id>',
+  now() - interval '1 day',
+  now() - interval '8 days', now()
+);
+
+-- Revoked invitation
+INSERT INTO public.tenant_invitations (
+  id, tenant_id, email, role, token_hash, status,
+  invited_by, revoked_at, expires_at, created_at, updated_at
+) VALUES (
+  'a1b2c3d4-0001-0001-0001-000000000003',
+  '<demo_tenant_id>',
+  'invite-revoked@enterprise.dev',
+  'guest',
+  encode(sha256('seed-token-revoked'::bytea), 'hex'),
+  'revoked',
+  '<admin_user_id>',
+  now() - interval '2 days',
+  now() + interval '5 days',
+  now() - interval '3 days', now()
+);
+```
+
+> **Note**: `<demo_tenant_id>`, `<owner_user_id>`, and `<admin_user_id>` reference existing deterministic seed IDs from the current `seed.sql`.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/core/src/services/__tests__/tenant-team-service.test.ts`
+
+| Test | What it verifies |
+|------|------------------|
+| `inviteTenantMember` success | Creates invitation, hashes token, calls email adapter |
+| `inviteTenantMember` duplicate | Rejects when pending invitation exists for same email |
+| `inviteTenantMember` role restriction | Rejects `owner` role assignment |
+| `acceptTenantInvitation` success | Validates token, creates profile, syncs `app_metadata` |
+| `acceptTenantInvitation` expired | Rejects expired token |
+| `acceptTenantInvitation` revoked | Rejects revoked invitation |
+| `changeTenantMemberRole` success | Updates profile and `app_metadata` |
+| `changeTenantMemberRole` permission | Admin cannot change owner role |
+| `removeTenantMember` success | Removes profile, clears `app_metadata` |
+| `removeTenantMember` self-remove | Rejects self-removal |
+
+### Contract tests
+
+Location: `packages/contracts/src/__tests__/tenant-team.test.ts`
+
+Test all schemas for valid input, boundary values, and rejection of invalid input.
+
+### E2E tests
+
+Location: `ui/e2e/tenant-team-management/tenant-team-management.spec.ts`
+
+| Test | Tag | Flow |
+|------|-----|------|
+| Owner invites member | `@critical` | Login as owner → invite → verify in table |
+| Admin invites guest | | Login as admin → invite → verify |
+| Member sees no admin actions | `@critical` | Login as member → verify hidden controls |
+| Owner changes member to admin | | Login as owner → change role → verify |
+| Admin cannot modify owner | | Login as admin → verify owner row has no actions |
+| Owner revokes invitation | | Login as owner → revoke → verify status |
+| Accept valid invitation | `@critical` | Navigate to invite link → accept → verify membership |
+| Expired invitation shows error | | Navigate to expired link → verify error |
+| Guest cannot access team page | | Login as guest → navigate → verify redirect |
+
+---
+
+## Sentry area registration
+
+Add `team` to the `SentryArea` union in `ui/lib/sentry.ts`:
+
+```typescript
+export type SentryArea = "auth" | "dashboard" | "resources" | "settings" | "team" | "webhook";
+```
 
 ---
 
 ## Trade-offs
 
-- **Chosen:** explicit service functions per action for clarity and auditability.
-- **Not chosen:** generic role mutation endpoint, because it obscures authorization intent.
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Service pattern | Explicit function per action | Generic role mutation endpoint | Clarity, auditability, per-action permission checks |
+| Token storage | SHA-256 hashed | Plain text | Security — DB leak does not expose usable tokens |
+| Role sync | Dual write (profile + `app_metadata`) | Profile-only | RLS depends on JWT claims, not profile table |
+| Email adapter | Port/adapter with env-var selection | Direct Resend calls | Local dev works without credentials |
+| Invitation acceptance auth | Admin client (service role) | Authenticated client | Accepting user has no tenant context in JWT |
 
 ## Risks
 
-- RLS policy drift between memberships and invitations.
-- Race conditions on simultaneous role updates.
-- Email invite lifecycle complexity if provider behavior varies.
+| Risk | Mitigation |
+|------|------------|
+| RLS policy drift between profiles and invitations | Both tables use same `tenantClaimMatchesColumn` pattern |
+| Race conditions on simultaneous role updates | Service-level optimistic concurrency via `updated_at` check |
+| Stale JWT after role change | Document that UI should trigger session refresh; short JWT expiry recommended |
+| Email adapter failure | Console fallback always works; audit event `email_delivery_failed` logged |
 
 ---
 
-## Rollout and implementation phases
+## Implementation phases
 
-1. Contracts and data model foundations.
-2. Service functions with unit tests.
-3. Server Actions and UI integration.
-4. E2E flows for invite, role update, removal.
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Contracts: Zod schemas + types in `@enterprise/contracts` | None |
+| 2 | Data model: `tenant_invitations` table, enum, RLS, migration | Phase 1 |
+| 3 | Services: `tenant-team-service.ts` + email adapter + unit tests | Phase 1, 2 |
+| 4 | Server Actions + Sentry instrumentation | Phase 3 |
+| 5 | UI: team page, invite dialog, tables, acceptance page | Phase 4 |
+| 6 | Seed data + E2E tests | Phase 5 |
 
-## Open questions
+---
 
-- Should invitation token storage be hashed at rest in MVP?
-- Should owner role be immutable in v1?
-- What audit metadata fields are required for compliance-ready logs?
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Token hashed at rest? | Yes — SHA-256 | Security best practice |
+| Owner role immutable in v1? | Yes — no owner transfer | Simplifies permission model |
+| Audit metadata fields? | `tenantId`, `userId`, `action`, `resource`, `resourceId`, domain-specific extras | Compliance-ready baseline |
+| `profiles.role` vs `user_roles` as source? | `profiles.role` is primary; `user_roles` for history | Simpler model, history preserved in audit log |
 
 ---
 

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -10,12 +10,12 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Action | Skill |
 |--------|-------|
-| Writing Zod validation schemas | `typescript` |
-| TypeScript types, DTO exports, strict-mode fixes | `typescript` |
-| Making permission or role-based decisions | `typescript` |
-| Defining enums or const objects | `typescript` |
-
-Project uses **Zod 3.24**. A `zod-4` skill exists for future migration reference. Current validation patterns follow the rules below.
+| Committing changes | `enterprise-commit` |
+| Creating SDD proposals for features | `feature-readiness` |
+| Creating a git commit | `enterprise-commit` |
+| Reviewing a feature PRD or RFC | `feature-readiness` |
+| Starting feature implementation | `feature-readiness` |
+| Writing a feature PRD or RFC | `feature-readiness` |
 
 ---
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -11,8 +11,11 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Action | Skill |
 |--------|-------|
 | Adding RLS policies | `drizzle` |
+| Committing changes | `enterprise-commit` |
 | Configuring RLS at client level | `supabase` |
 | Configuring database connections | `supabase-postgres-best-practices` |
+| Creating SDD proposals for features | `feature-readiness` |
+| Creating a git commit | `enterprise-commit` |
 | Creating database relations | `drizzle` |
 | Creating database schemas | `drizzle` |
 | Defining auth-related database schemas or RLS policies | `drizzle` |
@@ -20,11 +23,14 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Implementing auth flows | `supabase` |
 | Implementing pgvector/embeddings | `drizzle` |
 | Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Reviewing a feature PRD or RFC | `feature-readiness` |
 | Reviewing schema performance | `supabase-postgres-best-practices` |
 | Running migrations | `drizzle` |
 | Setting up Supabase SSR cookies | `supabase` |
+| Starting feature implementation | `feature-readiness` |
 | Using getUser or getSession | `supabase` |
 | Working with Supabase clients | `supabase` |
+| Writing a feature PRD or RFC | `feature-readiness` |
 | Writing database queries | `drizzle` |
 
 ---

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -11,15 +11,21 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Action | Skill |
 |--------|-------|
 | Adding RLS policies | `drizzle` |
+| Committing changes | `enterprise-commit` |
 | Configuring database connections | `supabase-postgres-best-practices` |
+| Creating SDD proposals for features | `feature-readiness` |
+| Creating a git commit | `enterprise-commit` |
 | Creating database relations | `drizzle` |
 | Creating database schemas | `drizzle` |
 | Defining auth-related database schemas or RLS policies | `drizzle` |
 | Defining table columns and types | `drizzle` |
 | Implementing pgvector/embeddings | `drizzle` |
 | Optimizing Postgres queries | `supabase-postgres-best-practices` |
+| Reviewing a feature PRD or RFC | `feature-readiness` |
 | Reviewing schema performance | `supabase-postgres-best-practices` |
 | Running migrations | `drizzle` |
+| Starting feature implementation | `feature-readiness` |
+| Writing a feature PRD or RFC | `feature-readiness` |
 | Writing database queries | `drizzle` |
 
 ---

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -15,8 +15,10 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Building mobile-first UI | `design-components` |
 | Choosing between border and tonal shift | `design-rules` |
 | Choosing colors for components | `design-tokens` |
+| Committing changes | `enterprise-commit` |
 | Composing layout structure | `design-rules` |
 | Composing shadcn components for a screen | `design-components` |
+| Creating a git commit | `enterprise-commit` |
 | Creating cards, panels, or containers | `design-rules` |
 | Creating feature components | `design-components` |
 | Creating navigation or layout components | `design-components` |

--- a/skills/feature-readiness/SKILL.md
+++ b/skills/feature-readiness/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: feature-readiness
+description: >
+  Feature traceability readiness checklist for the Enterprise Platform. Ensures every feature with mutations
+  or external integrations defines audit events, Sentry instrumentation, seed data, E2E flows, external
+  adapters, env vars, and production readiness criteria before implementation begins.
+  Trigger: When writing PRD/RFC docs, reviewing feature specs, creating SDD proposals, or starting feature implementation.
+license: Apache-2.0
+metadata:
+  author: enterprise-platform
+  version: "1.0"
+  scope: [root, ui, packages/core, packages/db, packages/contracts]
+  auto_invoke:
+    - "Writing a feature PRD or RFC"
+    - "Reviewing a feature PRD or RFC"
+    - "Starting feature implementation"
+    - "Creating SDD proposals for features"
+---
+
+## Critical Rules
+
+- ALWAYS complete the traceability checklist before implementation starts
+- ALWAYS define one audit event per mutation (create, update, delete)
+- ALWAYS register a Sentry area for each new feature module
+- ALWAYS define local seed data for E2E testing
+- ALWAYS use the adapter pattern for external providers
+- ALWAYS ensure local dev works without production provider credentials
+- NEVER skip traceability for features with mutations — this is not optional
+- NEVER send PII or secrets to Sentry — only field names, codes, and IDs
+- NEVER hardcode test data in E2E tests — use deterministic seed data
+
+---
+
+## When to use
+
+Load this skill when:
+- Writing or reviewing a feature PRD or RFC
+- Creating SDD proposals, specs, or task breakdowns for features
+- Starting implementation of a feature with mutations or external integrations
+- Reviewing whether a feature is ready to ship
+
+## When this does NOT apply
+
+```
+Does the feature include mutations (CUD)?
+├── Yes → Full checklist required
+└── No
+    ├── Does it integrate with an external provider?
+    │   └── Yes → Adapter + env var sections required
+    └── No  → This skill does not apply (read-only, no external deps)
+```
+
+---
+
+## Traceability checklist
+
+Every feature PRD/RFC MUST include a **Traceability** section with these categories resolved:
+
+### 1. Audit events
+
+Define one named event per mutation using `{domain}.{action}` format:
+
+```
+tenant_member.invited
+tenant_member.removed
+tenant_member.role_changed
+tenant_invitation.revoked
+tenant_invitation.accepted
+resource.created
+resource.updated
+resource.archived
+```
+
+Rules:
+- Use `AuditService.log()` or equivalent audit abstraction in the service layer
+- Include `tenantId`, `userId`, `action`, `resource`, `resourceId` in every event
+- Include relevant non-PII metadata (e.g., `{ previousRole: "member", newRole: "admin" }`)
+- Log at service layer, never in Server Actions
+
+### 2. Sentry instrumentation
+
+Define:
+
+| Item | What to specify |
+|------|----------------|
+| **Area tag** | New `SentryArea` value to add to `ui/lib/sentry.ts` (e.g., `"team"`) |
+| **Server Actions** | List all actions that need `withServerActionInstrumentation` |
+| **Error capture** | Which service failures trigger `captureActionError` |
+| **PII exclusions** | What data MUST NOT be sent (emails, tokens, invite URLs, form values) |
+| **Allowed metadata** | What CAN be sent (`inputShape` keys, error codes, IDs) |
+
+Example for a feature RFC:
+
+```markdown
+## Sentry instrumentation
+
+- Area: `team`
+- Instrumented actions: `inviteMemberAction`, `changeMemberRoleAction`, `removeMemberAction`
+- Captured errors: DB failures, role sync failures, email delivery failures
+- PII exclusions: email addresses, invitation tokens, form field values
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`
+```
+
+### 3. Seed data
+
+Define deterministic local data in `supabase/seed.sql`:
+
+| Item | What to specify |
+|------|----------------|
+| **Users** | Deterministic emails and passwords aligned with existing seed users |
+| **Entities** | At least one entity per relevant state |
+| **Relationships** | Cross-entity references needed for E2E flows |
+
+Rules:
+- Use existing seed users when possible (`admin@enterprise.dev`, `member@enterprise.dev`)
+- Add new seed users only when the feature requires a distinct persona
+- Use deterministic UUIDs so Playwright tests can reference them
+- Document seed data in the RFC for implementer clarity
+
+### 4. E2E flows
+
+Define minimum Playwright scenarios:
+
+| Category | Required scenarios |
+|----------|--------------------|
+| **Happy path** | Core CRUD or workflow succeeds end-to-end |
+| **Permission denied** | Lower-role user cannot perform restricted action |
+| **Validation error** | Invalid input shows client-side and server-side errors |
+| **Error state** | Expired/revoked/missing entity shows appropriate UI feedback |
+| **Empty state** | Feature renders correctly with no data |
+
+Rules:
+- Use Page Object Model pattern (see `playwright` skill)
+- Reference seed data by deterministic values, not dynamic lookup
+- Tag critical flows with `@critical`
+
+### 5. External adapters
+
+For each external provider (email, storage, payment, webhook):
+
+| Item | What to specify |
+|------|----------------|
+| **Interface** | Port/adapter interface in `@enterprise/core` |
+| **Local mode** | Fake/stub implementation (console log, in-memory, mock return) |
+| **Production mode** | Real provider implementation |
+| **Selection** | Based on env var presence, NOT `NODE_ENV` |
+
+Example:
+
+```markdown
+## Email adapter
+
+- Interface: `InvitationEmailPort` in `@enterprise/core`
+- Local: `ConsoleInvitationEmailAdapter` — logs invite URL to console
+- Production: `ResendInvitationEmailAdapter` — sends via Resend API
+- Selection: if `RESEND_API_KEY` is set, use Resend; otherwise use console adapter
+```
+
+### 6. Environment variables
+
+| Variable | Required | Scope | Fallback behavior |
+|----------|----------|-------|-------------------|
+| `RESEND_API_KEY` | Optional | Server | Console adapter used when missing |
+
+Rules:
+- Required vars MUST fail fast at startup if missing
+- Optional vars MUST degrade gracefully (local fake, disabled feature, console log)
+- Use `getEnv()` for all access — never `process.env.X!`
+
+### 7. Production readiness
+
+Define what must pass before the feature ships:
+
+```markdown
+## Production readiness criteria
+
+- [ ] All audit events verified in audit_log table
+- [ ] Sentry area registered and Server Actions instrumented
+- [ ] Unit tests pass for service layer
+- [ ] E2E tests pass for all defined flows
+- [ ] RLS policies verified (no cross-tenant leaks)
+- [ ] Seed data committed and `supabase db reset` works cleanly
+- [ ] Optional provider env vars documented in production deployment guide
+```
+
+---
+
+## PRD/RFC section template
+
+Add this section to every feature PRD that involves mutations or external integrations:
+
+```markdown
+---
+
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `{domain}.{action}` | When {description} | `{ key: value }` |
+
+### Sentry
+
+- Area: `{area}`
+- Instrumented actions: {list}
+- Captured errors: {list}
+- PII exclusions: {list}
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| {entity} | {state} | {deterministic values} |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| {description} | {role} | {result} |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| {name} | {port} | {fake} | {real} | {var} |
+
+### Production readiness
+
+- [ ] {criterion}
+```
+
+---
+
+## Decision tree: does this feature need the full checklist?
+
+```
+New feature being planned or implemented?
+├── Does it include CUD operations?
+│   └── Yes → Full checklist (all 7 categories)
+├── Does it integrate with an external provider?
+│   └── Yes → Categories 5, 6, 7 required; 1-4 if it also has mutations
+├── Is it read-only with no external deps?
+│   └── Yes → Checklist NOT required
+└── Is it a UI-only change (styling, layout)?
+    └── Yes → Checklist NOT required
+```
+
+---
+
+## References
+
+- [ADR 005: Feature Traceability Readiness](../../docs/adr/005-feature-traceability-readiness.md) — Decision record for this convention
+- [Service Layer](../../docs/architecture/service-layer.md) — Audit logging in services
+- [Sentry skill](../sentry/SKILL.md) — Server Action instrumentation patterns
+- [Playwright skill](../playwright/SKILL.md) — E2E test patterns

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -22,6 +22,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Composing layout structure | `design-rules` |
 | Composing shadcn components for a screen | `design-components` |
 | Configuring RLS at client level | `supabase` |
+| Creating SDD proposals for features | `feature-readiness` |
 | Creating a git commit | `enterprise-commit` |
 | Creating cards, panels, or containers | `design-rules` |
 | Creating database relations | `drizzle` |
@@ -34,9 +35,11 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Implementing auth flows | `supabase` |
 | Implementing pgvector/embeddings | `drizzle` |
 | Modifying globals.css or @theme tokens | `design-tokens` |
+| Reviewing a feature PRD or RFC | `feature-readiness` |
 | Running migrations | `drizzle` |
 | Setting typography font families or weights | `design-tokens` |
 | Setting up Supabase SSR cookies | `supabase` |
+| Starting feature implementation | `feature-readiness` |
 | Styling component visual hierarchy | `design-rules` |
 | Using Zustand stores | `zustand-5` |
 | Using captureException or captureActionError | `sentry` |
@@ -47,6 +50,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Writing Playwright E2E tests | `playwright` |
 | Writing React components | `react-19` |
 | Writing TypeScript types/interfaces | `typescript` |
+| Writing a feature PRD or RFC | `feature-readiness` |
 | Writing database queries | `drizzle` |
 
 ---


### PR DESCRIPTION
## Summary

- Add ADR 005 establishing a feature traceability readiness convention for the platform
- Add `feature-readiness` skill with a 7-category checklist (audit, Sentry, seed, E2E, adapters, env vars, production readiness)
- Rewrite tenant team management PRD and RFC from roadmap-level to implementation-ready quality, applying the new convention

## Changes

| File | Change |
|------|--------|
| `docs/adr/005-feature-traceability-readiness.md` | New ADR — every feature with mutations must define traceability before implementation |
| `skills/feature-readiness/SKILL.md` | New skill — reusable checklist auto-invoked when writing/reviewing PRD/RFC or starting implementation |
| `docs/features/tenant-team-management/prd.md` | Rewritten — permission matrix, user stories, UX spec, UI states, traceability section, decisions log |
| `docs/features/tenant-team-management/rfc.md` | Rewritten — data model, RLS, role sync, contracts, services, email adapter, seed SQL, testing strategy |
| `AGENTS.md` | Added feature-readiness to skills table, auto-invoke, and QA checklist |
| `ui/AGENTS.md` | Auto-invoke table updated via skill-sync |
| `packages/core/AGENTS.md` | Auto-invoke table updated via skill-sync |
| `packages/db/AGENTS.md` | Auto-invoke table updated via skill-sync |
| `packages/contracts/AGENTS.md` | Auto-invoke table updated via skill-sync |
| `packages/ui/AGENTS.md` | Auto-invoke table updated via skill-sync |

## Verification

- [x] No code changes — documentation and skill only
- [x] `skills/check.sh` passes (after git add)
- [x] `skill-sync` ran successfully across all workspaces
- [x] All generated artifacts in English
- [x] ADR follows existing format (001–004)
- [x] Skill follows agentskills.io standard with frontmatter metadata