### PR TITLE
chore: add multi-brand docs, billing rewrite, and form-validation test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 |--------|-------|
 | Adding developer guides | `enterprise-docs` |
 | Adding error tracking to Server Actions | `sentry` |
+| Adding form validation or error handling | `form-validation` |
 | After creating/modifying a skill | `skill-sync` |
 | App Router / Server Actions | `nextjs-15` |
 | Committing changes | `enterprise-commit` |
@@ -139,6 +140,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Configuring database connections | `supabase-postgres-best-practices` |
 | Creating MDX pages | `enterprise-docs` |
 | Creating SDD proposals for features | `feature-readiness` |
+| Creating Server Actions that validate input | `form-validation` |
 | Creating a git commit | `enterprise-commit` |
 | Creating a pull request | `enterprise-pr` |
 | Creating new skills | `skill-creator` |
@@ -152,9 +154,11 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Setting up Supabase SSR cookies | `supabase` |
 | Starting feature implementation | `feature-readiness` |
 | Troubleshoot why a skill is missing from AGENTS.md auto-invoke | `skill-sync` |
+| Using useActionState | `form-validation` |
 | Using Zustand stores | `zustand-5` |
 | Using captureException or captureActionError | `sentry` |
 | Using getUser or getSession | `supabase` |
+| Working with ActionResult error details | `form-validation` |
 | Working with Supabase clients | `supabase` |
 | Working with Tailwind classes | `tailwind-4` |
 | Working with error boundaries | `sentry` |

--- a/docs/features/backend-provider-decoupling/prd.md
+++ b/docs/features/backend-provider-decoupling/prd.md
@@ -1,0 +1,262 @@
+---
+title: "Backend provider decoupling PRD"
+description: "Introduces port/adapter interfaces in @enterprise/core so the template can work with different backend providers (Supabase, Firebase, custom PostgreSQL, etc.) without rewriting business logic."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Backend provider decoupling PRD
+
+## Purpose
+
+Define implementation-ready product requirements for introducing a port/adapter abstraction layer in `@enterprise/core` that decouples the template's business logic from Supabase-specific APIs. The goal is to allow template adopters to swap or extend backend providers (Auth, Storage, Session/Middleware) without modifying service logic, changing tests, or rewriting features. Supabase remains the reference implementation and the default; decoupling is additive, not a migration.
+
+## Scope
+
+- Included: `AuthPort` interface (sign-in, sign-up, sign-out, getUser, password reset, updateUser), `StoragePort` interface (upload, download, delete, getSignedUrl, listFiles), `SessionPort` interface (middleware-level cookie session management), Supabase reference adapters for each port, a `createBackendAdapters()` provider factory pattern, env-var-driven adapter selection, and a migration strategy for existing function-based services.
+- Excluded: `DatabasePort` abstraction (the PostgREST / Drizzle query layer — this is a P1 follow-up requiring deeper schema coupling analysis), `RealtimePort` abstraction (P2, only relevant for Realtime features), any UI changes, any changes to `@enterprise/contracts` schemas, billing adapter (already covered by `BillingPort` in the billing-and-plans feature), and multi-provider runtime fan-out.
+
+---
+
+## Problem
+
+`@enterprise/core` is structurally coupled to Supabase at every layer: `SupabaseClient` is threaded through every service function, auth flows call `client.auth.*` directly, storage uses Supabase Storage APIs, and middleware imports `@supabase/ssr` unconditionally. This means:
+
+1. **Template adopters who want to use Firebase, Clerk, Auth0, or a custom auth provider** must fork and gut the service layer — a high-effort, error-prone operation that eliminates future template upgrades.
+2. **Adopters with existing PostgreSQL backends** (not Supabase) cannot use the template without rewriting every service that touches the database or auth.
+3. **Testing the service layer** requires mocking Supabase internals, making tests brittle and provider-specific. Tests should prove business logic, not Supabase SDK behavior.
+4. **The billing feature already solved this problem** with `BillingPort` / `createPaymentAdapter()`. The pattern is proven, idiomatic, and consistent with the template's existing conventions — it simply has not been applied to auth and storage yet.
+
+The current state forces a false choice: use Supabase everywhere, or abandon the template entirely.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| Template adopter (default path) | Zero breaking changes — Supabase adapter is the default; existing code continues to work without modification |
+| Template adopter (custom auth) | A documented `AuthPort` interface and factory they can implement to plug in Firebase Auth, Clerk, Auth0, or a custom JWT service |
+| Template adopter (custom storage) | A documented `StoragePort` interface they can implement to point storage at S3, GCS, Cloudflare R2, or a local filesystem |
+| Template adopter (testing) | Services that accept port interfaces instead of `SupabaseClient`, enabling fast, provider-agnostic unit tests with simple mock objects |
+| Platform engineering | A consistent, bilateral pattern (port + adapter + factory) applied uniformly to Auth and Storage so the template is architecturally coherent |
+
+## Goals
+
+- Introduce `AuthPort`, `StoragePort`, and `SessionPort` interfaces in `packages/core/src/services/ports/` following the exact same convention as `InvitationEmailPort`.
+- Ship Supabase reference adapters for each port that preserve current behavior exactly — no behavior change for adopters using the default path.
+- Implement a `createBackendAdapters()` factory that selects adapters based on env vars, NOT `NODE_ENV`.
+- Migrate `auth-service.ts` to accept `AuthPort` instead of `SupabaseClient`. Expose a Supabase adapter that wraps `client.auth.*` calls.
+- Migrate `storage-paths.ts` usage to a `StoragePort` interface so storage operations are injectable.
+- Extract middleware session management into a `SessionPort` so `middleware.ts` can delegate to adapters rather than importing `@supabase/ssr` unconditionally.
+- Ensure all existing unit tests and E2E tests pass with zero changes when using the Supabase adapter.
+
+---
+
+## MVP scope
+
+### Core capabilities
+
+**Port interfaces** — defined in `packages/core/src/services/ports/`:
+
+- `AuthPort` — covers `signInWithPassword`, `signUp`, `signOut`, `getUser`, `requestPasswordReset`, `updatePassword`. Returns `ServiceResult<T>` from `auth-service.ts` — same discriminated union the services already use.
+- `StoragePort` — covers `upload`, `download`, `delete`, `getSignedUrl`, `getPublicUrl`, `listFiles`. Operates on typed bucket/path tuples derived from `storage-paths.ts` constants.
+- `SessionPort` — covers `refreshSession(request, response)` for use in Next.js middleware. Returns a `NextResponse` with refreshed cookies. Replaces the direct `@supabase/ssr` dependency in `middleware.ts`.
+
+**Supabase reference adapters** — defined in `packages/core/src/services/adapters/`:
+
+- `SupabaseAuthAdapter` — wraps `client.auth.*` calls from `auth-service.ts`. Constructed with a `SupabaseClient`. This IS the current `auth-service.ts` logic, re-expressed as an adapter class.
+- `SupabaseStorageAdapter` — wraps Supabase Storage API calls. Uses `STORAGE_BUCKETS` and `STORAGE_PATHS` constants from `storage-paths.ts` internally.
+- `SupabaseSessionAdapter` — wraps `updateSession()` from `middleware.ts`. Constructed with Supabase URL and anon key.
+
+**Provider factory** — `createBackendAdapters()` in `packages/core/src/services/backend-adapters.ts`:
+
+- Returns `{ auth: AuthPort, storage: StoragePort, session: SessionPort }`.
+- Reads `BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER` env vars.
+- Defaults to `supabase` for all ports when env vars are absent.
+- Supabase factory path reads `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — same env vars already in use, no new variables required for the default path.
+
+**Service migration** — existing function-based services are updated to accept port interfaces:
+
+- `auth-service.ts` functions that currently accept `SupabaseClient` are updated to accept `AuthPort`. The Supabase adapter is injected by the factory at the action layer.
+- Storage-touching services accept `StoragePort` instead of `SupabaseClient` for storage operations. They may still accept `SupabaseClient` for DB operations (the Database port is P1; this change only decouples the storage concern).
+- `middleware.ts` `updateSession()` delegates to `SessionPort.refreshSession()` instead of directly calling `@supabase/ssr`.
+
+**Consistency with billing pattern** — the `PaymentProviderPort` in billing is the reference. This feature applies the same pattern (port interface → adapter class → factory function → env-var selection) to auth and storage. Adopters who have already learned the billing adapter pattern have zero new concepts to learn.
+
+### Out of scope (MVP)
+
+- `DatabasePort` abstraction for PostgREST / Drizzle queries. This requires analysis of schema coupling and RLS delegation — P1 follow-up.
+- `RealtimePort` for subscription channels. Only relevant when Realtime features are implemented — P2.
+- Any UI changes or new pages. This is pure infrastructure.
+- Multi-provider fan-out (e.g., writing to both Supabase Storage and S3 simultaneously). Single active provider per service.
+- Automatic migration tooling for adopters. The migration guide (docs) is sufficient for MVP.
+- Firebase, Clerk, or Auth0 adapter implementations. The template ships the Supabase reference adapter; community adapters are documented as an extension point.
+- Runtime hot-swap of providers without restart. Provider selection is resolved at startup from env vars.
+
+---
+
+## User stories and acceptance criteria (from the template ADOPTER perspective)
+
+### US-1: Default path is zero-change
+
+**As** a template adopter using Supabase, **I want** the decoupling changes to be completely transparent so that my existing application continues to work without any code changes on my side.
+
+Acceptance criteria:
+1. After the port/adapter refactor is merged, `pnpm typecheck` passes with no new errors on a project that has not modified any service files.
+2. All existing unit tests in `packages/core/src/services/__tests__/` pass without modification.
+3. All existing E2E tests in `ui/e2e/` pass without modification.
+4. The `createBackendAdapters()` factory returns Supabase adapters by default when `BACKEND_AUTH_PROVIDER` and `BACKEND_STORAGE_PROVIDER` are not set.
+5. No new required environment variables are introduced. The Supabase adapter continues to use `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+
+### US-2: Adopter swaps auth provider via env var
+
+**As** a template adopter who wants to use a custom auth provider (e.g., Clerk or Firebase Auth), **I want** to implement `AuthPort` and register my adapter via an env var so I can replace Supabase Auth without touching any service or action files.
+
+Acceptance criteria:
+1. `AuthPort` is a documented TypeScript interface exported from `@enterprise/core/services`.
+2. The interface covers: `signInWithPassword`, `signUp`, `signOut`, `getUser`, `requestPasswordReset`, `updatePassword` — all returning `ServiceResult<T>`.
+3. An adopter can set `BACKEND_AUTH_PROVIDER=custom` and provide a custom adapter path in `createBackendAdapters()` without modifying any service file.
+4. Auth-related Server Actions (`signInAction`, `signUpAction`, `signOutAction`, `requestPasswordResetAction`, `updatePasswordAction`) continue to work correctly via the injected adapter.
+5. The Supabase reference adapter (`SupabaseAuthAdapter`) is fully documented in the developer guide as the canonical example of how to implement `AuthPort`.
+
+### US-3: Adopter swaps storage provider via env var
+
+**As** a template adopter who wants to use S3 or Cloudflare R2 instead of Supabase Storage, **I want** to implement `StoragePort` and register my adapter via an env var so I can replace storage without changing any business logic.
+
+Acceptance criteria:
+1. `StoragePort` is a documented TypeScript interface exported from `@enterprise/core/services`.
+2. The interface covers: `upload`, `download`, `delete`, `getSignedUrl`, `getPublicUrl`, `listFiles`.
+3. `upload` accepts a `Blob | File | ArrayBuffer`, a bucket name, a path string, and optional content-type metadata.
+4. `getSignedUrl` accepts a bucket name, a path string, and an expiry in seconds.
+5. Setting `BACKEND_STORAGE_PROVIDER=custom` routes all storage operations through the custom adapter without any change to services or Server Actions.
+6. The `STORAGE_BUCKETS` and `STORAGE_PATHS` constants remain usable by any adapter as naming conventions — they are not Supabase-specific.
+
+### US-4: Adopter swaps session/middleware provider
+
+**As** a template adopter who uses a non-Supabase auth system, **I want** the Next.js middleware to delegate session refresh to an injected `SessionPort` so I can replace Supabase SSR cookie handling with my own session logic.
+
+Acceptance criteria:
+1. `SessionPort` is a documented TypeScript interface with a single `refreshSession(request: NextRequest): Promise<NextResponse>` method.
+2. `middleware.ts` imports `SessionPort` and calls `sessionPort.refreshSession(request)` — it does not import `@supabase/ssr` directly.
+3. `SupabaseSessionAdapter` wraps the existing `updateSession()` logic and is the default.
+4. An adopter can provide a custom `SessionPort` implementation to handle cookie-based sessions for their own auth provider.
+5. The Next.js middleware file (`ui/middleware.ts`) requires no changes to swap the session adapter — it reads the adapter from the factory.
+
+### US-5: Adopter writes provider-agnostic unit tests
+
+**As** a template adopter writing unit tests for a custom service, **I want** to mock `AuthPort` and `StoragePort` with simple objects instead of mocking the Supabase client internals so my tests are stable and fast.
+
+Acceptance criteria:
+1. `AuthPort` and `StoragePort` are plain TypeScript interfaces — no abstract classes, no SDK dependencies. Any object satisfying the interface is a valid adapter.
+2. A test can construct a mock auth adapter with `vi.fn()` stubs without importing `@supabase/supabase-js`.
+3. The `packages/core/src/services/__tests__/` directory includes at least one test file demonstrating port-based mocking as the canonical test pattern.
+4. Existing Supabase-mocked tests are updated to use port mocks, and the test suite passes.
+
+### US-6: Adopter reads migration guide
+
+**As** a template adopter who already has a running Supabase-based project and wants to adopt the port pattern, **I want** a step-by-step migration guide so I can understand what changed and what I need to update in my fork.
+
+Acceptance criteria:
+1. A migration guide exists in `docs/developer-guide/` explaining: (a) what changed in each service, (b) how to inject adapters via the factory, (c) how to write a custom adapter, and (d) how to update existing tests to use port mocks.
+2. The guide references the billing `BillingPort` / `createPaymentAdapter()` pattern as a prior art example.
+3. The guide includes a before/after code diff for at least one service function (`signInWithPasswordService` is the canonical example).
+4. The guide documents every new env var and its accepted values.
+
+---
+
+## Success metrics
+
+- Zero breaking changes for existing Supabase adopters: `pnpm typecheck`, `pnpm test`, and `pnpm e2e` all pass without modification after the refactor is merged.
+- Test isolation quality: the `@enterprise/core` test suite no longer requires `@supabase/supabase-js` imports in any test file — all service tests mock via port interfaces.
+- Interface coverage: `AuthPort`, `StoragePort`, and `SessionPort` each have 100% operation coverage by their Supabase reference adapters (no unimplemented methods).
+- Developer friction: an adopter can implement a custom `AuthPort` and have it running in under 2 hours, measured by internal dry-run with a Firebase Auth prototype.
+- Pattern consistency: the `createBackendAdapters()` factory follows the same factory shape as `createPaymentAdapter()` from billing — verified by code review checklist.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Services that accept both `AuthPort` and `SupabaseClient` (for DB) have a split dependency that confuses adopters | Keep DB operations using `SupabaseClient` explicitly until `DatabasePort` is introduced (P1 follow-up). Document this split clearly in the migration guide and in code comments. |
+| Port interfaces diverge from Supabase capabilities, making the Supabase adapter impossible to implement cleanly | Design port methods around the LOWEST COMMON DENOMINATOR of auth/storage providers. Methods that are Supabase-only (e.g., Magic Link) are excluded from `AuthPort` MVP scope and documented as extension points. |
+| Adopters bypass the port and import `SupabaseClient` directly in new services (defeating the pattern) | The `packages/core/AGENTS.md` QA checklist is updated to include: "New services accept port interfaces, not `SupabaseClient` directly (after decoupling is merged)". Code review enforces this. |
+| The `createBackendAdapters()` factory creates Supabase clients eagerly at startup, causing failures in non-Supabase environments | The factory is lazy: Supabase clients are only constructed when `BACKEND_AUTH_PROVIDER=supabase` (the default). Custom adapter paths never touch Supabase env vars. |
+| SessionPort abstraction is thin enough to be a leaky abstraction (Next.js middleware is inherently Next.js-specific) | `SessionPort` is scoped to cookie-based session refresh — it does NOT abstract Next.js primitives. The interface returns `NextResponse`, which is intentionally Next.js-typed. Adopters who leave Next.js must re-implement middleware anyway. |
+| Renaming service signatures breaks existing Server Actions in adopter forks | The Supabase adapter is injected at the call site in Server Actions. Service function signatures change from `(client: SupabaseClient, ...)` to `(auth: AuthPort, ...)`. The migration guide documents this with before/after diffs. |
+
+---
+
+## Traceability
+
+### Audit events (if applicable)
+
+Backend provider decoupling is infrastructure-only with no user-visible mutations. No new audit events are introduced by this feature. The existing audit log writes in services (e.g., `writeAuditLog()` in `resource-service.ts`) are unaffected — they continue to write via `SupabaseClient` for DB operations, which are not decoupled in MVP.
+
+### Sentry
+
+- Area: `core/adapters`
+- This is infrastructure code with no new Server Actions. Sentry instrumentation is the responsibility of the Server Actions that call the services — no change required.
+- Supabase adapter errors bubble up as `ServiceResult<T>` failures with `success: false`. The existing pattern of capturing these in Server Actions via `captureActionError` is unchanged.
+- If a custom adapter is implemented by an adopter, they are responsible for ensuring adapter errors are surfaced as `ServiceResult` failures and not thrown as uncaught exceptions.
+
+### Seed data
+
+No new seed data is required. The port/adapter layer is transparent to the DB schema — it wraps existing Supabase calls without changing the data model.
+
+### E2E flows
+
+No new E2E flows are required. The acceptance criterion for this feature is that ALL existing E2E flows continue to pass with zero changes after the refactor. The E2E suite implicitly validates that the Supabase adapter is functionally equivalent to the pre-refactor direct calls.
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|-----------------|
+| Sign in with email and password | Authenticated user | Auth succeeds via `SupabaseAuthAdapter`; session cookie is set; redirect to dashboard |
+| Sign up new account | Anonymous user | Account created via `SupabaseAuthAdapter`; email confirmation flow initiated |
+| Sign out | Authenticated user | Session cleared via `SupabaseAuthAdapter`; redirect to sign-in |
+| Request password reset | Unauthenticated user | Reset email sent via `SupabaseAuthAdapter`; success message shown |
+| Upload file (avatar) | Authenticated user | File uploaded via `SupabaseStorageAdapter`; signed URL returned |
+| Middleware refreshes session | Any user | `SupabaseSessionAdapter.refreshSession()` called; session cookie refreshed transparently |
+
+### External adapters
+
+| Port | Interface | Default adapter | Env var | Example custom adapter |
+|------|-----------|-----------------|---------|------------------------|
+| Auth | `AuthPort` | `SupabaseAuthAdapter` | `BACKEND_AUTH_PROVIDER=supabase` (default) | Firebase Auth adapter, Clerk adapter, Auth0 adapter |
+| Storage | `StoragePort` | `SupabaseStorageAdapter` | `BACKEND_STORAGE_PROVIDER=supabase` (default) | S3 adapter, Cloudflare R2 adapter, local filesystem adapter |
+| Session | `SessionPort` | `SupabaseSessionAdapter` | No env var needed — always instantiated by `createBackendAdapters()` alongside `AuthPort` | Custom JWT cookie adapter |
+
+### Production readiness
+
+- [ ] `AuthPort` interface is complete: all methods in `auth-service.ts` are covered
+- [ ] `StoragePort` interface is complete: upload, download, delete, getSignedUrl, getPublicUrl, listFiles
+- [ ] `SessionPort` interface is complete: `refreshSession(request)` returning `NextResponse`
+- [ ] `SupabaseAuthAdapter` implements `AuthPort` — all methods tested with port-mock pattern
+- [ ] `SupabaseStorageAdapter` implements `StoragePort` — all methods tested with port-mock pattern
+- [ ] `SupabaseSessionAdapter` implements `SessionPort` — behavior verified against existing middleware E2E
+- [ ] `createBackendAdapters()` factory defaults to Supabase when env vars are absent
+- [ ] `createBackendAdapters()` throws a descriptive error when an unsupported provider name is set
+- [ ] `pnpm typecheck` passes across all packages
+- [ ] `pnpm test` passes with zero changes to existing test files
+- [ ] `pnpm e2e` passes with zero changes to existing E2E test files
+- [ ] Port interfaces are exported from `@enterprise/core/services` public API
+- [ ] Migration guide written in `docs/developer-guide/backend-provider-migration.md`
+- [ ] `packages/core/AGENTS.md` QA checklist updated to enforce port-based injection for new services
+- [ ] No `@supabase/supabase-js` imports remain in `packages/core/src/services/__tests__/` files
+- [ ] `BACKEND_AUTH_PROVIDER` and `BACKEND_STORAGE_PROVIDER` documented in `.env.example` with inline comments explaining accepted values
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Use the `PaymentProviderPort` / `createPaymentAdapter()` billing pattern as the reference? | Yes — same structure: port interface → adapter class → factory function → env-var selection | Pattern is already in the codebase, proven, and understood by anyone who has read the billing feature. Zero new conventions introduced. |
+| Include `DatabasePort` in MVP? | No — P1 follow-up | DB operations are the most complex decoupling surface (RLS policies, PostgREST vs Drizzle, schema coupling). Attempting this in MVP would delay Auth and Storage decoupling, which are the highest-value swaps for adopters. |
+| Include `RealtimePort` in MVP? | No — P2 | Realtime features are not yet implemented in the template. The port can be designed when the feature is built. |
+| Env-var selection vs. `NODE_ENV`? | Env vars (`BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`) — NOT `NODE_ENV` | `NODE_ENV` conflates deployment environment with provider choice. An adopter may want to run Supabase in production and Firebase in staging. Explicit env vars give full control. This mirrors the billing adapter decision. |
+| Service function signatures: change `SupabaseClient` to `AuthPort`? | Yes — for auth operations only | Services that also do DB queries still accept `SupabaseClient` for the DB part (until `DatabasePort` lands). The auth parameter type changes from `SupabaseClient` to `AuthPort`. This is a source-level breaking change documented in the migration guide. |
+| Ship community adapters (Firebase, Clerk) in this PR? | No — Supabase adapter only | Shipping unvalidated community adapters adds maintenance burden without production proof. The `AuthPort` interface is the deliverable; community adapters are examples in the migration guide and can be contributed as separate packages. |
+| Keep `STORAGE_BUCKETS` and `STORAGE_PATHS` constants as-is? | Yes — they are naming conventions, not Supabase-specific | Any `StoragePort` implementation can use these constants to derive paths. Moving them would be a needless breaking change. The Supabase adapter uses them internally. |
+| `SessionPort` returns `NextResponse` (Next.js type)? | Yes — this port is intentionally Next.js-scoped | The middleware is a Next.js primitive. Abstracting away `NextResponse` would require a custom response wrapper that adds complexity without benefit. Adopters who switch frameworks rewrite middleware regardless. |
+| Where do adapters live in the package tree? | `packages/core/src/services/adapters/` — same directory as `ConsoleInvitationEmailAdapter` and `ResendInvitationEmailAdapter` | Consistent location, consistent naming convention. No new directory structures introduced. |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/backend-provider-decoupling/rfc.md
+++ b/docs/features/backend-provider-decoupling/rfc.md
@@ -1,0 +1,1284 @@
+---
+title: "Backend provider decoupling RFC"
+description: "Defines the implementation-ready technical architecture for introducing AuthPort, StoragePort, and SessionPort abstractions in @enterprise/core so the template can work with different backend providers without rewriting business logic."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Backend provider decoupling RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for introducing a port/adapter abstraction layer in `@enterprise/core` that decouples the template's business logic from Supabase-specific APIs. Supabase remains the reference implementation and the default — decoupling is additive, not a migration. All existing behavior is preserved exactly. The billing feature already established this pattern with `PaymentProviderPort` + `createPaymentAdapter()`; this RFC extends the same pattern to Auth, Storage, and Session.
+
+## Scope
+
+- Included: `AuthPort` interface, `StoragePort` interface, `SessionPort` interface, Supabase reference adapters for all three ports, a `createBackendAdapters()` provider factory, env-var-driven adapter selection, migration strategy for existing function-based services, and middleware integration for `SessionPort`.
+- Excluded: `DatabasePort` abstraction (P1 follow-up — requires deeper analysis of RLS delegation and PostgREST vs Drizzle coupling), `RealtimePort` (P2 — no Realtime features implemented yet), any UI changes, any `@enterprise/contracts` schema changes, community adapters for Firebase / Clerk / Auth0 (extension point — not shipped), and multi-provider runtime fan-out.
+
+---
+
+## Summary
+
+Introduce `AuthPort`, `StoragePort`, and `SessionPort` interfaces in `packages/core/src/services/ports/`, implement Supabase reference adapters for each in `packages/core/src/services/adapters/`, and wire them through a `createBackendAdapters()` factory that selects adapters from env vars. Migrate `auth-service.ts` to accept `AuthPort` instead of `SupabaseClient` for auth operations. Migrate `middleware.ts` to delegate session refresh to `SessionPort` instead of importing `@supabase/ssr` directly. All existing unit tests and E2E tests pass without modification when using the default Supabase adapter path.
+
+## Technical objectives
+
+- `AuthPort`, `StoragePort`, and `SessionPort` are plain TypeScript interfaces — no abstract classes, no SDK imports. Any object satisfying the interface is a valid adapter.
+- The Supabase adapter is functionally equivalent to the pre-refactor direct calls — zero behavior change for adopters on the default path.
+- `createBackendAdapters()` follows the exact same factory shape as `createPaymentAdapter()` from the billing feature — adopters who understand billing have zero new concepts to learn.
+- Adapter selection uses explicit env vars (`BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`), NOT `NODE_ENV`.
+- No new required environment variables for the default path. The Supabase adapter continues using `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+- After the refactor, no `@supabase/supabase-js` imports remain in `packages/core/src/services/__tests__/` — all service tests mock via port interfaces.
+
+---
+
+## Port interfaces
+
+### AuthPort
+
+Location: `packages/core/src/services/ports/auth-port.ts`
+
+```typescript
+import type {
+  RegistrationMetadata,
+  UserRole,
+} from "@enterprise/contracts";
+import type {
+  ServiceResult,
+  SignInServiceData,
+  SignInServiceInput,
+  SignUpServiceData,
+  SignUpServiceInput,
+  PasswordResetServiceInput,
+  UpdatePasswordServiceInput,
+  UserRoleServiceData,
+} from "../auth-service";
+import type { PlatformUser } from "@enterprise/contracts";
+
+/**
+ * AuthPort — provider-agnostic authentication interface.
+ *
+ * Implement this interface to swap the auth backend without modifying any
+ * service or Server Action. The Supabase reference implementation is
+ * `SupabaseAuthAdapter`. Community adapters (Firebase, Clerk, Auth0) implement
+ * the same interface.
+ *
+ * All methods return `ServiceResult<T>` — the same discriminated union used
+ * throughout the service layer. Adapters MUST NOT throw; they must return
+ * `{ success: false, error: string, code: string }` on failure.
+ */
+export interface AuthPort {
+  /**
+   * Authenticates a user with email and password.
+   * Returns the user's role on success so the caller can resolve the redirect path.
+   */
+  signInWithPassword(input: SignInServiceInput): Promise<ServiceResult<SignInServiceData>>;
+
+  /**
+   * Registers a new user account.
+   * Returns the new userId and whether email confirmation is required before login.
+   */
+  signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>>;
+
+  /**
+   * Terminates the current user session.
+   */
+  signOut(): Promise<ServiceResult<null>>;
+
+  /**
+   * Returns the currently authenticated user, or null if no session is active.
+   * Implementors MUST validate the token server-side (equivalent to Supabase's getUser(),
+   * NOT getSession() which only decodes the JWT without server-side validation).
+   */
+  getUser(): Promise<ServiceResult<PlatformUser | null>>;
+
+  /**
+   * Returns the platform role for a given userId from the profiles table.
+   * This method exists separately because role resolution requires a DB query
+   * that may not be part of every auth provider's token claims.
+   * Implementors that embed the role in the JWT may resolve it without a DB call.
+   */
+  getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>>;
+
+  /**
+   * Sends a password reset email to the specified address.
+   * The redirectTo URL is where the provider redirects after the user clicks the link.
+   */
+  requestPasswordReset(input: PasswordResetServiceInput): Promise<ServiceResult<null>>;
+
+  /**
+   * Updates the password for the currently authenticated user.
+   * Requires an active session (the user clicked the reset link and is in a password-update flow).
+   */
+  updatePassword(input: UpdatePasswordServiceInput): Promise<ServiceResult<null>>;
+}
+```
+
+### StoragePort
+
+Location: `packages/core/src/services/ports/storage-port.ts`
+
+```typescript
+/**
+ * Metadata passed when uploading a file.
+ */
+export interface StorageUploadOptions {
+  /** MIME type of the file, e.g. "image/png". */
+  contentType?: string;
+  /** Whether to overwrite an existing file at the same path. Default: true. */
+  upsert?: boolean;
+}
+
+/**
+ * Result of a successful upload.
+ */
+export interface StorageUploadResult {
+  /** Full storage path (bucket-relative) of the uploaded file. */
+  path: string;
+  /** Full URL of the uploaded file (public or signed depending on bucket config). */
+  fullPath: string;
+}
+
+/**
+ * Result of a signed URL generation.
+ */
+export interface StorageSignedUrlResult {
+  /** Signed URL valid for the requested duration. */
+  signedUrl: string;
+  /** Expiry time in seconds from now. */
+  expiresIn: number;
+}
+
+/**
+ * Result of a public URL lookup (no expiry, no signature).
+ */
+export interface StoragePublicUrlResult {
+  /** Public URL for the file. Only valid if the bucket is configured as public. */
+  publicUrl: string;
+}
+
+/**
+ * A file entry returned by listFiles.
+ */
+export interface StorageFileEntry {
+  name: string;
+  id: string | null;
+  updatedAt: Date | null;
+  createdAt: Date | null;
+  /** File size in bytes. null for folders. */
+  size: number | null;
+  mimeType: string | null;
+}
+
+/**
+ * StoragePort — provider-agnostic file storage interface.
+ *
+ * Implement this interface to swap the storage backend (Supabase Storage, S3,
+ * Cloudflare R2, local filesystem) without modifying any service or Server Action.
+ *
+ * The `bucket` parameter always corresponds to a value from `STORAGE_BUCKETS` in
+ * `packages/core/src/supabase/storage-paths.ts`. The path parameters follow the
+ * conventions defined by `STORAGE_PATHS`. These constants are provider-agnostic
+ * naming conventions — they remain unchanged regardless of which adapter is active.
+ *
+ * All methods return `ServiceResult<T>`. Adapters MUST NOT throw; they return
+ * `{ success: false, error: string, code: string }` on failure.
+ */
+export interface StoragePort {
+  /**
+   * Uploads a file to the specified bucket at the given path.
+   * @param bucket - The target bucket name (from STORAGE_BUCKETS).
+   * @param path - The bucket-relative path (from STORAGE_PATHS helpers).
+   * @param file - The file content as Blob, File, or ArrayBuffer.
+   * @param options - Optional content-type and upsert flag.
+   */
+  upload(
+    bucket: string,
+    path: string,
+    file: Blob | File | ArrayBuffer,
+    options?: StorageUploadOptions,
+  ): Promise<ServiceResult<StorageUploadResult>>;
+
+  /**
+   * Downloads a file from the specified bucket.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   * @returns The file as a Blob.
+   */
+  download(bucket: string, path: string): Promise<ServiceResult<Blob>>;
+
+  /**
+   * Deletes one or more files from the specified bucket.
+   * @param bucket - The source bucket name.
+   * @param paths - One or more bucket-relative paths.
+   */
+  delete(bucket: string, paths: string[]): Promise<ServiceResult<null>>;
+
+  /**
+   * Generates a time-limited signed URL for a private file.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   * @param expiresIn - URL validity duration in seconds.
+   */
+  getSignedUrl(
+    bucket: string,
+    path: string,
+    expiresIn: number,
+  ): Promise<ServiceResult<StorageSignedUrlResult>>;
+
+  /**
+   * Returns the public URL for a file in a public bucket.
+   * This does not make a network call — it constructs the URL from the provider's
+   * base URL and the bucket/path. Only valid for publicly accessible buckets.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   */
+  getPublicUrl(bucket: string, path: string): Promise<ServiceResult<StoragePublicUrlResult>>;
+
+  /**
+   * Lists files in the specified bucket at the given prefix path.
+   * @param bucket - The source bucket name.
+   * @param prefix - The path prefix to list under. Defaults to root ("").
+   * @param limit - Maximum number of entries to return. Defaults to 100.
+   * @param offset - Pagination offset. Defaults to 0.
+   */
+  listFiles(
+    bucket: string,
+    prefix?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<ServiceResult<StorageFileEntry[]>>;
+}
+```
+
+### SessionPort
+
+Location: `packages/core/src/services/ports/session-port.ts`
+
+```typescript
+import type { NextRequest, NextResponse } from "next/server";
+
+/**
+ * SessionPort — Next.js middleware-level session management interface.
+ *
+ * This port is intentionally Next.js-scoped. It returns `NextResponse` because
+ * middleware is a Next.js primitive — abstracting this away would require a custom
+ * response wrapper that adds complexity without benefit. Adopters who switch
+ * frameworks must rewrite middleware regardless.
+ *
+ * `refreshSession` is the single responsibility: given an incoming request,
+ * refresh the session cookie and return a response with updated Set-Cookie headers.
+ * The middleware delegates all session refresh logic to this port — it does NOT
+ * import `@supabase/ssr` directly.
+ *
+ * The Supabase reference implementation is `SupabaseSessionAdapter`, which wraps
+ * the existing `updateSession()` logic from `packages/core/src/supabase/middleware.ts`.
+ */
+export interface SessionPort {
+  /**
+   * Refreshes the authentication session for an incoming middleware request.
+   *
+   * The implementation is responsible for:
+   * 1. Reading the session token from the request cookies.
+   * 2. Validating and refreshing the token with the auth provider (server-side).
+   * 3. Returning a NextResponse with updated Set-Cookie headers so the refreshed
+   *    token is written to the browser.
+   *
+   * @param request - The incoming Next.js middleware request.
+   * @returns A NextResponse with refreshed session cookies, or a pass-through response
+   *          if no session exists or no refresh was needed.
+   */
+  refreshSession(request: NextRequest): Promise<NextResponse>;
+}
+```
+
+---
+
+## Supabase reference adapters
+
+### SupabaseAuthAdapter
+
+Location: `packages/core/src/services/adapters/supabase-auth-adapter.ts`
+
+The `SupabaseAuthAdapter` is a direct re-expression of the current `auth-service.ts` logic as an adapter class. It wraps `client.auth.*` calls and the `profiles` table lookup. There is NO behavior change — the same Supabase SDK calls, the same error codes, the same `ServiceResult<T>` shapes.
+
+```typescript
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { PlatformUser, UserRole } from "@enterprise/contracts";
+import type { AuthPort } from "../ports/auth-port";
+import type {
+  ServiceResult,
+  SignInServiceData,
+  SignInServiceInput,
+  SignUpServiceData,
+  SignUpServiceInput,
+  PasswordResetServiceInput,
+  UpdatePasswordServiceInput,
+  UserRoleServiceData,
+} from "../auth-service";
+
+/**
+ * SupabaseAuthAdapter — implements AuthPort using the Supabase JS client.
+ *
+ * This is the reference implementation and the canonical example for building
+ * custom AuthPort adapters. Each method maps 1:1 to a function in the
+ * pre-refactor auth-service.ts.
+ *
+ * Construction requires a SupabaseClient scoped to the current request
+ * (server or middleware client). It is the caller's responsibility to provide
+ * the correctly-scoped client — server client for Server Actions, middleware
+ * client for middleware flows.
+ */
+export class SupabaseAuthAdapter implements AuthPort {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async signInWithPassword(
+    input: SignInServiceInput,
+  ): Promise<ServiceResult<SignInServiceData>> {
+    // Maps to: client.auth.signInWithPassword() + client.auth.getUser() + getUserRole()
+    // Error codes: INVALID_CREDENTIALS, USER_NOT_FOUND, ROLE_LOOKUP_FAILED
+    const { error } = await this.client.auth.signInWithPassword({
+      email: input.email,
+      password: input.password,
+    });
+
+    if (error) {
+      return { success: false, error: "Invalid credentials", code: "INVALID_CREDENTIALS" };
+    }
+
+    const { data: { user } } = await this.client.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not found after sign-in", code: "USER_NOT_FOUND" };
+    }
+
+    const roleResult = await this.getUserRole(user.id);
+
+    if (!roleResult.success) {
+      return roleResult;
+    }
+
+    return { success: true, data: { role: roleResult.data.role } };
+  }
+
+  async signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>> {
+    // Maps to: client.auth.signUp()
+    // Error codes: SIGN_UP_FAILED, USER_NOT_CREATED
+    const { data, error } = await this.client.auth.signUp({
+      email: input.email,
+      password: input.password,
+      options: {
+        data: input.metadata,
+        emailRedirectTo: input.emailRedirectTo,
+      },
+    });
+
+    if (error) {
+      return { success: false, error: "Could not create account", code: "SIGN_UP_FAILED" };
+    }
+
+    if (!data.user) {
+      return { success: false, error: "User was not created", code: "USER_NOT_CREATED" };
+    }
+
+    return {
+      success: true,
+      data: {
+        userId: data.user.id,
+        needsEmailConfirmation: data.session === null,
+      },
+    };
+  }
+
+  async signOut(): Promise<ServiceResult<null>> {
+    // Maps to: client.auth.signOut()
+    // Error codes: SIGN_OUT_FAILED
+    const { error } = await this.client.auth.signOut();
+
+    if (error) {
+      return { success: false, error: "Could not sign out", code: "SIGN_OUT_FAILED" };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async getUser(): Promise<ServiceResult<PlatformUser | null>> {
+    // Maps to: client.auth.getUser() + profiles table lookup
+    // Error codes: AUTH_USER_LOOKUP_FAILED
+    const { data: { user }, error } = await this.client.auth.getUser();
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not resolve authenticated user",
+        code: "AUTH_USER_LOOKUP_FAILED",
+      };
+    }
+
+    if (!user) {
+      return { success: true, data: null };
+    }
+
+    const { data: profile } = await this.client
+      .from("profiles")
+      .select("tenant_id, role, name, avatar_url")
+      .eq("id", user.id)
+      .single();
+
+    return {
+      success: true,
+      data: {
+        id: user.id,
+        createdAt: new Date(user.created_at),
+        updatedAt: new Date(user.updated_at ?? user.created_at),
+        email: user.email ?? "",
+        name: profile?.name ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+        role: (profile?.role as UserRole | undefined) ?? "guest",
+        tenantId: profile?.tenant_id ?? "",
+      },
+    };
+  }
+
+  async getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>> {
+    // Maps to: profiles table lookup for role column
+    // Error codes: ROLE_LOOKUP_FAILED
+    const { data: profile, error } = await this.client
+      .from("profiles")
+      .select("role")
+      .eq("id", userId)
+      .single();
+
+    if (error && error.code !== "PGRST116") {
+      return {
+        success: false,
+        error: "Could not load user role",
+        code: "ROLE_LOOKUP_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        role: (profile?.role as UserRole | null | undefined) ?? "guest",
+      },
+    };
+  }
+
+  async requestPasswordReset(
+    input: PasswordResetServiceInput,
+  ): Promise<ServiceResult<null>> {
+    // Maps to: client.auth.resetPasswordForEmail()
+    // Error codes: PASSWORD_RESET_REQUEST_FAILED
+    const { error } = await this.client.auth.resetPasswordForEmail(input.email, {
+      redirectTo: input.redirectTo,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not send password reset email",
+        code: "PASSWORD_RESET_REQUEST_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async updatePassword(
+    input: UpdatePasswordServiceInput,
+  ): Promise<ServiceResult<null>> {
+    // Maps to: client.auth.updateUser({ password })
+    // Error codes: PASSWORD_UPDATE_FAILED
+    const { error } = await this.client.auth.updateUser({
+      password: input.password,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not update password",
+        code: "PASSWORD_UPDATE_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+}
+```
+
+### SupabaseStorageAdapter
+
+Location: `packages/core/src/services/adapters/supabase-storage-adapter.ts`
+
+The `SupabaseStorageAdapter` wraps the Supabase Storage API. It uses the same `STORAGE_BUCKETS` and `STORAGE_PATHS` constants from `storage-paths.ts` as naming conventions — the constants are not Supabase-specific. Any other adapter can use them too.
+
+```typescript
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { StoragePort, StorageUploadOptions, StorageUploadResult,
+  StorageSignedUrlResult, StoragePublicUrlResult, StorageFileEntry } from "../ports/storage-port";
+import type { ServiceResult } from "../auth-service";
+
+/**
+ * SupabaseStorageAdapter — implements StoragePort using the Supabase Storage API.
+ *
+ * Construction requires a SupabaseClient. In practice this is the server client
+ * from `getServerClient()` (authenticated user context) or the admin client for
+ * service-role operations.
+ *
+ * Bucket and path naming conventions follow `STORAGE_BUCKETS` and `STORAGE_PATHS`
+ * from `packages/core/src/supabase/storage-paths.ts`. These constants are
+ * provider-agnostic — they are just naming conventions that any adapter can use.
+ */
+export class SupabaseStorageAdapter implements StoragePort {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async upload(
+    bucket: string,
+    path: string,
+    file: Blob | File | ArrayBuffer,
+    options?: StorageUploadOptions,
+  ): Promise<ServiceResult<StorageUploadResult>> {
+    // Maps to: client.storage.from(bucket).upload(path, file, { contentType, upsert })
+    // Supabase Storage returns { data: { path, fullPath }, error }
+    const { data, error } = await this.client.storage
+      .from(bucket)
+      .upload(path, file, {
+        contentType: options?.contentType,
+        upsert: options?.upsert ?? true,
+      });
+
+    if (error) {
+      return {
+        success: false,
+        error: `Upload failed: ${error.message}`,
+        code: "STORAGE_UPLOAD_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: { path: data.path, fullPath: data.fullPath },
+    };
+  }
+
+  async download(bucket: string, path: string): Promise<ServiceResult<Blob>> {
+    // Maps to: client.storage.from(bucket).download(path)
+    // Returns a Blob; error is a StorageError
+    const { data, error } = await this.client.storage.from(bucket).download(path);
+
+    if (error || !data) {
+      return {
+        success: false,
+        error: `Download failed: ${error?.message ?? "no data"}`,
+        code: "STORAGE_DOWNLOAD_FAILED",
+      };
+    }
+
+    return { success: true, data };
+  }
+
+  async delete(bucket: string, paths: string[]): Promise<ServiceResult<null>> {
+    // Maps to: client.storage.from(bucket).remove(paths)
+    const { error } = await this.client.storage.from(bucket).remove(paths);
+
+    if (error) {
+      return {
+        success: false,
+        error: `Delete failed: ${error.message}`,
+        code: "STORAGE_DELETE_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    path: string,
+    expiresIn: number,
+  ): Promise<ServiceResult<StorageSignedUrlResult>> {
+    // Maps to: client.storage.from(bucket).createSignedUrl(path, expiresIn)
+    const { data, error } = await this.client.storage
+      .from(bucket)
+      .createSignedUrl(path, expiresIn);
+
+    if (error || !data) {
+      return {
+        success: false,
+        error: `Signed URL failed: ${error?.message ?? "no data"}`,
+        code: "STORAGE_SIGNED_URL_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: { signedUrl: data.signedUrl, expiresIn },
+    };
+  }
+
+  async getPublicUrl(
+    bucket: string,
+    path: string,
+  ): Promise<ServiceResult<StoragePublicUrlResult>> {
+    // Maps to: client.storage.from(bucket).getPublicUrl(path)
+    // Note: Supabase getPublicUrl() never returns an error — it constructs the URL
+    // from the project URL without making a network call.
+    const { data } = this.client.storage.from(bucket).getPublicUrl(path);
+
+    return {
+      success: true,
+      data: { publicUrl: data.publicUrl },
+    };
+  }
+
+  async listFiles(
+    bucket: string,
+    prefix = "",
+    limit = 100,
+    offset = 0,
+  ): Promise<ServiceResult<StorageFileEntry[]>> {
+    // Maps to: client.storage.from(bucket).list(prefix, { limit, offset })
+    const { data, error } = await this.client.storage
+      .from(bucket)
+      .list(prefix, { limit, offset });
+
+    if (error) {
+      return {
+        success: false,
+        error: `List files failed: ${error.message}`,
+        code: "STORAGE_LIST_FAILED",
+      };
+    }
+
+    const entries: StorageFileEntry[] = (data ?? []).map((item) => ({
+      name: item.name,
+      id: item.id ?? null,
+      updatedAt: item.updated_at ? new Date(item.updated_at) : null,
+      createdAt: item.created_at ? new Date(item.created_at) : null,
+      size: item.metadata?.size ?? null,
+      mimeType: item.metadata?.mimetype ?? null,
+    }));
+
+    return { success: true, data: entries };
+  }
+}
+```
+
+### SupabaseSessionAdapter
+
+Location: `packages/core/src/services/adapters/supabase-session-adapter.ts`
+
+The `SupabaseSessionAdapter` wraps the existing `updateSession()` function from `packages/core/src/supabase/middleware.ts`. This is a thin wrapper — no new logic is introduced.
+
+```typescript
+import type { NextRequest, NextResponse } from "next/server";
+import type { SessionPort } from "../ports/session-port";
+import { updateSession, type MiddlewareSupabaseConfig } from "../../supabase/middleware";
+
+/**
+ * SupabaseSessionAdapter — implements SessionPort using @supabase/ssr.
+ *
+ * This adapter wraps the existing updateSession() function from
+ * packages/core/src/supabase/middleware.ts. The function reads the session
+ * token from request cookies, validates it with the Supabase Auth server
+ * (via getUser()), and returns a NextResponse with refreshed Set-Cookie headers.
+ *
+ * Construction requires the Supabase project URL and anon key. These are the
+ * same env vars already in use: NEXT_PUBLIC_SUPABASE_URL and
+ * NEXT_PUBLIC_SUPABASE_ANON_KEY. No new env vars are introduced.
+ */
+export class SupabaseSessionAdapter implements SessionPort {
+  private readonly config: MiddlewareSupabaseConfig;
+
+  constructor(supabaseUrl: string, supabaseAnonKey: string) {
+    this.config = { supabaseUrl, supabaseAnonKey };
+  }
+
+  async refreshSession(request: NextRequest): Promise<NextResponse> {
+    // Delegates directly to updateSession() — same behavior as pre-refactor middleware.
+    // The function creates a server client, calls getUser() to validate and refresh
+    // the session, then returns a response with updated cookies.
+    return updateSession(request, this.config);
+  }
+}
+```
+
+---
+
+## Adapter factory
+
+### createBackendAdapters()
+
+Location: `packages/core/src/services/backend-adapters.ts`
+
+This factory follows the exact same pattern as `createPaymentAdapter()` from the billing feature. Selection is based on explicit env vars, NOT `NODE_ENV`. Supabase clients are constructed lazily — only when the Supabase provider is selected. Custom adapter paths never touch Supabase env vars.
+
+```typescript
+import type { AuthPort } from "./ports/auth-port";
+import type { StoragePort } from "./ports/storage-port";
+import type { SessionPort } from "./ports/session-port";
+import { SupabaseAuthAdapter } from "./adapters/supabase-auth-adapter";
+import { SupabaseStorageAdapter } from "./adapters/supabase-storage-adapter";
+import { SupabaseSessionAdapter } from "./adapters/supabase-session-adapter";
+
+/**
+ * The resolved set of backend adapters.
+ * All three ports are returned together so the factory call site has a
+ * single, stable dependency to inject.
+ */
+export interface BackendAdapters {
+  /** Auth operations: sign in, sign up, sign out, get user, password reset. */
+  auth: AuthPort;
+  /** File storage operations: upload, download, delete, signed URL, list. */
+  storage: StoragePort;
+  /** Middleware-level session refresh — used by ui/middleware.ts. */
+  session: SessionPort;
+}
+
+/**
+ * createBackendAdapters — selects and instantiates the active backend adapters.
+ *
+ * Selection is driven by env vars:
+ *   BACKEND_AUTH_PROVIDER    — "supabase" (default) | "custom"
+ *   BACKEND_STORAGE_PROVIDER — "supabase" (default) | "custom"
+ *
+ * The session adapter has no selection env var: it is always instantiated
+ * alongside the auth adapter because session management is tightly coupled
+ * to the auth provider in practice.
+ *
+ * For custom providers, adopters replace the Supabase instantiation block
+ * with their own adapter class. The returned interface shape is identical.
+ *
+ * Throws a descriptive error if an unsupported provider name is set, so
+ * misconfiguration fails loudly at startup rather than silently at runtime.
+ *
+ * @example
+ * // Default Supabase path — no env vars needed
+ * const adapters = createBackendAdapters();
+ *
+ * @example
+ * // In a Server Action (auth):
+ * const { auth } = createBackendAdapters();
+ * const client = await getServerClient();
+ * return signInWithPasswordService(auth(client), input);
+ *
+ * @example
+ * // In middleware (session):
+ * const { session } = createBackendAdapters();
+ * const response = await session.refreshSession(request);
+ */
+export function createBackendAdapters(): {
+  auth: (client: import("@supabase/supabase-js").SupabaseClient) => AuthPort;
+  storage: (client: import("@supabase/supabase-js").SupabaseClient) => StoragePort;
+  session: SessionPort;
+} {
+  const authProvider = process.env["BACKEND_AUTH_PROVIDER"] ?? "supabase";
+  const storageProvider = process.env["BACKEND_STORAGE_PROVIDER"] ?? "supabase";
+
+  // --- Auth adapter factory ---
+  let authFactory: (client: import("@supabase/supabase-js").SupabaseClient) => AuthPort;
+
+  if (authProvider === "supabase") {
+    authFactory = (client) => new SupabaseAuthAdapter(client);
+  } else {
+    throw new Error(
+      `[createBackendAdapters] Unknown BACKEND_AUTH_PROVIDER: "${authProvider}". ` +
+        `Supported values: "supabase". Custom adapters: implement AuthPort and ` +
+        `return a new instance in this factory.`,
+    );
+  }
+
+  // --- Storage adapter factory ---
+  let storageFactory: (client: import("@supabase/supabase-js").SupabaseClient) => StoragePort;
+
+  if (storageProvider === "supabase") {
+    storageFactory = (client) => new SupabaseStorageAdapter(client);
+  } else {
+    throw new Error(
+      `[createBackendAdapters] Unknown BACKEND_STORAGE_PROVIDER: "${storageProvider}". ` +
+        `Supported values: "supabase". Custom adapters: implement StoragePort and ` +
+        `return a new instance in this factory.`,
+    );
+  }
+
+  // --- Session adapter (always Supabase in MVP; no selection env var) ---
+  const supabaseUrl = process.env["NEXT_PUBLIC_SUPABASE_URL"];
+  const supabaseAnonKey = process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "[createBackendAdapters] Missing NEXT_PUBLIC_SUPABASE_URL or " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY. These are required for the session adapter.",
+    );
+  }
+
+  const session: SessionPort = new SupabaseSessionAdapter(supabaseUrl, supabaseAnonKey);
+
+  return {
+    auth: authFactory,
+    storage: storageFactory,
+    session,
+  };
+}
+```
+
+> **Note on client threading**: Unlike `createPaymentAdapter()` (which returns a fully-constructed adapter), the auth and storage factories return a function `(client) => Adapter`. This is because `SupabaseClient` is request-scoped — it must be created per-request from `getServerClient()`. The factory itself is safely called once at module level in Server Actions; the client is passed per-invocation.
+
+---
+
+## Migration strategy
+
+### Phase approach for existing services
+
+The migration from direct `SupabaseClient` auth calls to `AuthPort` is a source-level breaking change for any adopter fork that calls the service functions directly. The migration guide in `docs/developer-guide/backend-provider-migration.md` documents every change. This section covers the mechanics.
+
+#### Before/after: `signInWithPasswordService`
+
+**Before (pre-refactor)** — function accepts `SupabaseClient`, calls `client.auth.*` directly:
+
+```typescript
+// packages/core/src/services/auth-service.ts (BEFORE)
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function signInWithPasswordService(
+  client: SupabaseClient,
+  input: SignInServiceInput,
+): Promise<ServiceResult<SignInServiceData>> {
+  const { error } = await client.auth.signInWithPassword({
+    email: input.email,
+    password: input.password,
+  });
+  // ... rest of implementation
+}
+```
+
+**After (post-refactor)** — function accepts `AuthPort`, delegates to adapter:
+
+```typescript
+// packages/core/src/services/auth-service.ts (AFTER)
+import type { AuthPort } from "./ports/auth-port";
+
+export async function signInWithPasswordService(
+  auth: AuthPort,
+  input: SignInServiceInput,
+): Promise<ServiceResult<SignInServiceData>> {
+  return auth.signInWithPassword(input);
+}
+```
+
+**Caller site (Server Action)** — before and after:
+
+```typescript
+// ui/features/auth/actions.ts (BEFORE)
+"use server";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { signInWithPasswordService } from "@enterprise/core/services/auth-service";
+
+export async function signInAction(input: SignInInput): Promise<ActionResult<SignInData>> {
+  const client = await getServerClient();
+  const result = await signInWithPasswordService(client, input);
+  // ...
+}
+
+// ui/features/auth/actions.ts (AFTER)
+"use server";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
+import { signInWithPasswordService } from "@enterprise/core/services/auth-service";
+
+const { auth: authFactory } = createBackendAdapters();
+
+export async function signInAction(input: SignInInput): Promise<ActionResult<SignInData>> {
+  const client = await getServerClient();
+  const auth = authFactory(client);
+  const result = await signInWithPasswordService(auth, input);
+  // ...
+}
+```
+
+#### Before/after: `getUserRoleService`
+
+**Before** — called inside `signInWithPasswordService` using `client` directly:
+
+```typescript
+// BEFORE — auth-service.ts calls getUserRoleService(client, userId)
+const roleResult = await getUserRoleService(client, user.id);
+```
+
+**After** — `getUserRoleService` signature changes to accept `AuthPort`. The `SupabaseAuthAdapter` implements `getUserRole()` using the same `profiles` table query. Internal calls inside `auth-service.ts` call `auth.getUserRole()`.
+
+```typescript
+// AFTER — auth-service.ts calls auth.getUserRole(userId)
+const roleResult = await auth.getUserRole(user.id);
+```
+
+#### Middleware: before/after
+
+The `middleware.ts` change is the cleanest migration surface — `updateSession()` is replaced with `sessionPort.refreshSession()`:
+
+```typescript
+// ui/middleware.ts (BEFORE)
+import { updateSession } from "@enterprise/core/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  const response = await updateSession(request, middlewareSupabaseConfig);
+  // ...
+}
+
+// ui/middleware.ts (AFTER)
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
+
+const { session: sessionPort } = createBackendAdapters();
+
+export async function middleware(request: NextRequest) {
+  const response = await sessionPort.refreshSession(request);
+  // ...
+}
+```
+
+The `createMiddlewareClient()` call for role resolution remains — it is a DB query, not an auth port concern. Until `DatabasePort` lands, middleware still uses the Supabase middleware client directly for the `getUserRoleService` call. This split dependency is documented explicitly in `middleware.ts` with a comment:
+
+```typescript
+// ui/middleware.ts (AFTER — showing split dependency explicitly)
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
+import { createMiddlewareClient } from "@enterprise/core/supabase/middleware";
+import { getUserRoleService } from "@enterprise/core/services/auth-service";
+
+const { session: sessionPort } = createBackendAdapters();
+
+export async function middleware(request: NextRequest) {
+  // Session refresh is provider-agnostic via SessionPort
+  const response = await sessionPort.refreshSession(request);
+
+  // Role resolution still uses SupabaseClient for the DB query.
+  // This dependency is removed when DatabasePort lands (P1 follow-up).
+  const supabase = createMiddlewareClient(request, middlewareSupabaseConfig);
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user && !isPublicRoute && !isAuthCompletionRoute) {
+    // redirect...
+  }
+
+  const roleResult = await getUserRoleService(supabase, user.id);
+  // ...
+}
+```
+
+#### Services with mixed auth + DB dependencies
+
+Services like the future storage-touching feature services accept both `StoragePort` and `SupabaseClient`:
+
+```typescript
+// AFTER — storage-touching service with split dependency
+export async function uploadAvatarService(
+  storage: StoragePort,    // storage operations via port
+  client: SupabaseClient,  // DB operations via client (until DatabasePort lands)
+  tenantId: string,
+  userId: string,
+  file: File,
+): Promise<ServiceResult<{ url: string }>> {
+  const path = STORAGE_PATHS.avatar(tenantId, userId, "webp");
+  const uploadResult = await storage.upload(STORAGE_BUCKETS.AVATARS, path, file, {
+    contentType: "image/webp",
+  });
+
+  if (!uploadResult.success) return uploadResult;
+
+  // DB write still uses client directly
+  await client.from("profiles").update({ avatar_url: uploadResult.data.fullPath }).eq("id", userId);
+
+  const urlResult = await storage.getPublicUrl(STORAGE_BUCKETS.AVATARS, path);
+  if (!urlResult.success) return urlResult;
+
+  return { success: true, data: { url: urlResult.data.publicUrl } };
+}
+```
+
+The split dependency (port for storage, `SupabaseClient` for DB) is documented in code comments and in the migration guide. It is a deliberate, bounded concession until `DatabasePort` ships.
+
+---
+
+## Service layer changes
+
+The function-based services in `packages/core/src/services/` change their signatures as follows:
+
+| Function | Before | After |
+|----------|--------|-------|
+| `signInWithPasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signUpService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signOutService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getCurrentPlatformUserService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getUserRoleService` | `(client: SupabaseClient, userId)` | `(auth: AuthPort, userId)` |
+| `requestPasswordResetService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `updatePasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| Future storage services | `(client: SupabaseClient, ...)` | `(storage: StoragePort, client: SupabaseClient, ...)` |
+
+The service function bodies become thin delegations to the adapter. All business logic (error mapping, data shaping, result codes) moves into the adapter. This is deliberate: the service layer becomes a stable interface boundary; the adapter carries the provider-specific knowledge.
+
+> **Rule for new services (after decoupling merges)**: Any new service that touches auth operations MUST accept `AuthPort`, not `SupabaseClient`. Any new service that touches storage MUST accept `StoragePort`. This rule is added to `packages/core/AGENTS.md` QA checklist.
+
+---
+
+## Environment variables
+
+| Variable | Required | Default | Accepted values | Purpose |
+|----------|----------|---------|-----------------|---------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes (for Supabase adapter) | — | Supabase project URL | Supabase auth and storage API endpoint |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes (for Supabase adapter) | — | Supabase anon key | Supabase client authentication |
+| `BACKEND_AUTH_PROVIDER` | No | `"supabase"` | `"supabase"` \| `"custom"` | Selects the auth adapter. When `"custom"`, adopter must wire their adapter in `createBackendAdapters()`. |
+| `BACKEND_STORAGE_PROVIDER` | No | `"supabase"` | `"supabase"` \| `"custom"` | Selects the storage adapter. When `"custom"`, adopter must wire their adapter in `createBackendAdapters()`. |
+
+**Default path (no env vars set)**: `createBackendAdapters()` returns Supabase adapters for all ports. The only required env vars are `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`, which are already required today.
+
+**Custom provider path**: The adopter sets `BACKEND_AUTH_PROVIDER=custom` and modifies `createBackendAdapters()` to instantiate their adapter class. They do NOT set `NEXT_PUBLIC_SUPABASE_URL` unless they also use Supabase for storage or session.
+
+**`.env.example` additions**:
+
+```bash
+# Backend provider selection — controls adapter factory in createBackendAdapters()
+# Supported values: "supabase" (default) | "custom"
+# Set to "custom" to wire your own AuthPort implementation (e.g. Firebase, Clerk, Auth0)
+BACKEND_AUTH_PROVIDER=supabase
+
+# Supported values: "supabase" (default) | "custom"
+# Set to "custom" to wire your own StoragePort implementation (e.g. S3, R2, local)
+BACKEND_STORAGE_PROVIDER=supabase
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+#### Auth service tests (post-refactor)
+
+Location: `packages/core/src/services/__tests__/auth-service.test.ts`
+
+The existing Supabase-mocked test file is replaced entirely with port-mock tests. No `@supabase/supabase-js` import remains. The mock is a plain object satisfying `AuthPort` — simpler, faster, and provider-agnostic.
+
+```typescript
+// Canonical port-mock pattern for auth service tests
+function createMockAuthPort(): AuthPort {
+  return {
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getUser: vi.fn(),
+    getUserRole: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    updatePassword: vi.fn(),
+  };
+}
+```
+
+| Test | What it verifies |
+|------|-----------------|
+| `signInWithPasswordService` success | Delegates to `auth.signInWithPassword()`, returns role |
+| `signInWithPasswordService` invalid credentials | Propagates `INVALID_CREDENTIALS` from adapter |
+| `signInWithPasswordService` user not found | Propagates `USER_NOT_FOUND` from adapter |
+| `signInWithPasswordService` role lookup failure | Propagates `ROLE_LOOKUP_FAILED` from adapter |
+| `signInWithPasswordService` null role defaults to guest | Returns `{ role: "guest" }` when adapter returns null role |
+| `signOutService` success | Delegates to `auth.signOut()`, returns null |
+| `signOutService` failure | Propagates `SIGN_OUT_FAILED` from adapter |
+| `signUpService` success with confirmation | Returns `needsEmailConfirmation: true` |
+| `signUpService` success without confirmation | Returns `needsEmailConfirmation: false` |
+| `signUpService` provider failure | Propagates `SIGN_UP_FAILED` |
+| `signUpService` user not created | Propagates `USER_NOT_CREATED` |
+| `requestPasswordResetService` success | Delegates to `auth.requestPasswordReset()` |
+| `requestPasswordResetService` failure | Propagates `PASSWORD_RESET_REQUEST_FAILED` |
+| `updatePasswordService` success | Delegates to `auth.updatePassword()` |
+| `updatePasswordService` failure | Propagates `PASSWORD_UPDATE_FAILED` |
+
+#### Supabase adapter tests
+
+Location: `packages/core/src/services/__tests__/supabase-auth-adapter.test.ts`
+
+These tests verify that `SupabaseAuthAdapter` correctly maps Supabase SDK responses to `ServiceResult<T>`. They DO import and mock `@supabase/supabase-js` — this is appropriate because adapter tests are explicitly testing the Supabase mapping, not business logic.
+
+| Test | What it verifies |
+|------|-----------------|
+| `signInWithPassword` maps SDK success to `ServiceResult` | Correct role is extracted and returned |
+| `signInWithPassword` maps SDK error to `INVALID_CREDENTIALS` | Error code is set correctly |
+| `signInWithPassword` maps null user to `USER_NOT_FOUND` | Boundary: user null after sign-in |
+| `signUp` sets `needsEmailConfirmation: true` when session is null | Supabase returns null session when email conf required |
+| `signUp` sets `needsEmailConfirmation: false` when session exists | Supabase returns session when email conf disabled |
+| `getUser` returns null when no session | Boundary: anonymous visitor |
+| `getUser` maps user + profile to `PlatformUser` | All fields mapped correctly |
+| `getUserRole` maps profile.role to UserRole | Role extraction from profiles table |
+| `getUserRole` ignores PGRST116 (row not found) | Missing profile defaults to guest role |
+| `getUserRole` propagates non-PGRST116 errors | Network errors bubble up |
+| `requestPasswordReset` maps SDK success | Delegates to `resetPasswordForEmail` |
+| `updatePassword` maps SDK success | Delegates to `auth.updateUser()` |
+
+#### Storage adapter tests
+
+Location: `packages/core/src/services/__tests__/supabase-storage-adapter.test.ts`
+
+| Test | What it verifies |
+|------|-----------------|
+| `upload` success returns path and fullPath | Supabase storage response is mapped correctly |
+| `upload` failure returns `STORAGE_UPLOAD_FAILED` | Error from Supabase storage is captured |
+| `download` success returns Blob | Response Blob is returned as-is |
+| `download` failure returns `STORAGE_DOWNLOAD_FAILED` | Error and null data both handled |
+| `delete` success returns null | Remove call succeeds |
+| `delete` failure returns `STORAGE_DELETE_FAILED` | Error from Supabase storage is captured |
+| `getSignedUrl` success returns URL and expiresIn | URL is returned with correct expiry |
+| `getSignedUrl` failure returns `STORAGE_SIGNED_URL_FAILED` | Error and null data both handled |
+| `getPublicUrl` always succeeds | Supabase never errors on public URL construction |
+| `listFiles` maps Supabase FileObject array to StorageFileEntry | All nullable fields handled |
+| `listFiles` with empty result returns empty array | Empty bucket returns `[]` |
+
+#### Storage port unit tests
+
+Location: `packages/core/src/services/__tests__/storage-service.test.ts` (example service using `StoragePort`)
+
+```typescript
+// Canonical port-mock pattern for storage service tests
+function createMockStoragePort(): StoragePort {
+  return {
+    upload: vi.fn(),
+    download: vi.fn(),
+    delete: vi.fn(),
+    getSignedUrl: vi.fn(),
+    getPublicUrl: vi.fn(),
+    listFiles: vi.fn(),
+  };
+}
+```
+
+#### Factory tests
+
+Location: `packages/core/src/services/__tests__/backend-adapters.test.ts`
+
+| Test | What it verifies |
+|------|-----------------|
+| Default (no env vars) returns Supabase adapters | `auth`, `storage`, `session` are all defined |
+| `BACKEND_AUTH_PROVIDER=supabase` returns Supabase auth adapter | Explicit `supabase` value works identically to default |
+| `BACKEND_AUTH_PROVIDER=custom` throws descriptive error | Clear error message for unsupported value |
+| `BACKEND_STORAGE_PROVIDER=supabase` returns Supabase storage adapter | Explicit `supabase` value works identically to default |
+| `BACKEND_STORAGE_PROVIDER=custom` throws descriptive error | Clear error message for unsupported value |
+| Missing `NEXT_PUBLIC_SUPABASE_URL` throws on session construction | Configuration error caught early |
+
+### Integration tests
+
+No new Supabase integration tests are required. The `packages/core/src/supabase/rls-policies.test.ts` file tests RLS via the real Supabase client and is unaffected — it does not go through the port layer.
+
+### E2E tests
+
+No new E2E test files are required. All existing E2E tests implicitly validate that the Supabase adapter is functionally equivalent to the pre-refactor direct calls. Passing the full E2E suite without modification is the acceptance criterion for the default path (US-1 in the PRD).
+
+The specific flows verified implicitly:
+
+| Scenario | Adapter exercised |
+|----------|-------------------|
+| Sign in with email/password | `SupabaseAuthAdapter.signInWithPassword()` |
+| Sign up new account | `SupabaseAuthAdapter.signUp()` |
+| Sign out | `SupabaseAuthAdapter.signOut()` |
+| Request password reset | `SupabaseAuthAdapter.requestPasswordReset()` |
+| Update password | `SupabaseAuthAdapter.updatePassword()` |
+| Middleware session refresh | `SupabaseSessionAdapter.refreshSession()` |
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Port interfaces as plain TypeScript interfaces | Plain interface (`interface AuthPort`) | Abstract class | No SDK imports required to satisfy the interface. Any object literal or class works. Testing is trivial — no mock library needed beyond `vi.fn()`. |
+| Auth and storage adapters take `SupabaseClient` per-call | Factory returns `(client) => Adapter` function | Factory returns fully-constructed adapter | `SupabaseClient` is request-scoped — it cannot be captured at module level. The function wrapper makes the per-request wiring explicit. |
+| Session adapter constructed at module level | `createBackendAdapters()` constructs `SupabaseSessionAdapter` at call time | Session constructed per-request | `SupabaseSessionAdapter` captures URL and anon key at construction, not the client. It creates its own internal Supabase client per `refreshSession()` call via `updateSession()`. This is safe to construct once. |
+| Service functions become thin delegations | Service delegates to adapter: `return auth.signInWithPassword(input)` | Service retains implementation, adapter wraps service | Moves provider-specific logic entirely into the adapter. Services become stable interface boundaries. Makes unit testing trivial — mock the adapter, not the Supabase SDK. |
+| `SessionPort` returns `NextResponse` | `NextResponse` (Next.js type) | Custom response wrapper | Middleware is a Next.js primitive. A custom response abstraction would add complexity without benefit. Adopters who leave Next.js must rewrite middleware anyway. This is intentionally scoped to Next.js. |
+| No `DatabasePort` in MVP | Excluded | Included | DB operations are the most complex decoupling surface — RLS policies, PostgREST vs Drizzle, schema coupling. Attempting this in MVP would delay Auth and Storage decoupling, which are the highest-value swaps for adopters. |
+| `getUserRole` on `AuthPort` (not separate port) | `AuthPort.getUserRole()` | Separate `ProfilePort` or DB query | Role resolution is required in auth flows and middleware. Placing it on `AuthPort` keeps the adapter cohesive. Adopters with JWT-embedded roles implement it without a DB call. |
+| `STORAGE_BUCKETS` and `STORAGE_PATHS` constants unchanged | Retained as-is in `storage-paths.ts` | Moved into `StoragePort` | The constants are provider-agnostic naming conventions. Any adapter can use them. Moving them would be a needless breaking change. |
+| Env-var selection vs. `NODE_ENV` | Explicit env vars (`BACKEND_AUTH_PROVIDER`) | `NODE_ENV` check | `NODE_ENV` conflates deployment environment with provider choice. An adopter may run Firebase in staging and Supabase in production, or vice versa. Explicit env vars give full control and match the billing adapter pattern. |
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Services that accept both `AuthPort` and `SupabaseClient` create a confusing split dependency | Medium — adopters may not understand which parameter handles which concern | Document the split clearly in code comments (`// Auth via AuthPort. DB via SupabaseClient until DatabasePort lands.`) and in the migration guide. This is a known, temporary state. |
+| Port methods designed for Supabase make the Supabase adapter trivial but alternative adapters hard | High — port becomes a leaky Supabase abstraction | Design methods around the LOWEST COMMON DENOMINATOR. Supabase-specific features (Magic Link, MFA, OTP) are excluded from `AuthPort` MVP scope and documented as extension points. |
+| Adopters bypass the port and import `SupabaseClient` directly in new services | Medium — defeats the pattern without a compile-time error | Add to `packages/core/AGENTS.md` QA checklist: "New services accept `AuthPort`/`StoragePort`, not `SupabaseClient`, for auth and storage operations (after decoupling merges)." Code review enforces this. |
+| `createBackendAdapters()` throws at startup if `NEXT_PUBLIC_SUPABASE_URL` is missing in custom-provider environments | Medium — breakage for adopters who set `BACKEND_AUTH_PROVIDER=custom` but still use Supabase for session | Split session adapter construction: if both `BACKEND_AUTH_PROVIDER=custom` AND `BACKEND_STORAGE_PROVIDER=custom`, the session adapter construction is deferred and the adopter must provide a custom `SessionPort`. Document this in the migration guide. |
+| Renaming service signatures from `SupabaseClient` to `AuthPort` breaks existing adopter forks | High for forks — source-level breaking change | Provide a complete before/after migration guide with diffs for every changed function signature. Version the change with a clear changelog entry. |
+| Unit tests that mocked `SupabaseClient` deeply no longer compile after the signature change | Medium — existing test files break | All existing tests in `packages/core/src/services/__tests__/` are updated as part of this feature. The PR includes the updated test files. |
+| `SupabaseSessionAdapter.refreshSession()` calls `updateSession()` which internally calls `getUser()` — double server-round-trip risk | Low — this was already the case in the pre-refactor middleware | No change in behavior. The adapter wraps existing code exactly. Performance characteristics are identical. |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Port interfaces: `auth-port.ts`, `storage-port.ts`, `session-port.ts` in `packages/core/src/services/ports/` | None |
+| 2 | Supabase adapters: `SupabaseAuthAdapter`, `SupabaseStorageAdapter`, `SupabaseSessionAdapter` in `packages/core/src/services/adapters/` | Phase 1 |
+| 3 | Adapter factory: `createBackendAdapters()` in `packages/core/src/services/backend-adapters.ts` | Phase 2 |
+| 4 | Service migration: update `auth-service.ts` signatures from `SupabaseClient` to `AuthPort`; remove inline auth logic (now in adapter) | Phase 2 |
+| 5 | Test migration: update `__tests__/auth-service.test.ts` to use port mocks; add `__tests__/supabase-auth-adapter.test.ts`, `__tests__/supabase-storage-adapter.test.ts`, `__tests__/backend-adapters.test.ts` | Phases 3–4 |
+| 6 | Middleware migration: update `ui/middleware.ts` to use `SessionPort` from factory | Phase 3 |
+| 7 | Server Action wiring: update all auth Server Actions in `ui/features/auth/actions.ts` to inject adapter via factory | Phases 3–4 |
+| 8 | Public API exports: update `packages/core/src/services/index.ts` (or subpath exports) to export `AuthPort`, `StoragePort`, `SessionPort` | Phases 1–3 |
+| 9 | Documentation: `docs/developer-guide/backend-provider-migration.md` | Phases 1–7 |
+| 10 | QA checklist update: `packages/core/AGENTS.md` — add port-based injection rule for new services | Phase 9 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Use `PaymentProviderPort` / `createPaymentAdapter()` billing pattern as the reference? | Yes — same structure: port interface → adapter class → factory function → env-var selection | Pattern is already in the codebase, proven, and understood by anyone who has read the billing feature. Zero new conventions introduced. |
+| Plain interface vs. abstract class for ports? | Plain interface | Any object satisfying the shape is a valid adapter. No SDK imports required. Mocking is trivial. Consistent with `InvitationEmailPort` pattern already in the codebase. |
+| Auth adapter receives `SupabaseClient` per-call (factory returns function) vs. at construction? | Factory returns `(client) => Adapter` function | `SupabaseClient` is request-scoped — constructed per-request from `getServerClient()`. Capturing it at module level would serve stale sessions. The function wrapper makes per-request wiring explicit and type-safe. |
+| Include `getUserRole` on `AuthPort`? | Yes — as `getUserRole(userId: string)` | Role resolution is always needed after sign-in and in middleware. Placing it on `AuthPort` keeps auth concerns cohesive. Adopters using JWT-embedded roles implement it without a DB call. |
+| `SessionPort` returns `NextResponse`? | Yes — intentionally Next.js-scoped | Middleware is a Next.js primitive. Abstracting away `NextResponse` into a custom response type adds complexity without benefit. Adopters who leave Next.js must rewrite middleware regardless. |
+| `SessionPort` selection env var? | No separate env var — always instantiated alongside `AuthPort` | Session management is tightly coupled to the auth provider in practice. Separating them would require adopters to configure two env vars for one conceptual swap. |
+| Include `DatabasePort` in this RFC? | No — P1 follow-up | DB operations (PostgREST vs. Drizzle, RLS delegation, schema coupling) require deeper analysis. Blocking auth/storage decoupling on this would delay the highest-value swaps. |
+| Where do new port files live? | `packages/core/src/services/ports/` — alongside `invitation-email-port.ts` | Consistent with existing port location. No new directory structures introduced. |
+| Where do new adapter files live? | `packages/core/src/services/adapters/` — alongside `ConsoleInvitationEmailAdapter` and `ResendInvitationEmailAdapter` | Consistent with existing adapter location and naming convention. |
+| Ship Firebase, Clerk, or Auth0 adapters in this PR? | No — Supabase adapter only | Shipping unvalidated community adapters adds maintenance burden without production proof. The `AuthPort` interface is the deliverable; community adapters are examples in the migration guide. |
+| `STORAGE_BUCKETS` and `STORAGE_PATHS` constants kept as-is? | Yes — provider-agnostic naming conventions | Any `StoragePort` implementation can use these constants. Moving them into the port would be a breaking change without benefit. The Supabase adapter uses them internally. |
+| Env-var selection driven by explicit vars vs. `NODE_ENV`? | Explicit env vars (`BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`) | Mirrors the billing adapter decision. `NODE_ENV` conflates environment with provider choice. Explicit env vars give adopters full control (e.g., Supabase in prod, custom in staging). |
+
+---
+
+## File inventory
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `packages/core/src/services/ports/auth-port.ts` | `AuthPort` interface — provider-agnostic auth operations |
+| `packages/core/src/services/ports/storage-port.ts` | `StoragePort` interface — provider-agnostic file storage operations |
+| `packages/core/src/services/ports/session-port.ts` | `SessionPort` interface — Next.js middleware session refresh |
+| `packages/core/src/services/adapters/supabase-auth-adapter.ts` | `SupabaseAuthAdapter` class implementing `AuthPort` |
+| `packages/core/src/services/adapters/supabase-storage-adapter.ts` | `SupabaseStorageAdapter` class implementing `StoragePort` |
+| `packages/core/src/services/adapters/supabase-session-adapter.ts` | `SupabaseSessionAdapter` class implementing `SessionPort` |
+| `packages/core/src/services/backend-adapters.ts` | `createBackendAdapters()` factory — env-var-driven adapter selection |
+| `packages/core/src/services/__tests__/supabase-auth-adapter.test.ts` | Unit tests for `SupabaseAuthAdapter` — Supabase SDK mapping |
+| `packages/core/src/services/__tests__/supabase-storage-adapter.test.ts` | Unit tests for `SupabaseStorageAdapter` — Supabase Storage SDK mapping |
+| `packages/core/src/services/__tests__/backend-adapters.test.ts` | Unit tests for `createBackendAdapters()` factory — env-var selection |
+| `docs/developer-guide/backend-provider-migration.md` | Step-by-step migration guide for adopters |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `packages/core/src/services/auth-service.ts` | All function signatures changed from `(client: SupabaseClient, ...)` to `(auth: AuthPort, ...)`. Internal `client.auth.*` calls removed — delegated to adapter. `getUserRoleService` delegates to `auth.getUserRole()`. |
+| `packages/core/src/services/__tests__/auth-service.test.ts` | Rewritten to use port-mock pattern. Removes `SupabaseClient` import. All `createMockClient()` usages replaced with `createMockAuthPort()`. |
+| `ui/middleware.ts` | `updateSession()` call replaced with `sessionPort.refreshSession()`. `createBackendAdapters()` imported and called at module level. Comment added explaining remaining Supabase dependency for DB (role lookup). |
+| `packages/core/src/index.ts` | Adds re-exports for `AuthPort`, `StoragePort`, `SessionPort`, and `createBackendAdapters` from their respective subpaths. |
+| `packages/core/AGENTS.md` | QA checklist updated: "New services accept `AuthPort`/`StoragePort`, not `SupabaseClient` directly, for auth and storage operations (after decoupling is merged)." |
+| `.env.example` | Two new commented entries: `BACKEND_AUTH_PROVIDER=supabase` and `BACKEND_STORAGE_PROVIDER=supabase` with inline documentation. |
+| `ui/features/auth/actions.ts` | All auth Server Actions updated to inject adapter via `createBackendAdapters()`. Client is passed to `authFactory(client)` per-request. |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/billing-and-plans/prd.md
+++ b/docs/features/billing-and-plans/prd.md
@@ -1,77 +1,375 @@
 ---
 title: "Billing and plans PRD"
-description: "Defines product requirements for plan management, subscription lifecycle, and billing visibility."
+description: "Defines product requirements for plan management, subscription lifecycle, billing visibility, and provider-agnostic billing adapter."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-05-11"
 ---
 
 # Billing and plans PRD
 
 ## Purpose
 
-Define the product scope for monetization primitives in the template: plans, subscription state, and billing-facing tenant controls.
+Define implementation-ready product requirements for tenant-scoped billing in a multi-tenant SaaS template, including plan catalog, subscription state management, and a provider-agnostic billing adapter.
 
 ## Scope
 
-- Included: plan catalog, subscription status, upgrade/downgrade flow, and billing visibility.
-- Excluded: payment-provider-specific technical implementation details and accounting integrations.
+- Included: plan catalog (DB-driven), subscription lifecycle, upgrade/downgrade flows, billing history view, payment method management (delegated to provider portal), billing adapter pattern, and traceability.
+- Excluded: multi-currency tax calculation, invoice rendering, revenue recognition, actual notification delivery system (billing events are flagged for display only), dunning management beyond grace period, and accounting/ERP integrations.
 
 ---
 
 ## Problem
 
-Template adopters need a baseline billing model to launch paid SaaS offerings without rebuilding subscription behavior from scratch.
+Template adopters need a complete billing foundation to launch paid SaaS offerings without rebuilding subscription behavior from scratch. Today there is no plan catalog, no subscription state machine, and no billing UI — every adopter reimplements the same primitives in isolation, often incorrectly.
 
 ## Users and stakeholders
 
 | Role | Need |
 |------|------|
-| Tenant owner | Understand current plan and manage subscription |
-| Finance/ops | Reliable subscription state for operational decisions |
-| Product team | Predictable entitlement foundation for gated features |
+| Tenant owner | Understand current plan, manage subscription, control payment method |
+| Tenant admin | View current plan and billing history; cannot change plan or payment method |
+| Platform engineering | Consistent, adapter-based billing model that decouples provider choice |
+| Template adopter | A complete billing starting point they can swap to any provider without rewrites |
 
 ## Goals
 
-- Provide a clear path from free to paid usage.
-- Make plan limits and current subscription state visible.
-- Keep plan transitions safe and auditable.
+- Provide a DB-driven plan catalog that is configurable without code changes.
+- Deliver a reliable subscription state machine with clear, auditable transitions.
+- Expose upgrade, downgrade, and cancellation flows behind permission-guarded Server Actions.
+- Decouple all provider-specific logic behind a `BillingPort` adapter interface.
+
+---
+
+## Permission matrix
+
+| Action | Owner | Admin | Member | Guest |
+|--------|-------|-------|--------|-------|
+| View current plan and status | Yes | Yes | No | No |
+| View billing history | Yes | Yes | No | No |
+| Upgrade plan | Yes | No | No | No |
+| Downgrade plan | Yes | No | No | No |
+| Cancel subscription | Yes | No | No | No |
+| Resubscribe / restart trial | Yes | No | No | No |
+| Manage payment method (provider portal) | Yes | No | No | No |
+
+> **Important**: Members and guests have no access to the `/billing` page. All billing mutations are owner-only. Admins have read-only visibility.
 
 ---
 
 ## MVP scope
 
-- Plan definitions with monthly/annual variants.
-- Tenant subscription state machine (active, trialing, past_due, canceled).
-- Upgrade and downgrade workflow entry points.
-- Billing history summary view (high-level, not full accounting ledger).
+### Plan and subscription lifecycle
 
-## Out of scope
+- Maintain a `plans` table as a DB-driven catalog with name, description, price per cycle, feature limits (stored as JSONB), and active flag.
+- Each tenant has exactly one `subscriptions` row tracking current plan, state, billing cycle, period dates, and grace period end.
+- Tenant owners can view their current plan, available plans, and initiate a plan change.
+- Plan changes are applied at period end by default; the adapter MAY support immediate proration.
+- Cancellation sets state to `canceled` at period end; active access continues until `current_period_end`.
+- A `past_due` state is introduced when a payment fails; `grace_ends_at` is set by the adapter on webhook.
+- Resubscription moves the tenant back to `active` (or `trial` if the plan offers a trial reset).
+- The billing adapter syncs subscription state via webhooks; the internal state is the authoritative source for entitlement checks.
 
-- Multi-currency tax calculation engine.
-- Invoice rendering and legal compliance workflows.
-- Revenue recognition reporting.
+### Subscription state machine
+
+| From state | Event | To state | Notes |
+|-----------|-------|----------|-------|
+| — | Tenant signs up | `trial` | Default for new tenants when plan has trial days |
+| — | Tenant signs up | `active` | When plan has no trial |
+| `trial` | Payment collected | `active` | Trial converts on successful charge |
+| `trial` | Trial expires, no payment | `canceled` | Grace period does not apply to trial |
+| `active` | Payment fails | `past_due` | `grace_ends_at` set by adapter |
+| `active` | Owner cancels | `canceled` | Access until `current_period_end` |
+| `past_due` | Payment retry succeeds | `active` | Grace period cleared |
+| `past_due` | Grace period expires | `canceled` | Adapter webhook triggers transition |
+| `canceled` | Owner resubscribes | `active` | Or `trial` if plan includes a new trial |
+
+Rules:
+- Only one active subscription per tenant at a time.
+- Plan catalog entries may be deactivated; existing subscriptions are not affected.
+- `grace_ends_at` is nullable — only set while in `past_due` state.
+- Entitlement checks MUST read subscription state from the DB, never from client-side state.
+- Billing events that create notification flags in MVP: `subscription.upgraded`, `subscription.downgraded`, `subscription.past_due`, `subscription.canceled` (display only — the notification system is a separate feature).
+
+### Out of scope (MVP)
+
+- Multi-currency and tax calculation engine.
+- Invoice PDF rendering and legal compliance workflows.
+- Revenue recognition and accounting reports.
+- Dunning sequences beyond a single grace period.
+- Bulk plan migrations across tenants.
+- Custom pricing per tenant (enterprise deals).
+- Actual in-app notification delivery (billing events are logged, not delivered in MVP).
+
+---
+
+## UX specification
+
+### Route
+
+`/billing`
+
+### Page layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Header: "Billing" + "Manage your subscription and billing info"  │
+├──────────────────────────────────────────────────────────────────┤
+│ Current plan card:                                               │
+│   Plan name | Price/cycle | Status badge | Renewal/Cancel date  │
+│   [Manage payment method →]  (owner only, opens provider portal) │
+├──────────────────────────────────────────────────────────────────┤
+│ Available plans section (owner only):                            │
+│   Plan card grid: Name | Price | Features | [Upgrade]/[Current] │
+│   Downgrade shown as secondary CTA on lower-tier cards          │
+├──────────────────────────────────────────────────────────────────┤
+│ Billing history table:                                           │
+│   Date | Event | Plan | Amount | Status                         │
+│   (Visible to owner and admin)                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **Current plan card** | Displays plan name, billing interval (monthly/annual), price, status badge (`trial`, `active`, `past_due`, `canceled`), and next renewal date (or cancellation date if canceled). Owner sees "Manage payment method" link. |
+| **Past due banner** | Shown when subscription is `past_due`. Displays grace period end date and a "Update payment method" CTA. Dismissible per session. |
+| **Plan comparison grid** | Cards for each active plan. Current plan is highlighted with "Current plan" badge. Upgrade/downgrade CTAs trigger a confirmation sheet. Hidden for non-owners. |
+| **Plan change sheet** | Slide-over or dialog showing: from plan → to plan, pricing delta, effective date ("at period end"), and a confirm/cancel action pair. |
+| **Cancel subscription dialog** | Confirmation dialog: "Your access continues until {date}. Cancel anyway?" Requires explicit owner action. |
+| **Billing history table** | Paginated table: date, event type (upgraded, downgraded, payment succeeded, payment failed, canceled), plan name, amount, and status badge. Read-only. |
+| **Manage payment method link** | External link to provider customer portal (Stripe customer portal pattern). Opens in new tab. Owner-only. |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Loading** | Skeleton in current plan card and history table |
+| **Trial active** | Status badge: `Trial` with days remaining. Plan grid visible with upgrade CTAs. |
+| **Active** | Status badge: `Active`. Renewal date shown. Cancel and upgrade/downgrade available. |
+| **Past due** | Status badge: `Past due`. Banner with grace period end date displayed above plan card. |
+| **Canceled** | Status badge: `Canceled`. Access-until date shown. Resubscribe CTA replaces upgrade/downgrade grid. |
+| **No billing history** | "No billing events yet" empty state in history table |
+| **Permission denied (member/guest)** | Entire `/billing` page redirects to `/dashboard` — billing is not visible to members or guests. |
+| **Plan change pending** | Upgrade/downgrade CTA on current plan shows "Change scheduled: {plan} at period end" badge; cancellable. |
+
+### Role-specific visibility
+
+| Element | Owner | Admin | Member | Guest |
+|---------|-------|-------|--------|-------|
+| `/billing` page access | Yes | Yes | No (redirect) | No (redirect) |
+| Current plan card | Yes | Yes | — | — |
+| Past due banner | Yes | Yes | — | — |
+| Plan comparison grid | Yes | No | — | — |
+| Plan change CTAs | Yes | No | — | — |
+| Cancel subscription | Yes | No | — | — |
+| Manage payment method | Yes | No | — | — |
+| Billing history table | Yes | Yes | — | — |
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: Owner views current plan and subscription status
+
+**As** a tenant owner, **I want** to see my current plan and subscription status so I understand what I am paying for and when it renews.
+
+Acceptance criteria:
+1. The `/billing` page loads and displays the current plan name, price, and billing interval.
+2. A status badge reflects the subscription state (`trial`, `active`, `past_due`, `canceled`).
+3. The next renewal date is displayed when the subscription is `active` or `trial`.
+4. When state is `canceled`, the access-until date is displayed instead of a renewal date.
+5. When state is `past_due`, a banner shows the grace period end date.
+
+### US-2: Owner upgrades plan
+
+**As** a tenant owner, **I want** to upgrade my subscription plan so my tenant has access to higher-tier features.
+
+Acceptance criteria:
+1. The plan comparison grid shows all active plans; the current plan is highlighted.
+2. Clicking "Upgrade" on a higher-tier plan opens a confirmation sheet.
+3. The sheet shows: current plan, target plan, price delta, and effective date ("at period end").
+4. Confirming the upgrade calls the billing adapter and updates the subscription record.
+5. The current plan card reflects the scheduled change with a "Change pending" badge.
+6. A `billing.plan_upgraded` audit event is logged.
+
+### US-3: Owner downgrades plan
+
+**As** a tenant owner, **I want** to downgrade my subscription so I can reduce costs when my needs change.
+
+Acceptance criteria:
+1. Lower-tier plans in the grid show a "Downgrade" CTA (secondary style).
+2. Clicking "Downgrade" opens the same confirmation sheet with downgrade-specific messaging.
+3. Confirming the downgrade schedules the change for period end.
+4. The current plan card reflects the scheduled change.
+5. A `billing.plan_downgraded` audit event is logged.
+
+### US-4: Owner cancels subscription
+
+**As** a tenant owner, **I want** to cancel my subscription so I stop being charged while retaining access until the period ends.
+
+Acceptance criteria:
+1. A "Cancel subscription" action is available in the current plan card (owner only).
+2. Clicking it opens a confirmation dialog with the access-until date.
+3. Confirming cancellation updates subscription state to `canceled`.
+4. The plan card shows "Canceled — access until {date}" with the correct date.
+5. A `billing.subscription_canceled` audit event is logged.
+6. Members and admins do not see the cancel action.
+
+### US-5: Owner manages payment method
+
+**As** a tenant owner, **I want** to update my payment method so I can prevent or resolve failed payments.
+
+Acceptance criteria:
+1. A "Manage payment method" link is visible in the current plan card (owner only).
+2. Clicking the link opens the provider's customer portal in a new tab.
+3. The link is generated by the billing adapter (Stripe customer portal URL pattern).
+4. Admins, members, and guests do not see this link.
+
+### US-6: Admin views billing information
+
+**As** a tenant admin, **I want** to view the current plan and billing history so I can answer team questions about subscription status.
+
+Acceptance criteria:
+1. Admin can access `/billing` and see the current plan card and status badge.
+2. Admin can see the billing history table.
+3. Admin cannot see the plan comparison grid, upgrade/downgrade CTAs, cancel action, or manage payment method link.
+4. Past due banner is visible to admin (read-only — no action CTA for admins).
+
+### US-7: Subscription enters past_due state
+
+**As** the system, **I want** to handle failed payments gracefully so tenants have time to resolve billing issues without losing access immediately.
+
+Acceptance criteria:
+1. When the billing adapter webhook reports a payment failure, subscription state transitions to `past_due`.
+2. `grace_ends_at` is set based on the plan's grace period configuration.
+3. A `billing.subscription_past_due` audit event is logged.
+4. The past due banner appears on `/billing` for owner and admin.
+5. If the owner updates the payment method and payment succeeds, state returns to `active` and the banner disappears.
+6. If `grace_ends_at` passes without payment, a webhook transitions state to `canceled`.
+
+### US-8: Owner resubscribes after cancellation
+
+**As** a tenant owner, **I want** to resubscribe after canceling so I can restart my subscription when my needs return.
+
+Acceptance criteria:
+1. When subscription state is `canceled`, the plan comparison grid shows a "Subscribe" CTA instead of "Upgrade".
+2. Clicking "Subscribe" opens a plan selection and confirmation flow.
+3. Confirming resubscription transitions state to `active` (or `trial` if plan has a trial and the tenant has never trialed).
+4. A `billing.subscription_reactivated` audit event is logged.
 
 ---
 
 ## Success metrics
 
-- Trial-to-paid conversion rate.
-- Upgrade completion rate.
-- Billing-related support tickets per 100 tenants.
-- Failed plan transition incidents.
+- Trial-to-paid conversion rate per tenant cohort (target: > 30% within 14 days of trial start).
+- Upgrade completion rate from confirmation sheet (target: > 85% of started upgrade flows complete).
+- Billing-related support tickets per 100 tenants per month (target: < 5).
+- Subscription state drift incidents (adapter webhook vs. DB mismatch) (target: 0 per month).
+- Mean time to resolve `past_due` state (target: < 48 hours).
 
 ## Risks
 
-- Entitlements and billing can drift if updates are asynchronous.
-- Plan messaging may be unclear for admins.
-- External provider failures can degrade subscription state trust.
-
-## Open questions
-
-- Should plan changes apply immediately or at period end by default?
-- How should grace periods be represented in UI?
-- Which billing events should create in-app notifications in MVP?
+| Risk | Mitigation |
+|------|------------|
+| Subscription state drifts when webhook delivery fails | Webhook idempotency keys + retry logic in adapter; scheduled reconciliation job (follow-up) |
+| Entitlement checks use stale client-side state | Entitlement checks always read from DB via service layer — never trust client-passed plan info |
+| Provider outage blocks plan changes | Adapter returns `ServiceResult` error; UI shows a "Try again later" message without corrupting state |
+| Plan changes confuse users (at period end vs. immediate) | Confirmation sheet explicitly shows effective date; follow-up email notification on change |
+| Grace period not surfaced clearly | Persistent past due banner with exact date; red status badge throughout session |
+| Adopters hardcode Stripe — defeats adapter pattern | `BillingPort` interface enforced; Stripe adapter is reference-only, clearly documented as swappable |
 
 ---
 
-*Last updated: 2026-05-07*
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `billing.plan_upgraded` | Owner confirms plan upgrade | `{ fromPlanId, toPlanId, effectiveAt, initiatedBy }` |
+| `billing.plan_downgraded` | Owner confirms plan downgrade | `{ fromPlanId, toPlanId, effectiveAt, initiatedBy }` |
+| `billing.subscription_canceled` | Owner confirms cancellation | `{ planId, accessUntil, initiatedBy }` |
+| `billing.subscription_reactivated` | Owner resubscribes | `{ planId, initiatedBy }` |
+| `billing.subscription_past_due` | Webhook: payment failed | `{ planId, graceEndsAt, providerEventId }` |
+| `billing.subscription_activated` | Webhook: payment succeeded after past_due | `{ planId, providerEventId }` |
+| `billing.subscription_expired` | Webhook: grace period ended, state → canceled | `{ planId, providerEventId }` |
+| `billing.webhook_processing_failed` | Adapter webhook handler throws | `{ providerEventId, errorCode }` |
+
+### Sentry
+
+- Area: `billing`
+- Instrumented actions: `upgradePlanAction`, `downgradePlanAction`, `cancelSubscriptionAction`, `resubscribeAction`, `createPaymentPortalSessionAction`, `handleBillingWebhookAction`
+- Captured errors: DB state transition failures, adapter call failures, webhook signature verification failures, idempotency key conflicts
+- PII exclusions: payment method details, card numbers, customer emails, billing address fields
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`, `providerEventId`, `fromPlanId`, `toPlanId`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Plan | `active` | `Free` — $0/month, 1 seat, 10 resources, no trial |
+| Plan | `active` | `Starter` — $29/month, 5 seats, 100 resources, 14-day trial |
+| Plan | `active` | `Pro` — $99/month, 25 seats, unlimited resources, 14-day trial |
+| Subscription | `trial` | Seed tenant on `Starter`, trial expires in 7 days |
+| Subscription | `active` | Second seed tenant on `Pro` plan, renews in 20 days |
+| Subscription | `past_due` | Third seed tenant on `Starter`, grace ends in 3 days |
+| Subscription | `canceled` | Fourth seed tenant on `Free`, access until yesterday |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| Owner views billing page on active subscription | Owner | Plan card shows correct plan, status badge is `Active`, history table loads |
+| Owner upgrades from Starter to Pro | Owner | Confirmation sheet shown, plan change recorded, audit event logged |
+| Owner downgrades from Pro to Starter | Owner | Confirmation sheet shown with downgrade messaging, change scheduled |
+| Owner cancels subscription | Owner | Confirmation dialog shown with access-until date, state becomes `canceled` |
+| Owner resubscribes after cancellation | Owner | Subscribe flow shown, state returns to `active` |
+| Admin views billing page | Admin | Plan card and history visible; no upgrade/cancel/payment CTAs present |
+| Member tries to access /billing | Member | Redirected to /dashboard |
+| Guest tries to access /billing | Guest | Redirected to /dashboard |
+| Webhook sets subscription to past_due | System | Past due banner appears on /billing for owner and admin |
+| Owner clicks manage payment method | Owner | Provider portal URL returned, link opens in new tab |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Billing provider | `BillingPort` | In-memory adapter — simulates state transitions and logs events | Stripe adapter | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` |
+| Customer portal | `BillingPort.createPortalSession()` | Returns a mock URL logged to console | Stripe customer portal URL | `STRIPE_SECRET_KEY` |
+
+### Production readiness
+
+- [ ] All audit events verified in `audit_log` table for happy and failure paths
+- [ ] Sentry area `billing` registered and all Server Actions instrumented
+- [ ] `BillingPort` interface documented with adapter contract and swap instructions
+- [ ] Unit tests pass for `billing-service.ts` (all state transition functions)
+- [ ] Unit tests pass for `plans-service.ts` (plan catalog read operations)
+- [ ] E2E tests pass for all defined flows
+- [ ] RLS policies on `plans` and `subscriptions` tables verified (no cross-tenant leaks)
+- [ ] Webhook handler verifies provider signature before processing
+- [ ] Webhook idempotency enforced (duplicate event IDs are no-ops)
+- [ ] Seed data committed and `supabase db reset` runs cleanly
+- [ ] `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` documented in production deployment guide
+- [ ] Entitlement gate pattern documented for adopters (how to check plan limits in services)
+- [ ] `/billing` route added to `ui/lib/routes.ts` (`ROUTES.billing`)
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Plan changes apply at period end by default? | Yes — period end | Predictable for users; avoids complex proration math in MVP. Adapter MAY support immediate proration. |
+| How is grace period represented in UI? | `past_due` state + banner with `grace_ends_at` date | Clear, persistent signal without interrupting access; matches industry patterns (Stripe, Paddle) |
+| Which billing events create notification flags in MVP? | `subscription.upgraded`, `subscription.downgraded`, `subscription.past_due`, `subscription.canceled` | These are the events users care most about; actual delivery is a separate notification feature |
+| Plans in DB or hardcoded? | DB-driven `plans` table | Template adopters need to configure plans without code changes; hardcoding defeats the template purpose |
+| Provider coupling? | Adapter pattern (`BillingPort` interface) with Stripe as reference implementation | Template must remain provider-agnostic; Stripe adapter is swappable without touching services or UI |
+| Members and guests see billing? | No — redirect to /dashboard | Billing is sensitive commercial info; members have no need to see it; consistent with industry norms |
+| Resubscription resets trial? | Only if plan has trial and tenant has never trialed it before | Prevents trial abuse while allowing legitimate plan restarts |
+| Multi-plan subscriptions (add-ons)? | No — one subscription per tenant in MVP | Simplifies state machine significantly; add-ons are a follow-up |
+| Payment method management delegated to provider? | Yes — provider customer portal | Avoids PCI scope for the template; Stripe customer portal handles all card data |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/billing-and-plans/rfc.md
+++ b/docs/features/billing-and-plans/rfc.md
@@ -1,79 +1,702 @@
 ---
 title: "Billing and plans RFC"
-description: "Defines the technical architecture for subscription state, plans, and entitlement synchronization."
+description: "Defines the implementation-ready technical architecture for subscription state, plan management, and payment provider integration."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-05-11"
 ---
 
 # Billing and plans RFC
 
 ## Purpose
 
-Define a technical plan for billing and plan management that remains provider-agnostic at service boundaries.
+Define an implementation-ready technical approach for provider-agnostic billing and plan management aligned with the service layer, contracts, adapter, and traceability conventions of the Enterprise Platform.
 
 ## Scope
 
-- Included: data model, service interfaces, webhook ingestion boundary, and entitlement sync.
-- Excluded: provider-specific SDK internals and finance back-office systems.
+- Included: data model, RLS policies, Zod contracts, service APIs, payment adapter (Stripe + local), Server Actions, webhook ingestion route, UI routes, seed data, and testing strategy.
+- Excluded: invoice PDF generation, dunning automation, usage-based metering, multi-seat seat licensing, tax calculation (Avalara/TaxJar), finance back-office systems, provider-specific SDK internals beyond the adapter boundary.
 
 ---
 
 ## Summary
 
-Billing state lives in tenant-scoped tables. External payment events enter through a bounded adapter and update subscription state through service functions.
+Implement billing as a tenant-bounded module using Drizzle schema for `plans`, `tenant_subscriptions`, and `billing_events` tables with RLS policies, Zod contracts in `@enterprise/contracts` for all inputs and outputs, function-based services in `@enterprise/core/src/services/billing-service.ts`, a port/adapter pattern for payment provider operations (Stripe in production, local no-op in development), thin Server Actions in `ui/features/billing/actions.ts`, and a Next.js Route Handler for idempotent webhook ingestion. All mutations are auditable via `AuditService.log()` and traceable via Sentry instrumentation under the `billing` area.
 
-## Technical objective
+## Technical objectives
 
-- Keep billing source-of-truth consistent and auditable.
-- Expose stable plan and entitlement contracts to app features.
-- Protect tenant isolation while processing cross-tenant provider events.
+- Tenant subscription state is always consistent, queryable, and auditable — no opaque provider payload blobs as source of truth.
+- Local development works without Stripe credentials via `LocalPaymentAdapter`.
+- Webhook processing is idempotent: duplicate provider events produce no side effects.
+- Billing data is fully tenant-isolated via RLS; webhook handlers use the service role only after signature verification.
 
 ---
 
-## Proposed design
+## Data model
 
-| Area | Design |
-|------|--------|
-| Contracts | Add plan, subscription, and entitlement schemas in `@enterprise/contracts` |
-| Service layer | Add `billing-service.ts` with sync and transition handlers |
-| Data model | Add `plans`, `tenant_subscriptions`, and `billing_events` in Drizzle |
-| Ingestion | Route webhook events to a provider adapter, then service-layer mutation |
-| App layer | Server Actions read subscription state and request plan transitions |
+Location: `packages/db/src/schema/billing.ts` — **new file**
 
-## Security and tenant isolation implications
+### New enums
 
-- Provider events are verified before processing.
-- Tenant-scoped subscription reads remain under RLS.
-- Background event handlers use strict mapping from provider customer ID to tenant ID.
+```typescript
+export const subscriptionStatusEnum = pgEnum("subscription_status", [
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+]);
+
+export const billingCycleEnum = pgEnum("billing_cycle", [
+  "monthly",
+  "yearly",
+]);
+```
+
+### `plans` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `name` | `text` | NOT NULL |
+| `slug` | `text` | NOT NULL, UNIQUE |
+| `description` | `text` | NULLABLE |
+| `price_monthly` | `integer` | NOT NULL (cents) |
+| `price_yearly` | `integer` | NOT NULL (cents) |
+| `currency` | `text` | NOT NULL, default `'usd'` |
+| `features` | `text` | NOT NULL (JSON string — feature flags/limits) |
+| `limits` | `text` | NOT NULL (JSON string — quota limits) |
+| `is_active` | `boolean` | NOT NULL, default `true` |
+| `display_order` | `integer` | NOT NULL, default `0` |
+| `trial_days` | `integer` | NOT NULL, default `0` |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### `tenant_subscriptions` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE, UNIQUE |
+| `plan_id` | `uuid` | NOT NULL, FK `plans.id` |
+| `status` | `subscription_status` enum | NOT NULL |
+| `billing_cycle` | `billing_cycle` enum | NOT NULL |
+| `current_period_start` | `timestamptz` | NOT NULL |
+| `current_period_end` | `timestamptz` | NOT NULL |
+| `cancel_at_period_end` | `boolean` | NOT NULL, default `false` |
+| `canceled_at` | `timestamptz` | NULLABLE |
+| `trial_ends_at` | `timestamptz` | NULLABLE |
+| `grace_ends_at` | `timestamptz` | NULLABLE |
+| `external_subscription_id` | `text` | NULLABLE, UNIQUE |
+| `external_customer_id` | `text` | NULLABLE |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### `billing_events` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `subscription_id` | `uuid` | NULLABLE, FK `tenant_subscriptions.id` |
+| `event_type` | `text` | NOT NULL |
+| `provider` | `text` | NOT NULL (e.g. `'stripe'`, `'local'`) |
+| `external_event_id` | `text` | NULLABLE, UNIQUE |
+| `payload` | `text` | NULLABLE (JSON string) |
+| `processed_at` | `timestamptz` | NULLABLE |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `plans_slug_idx` | `slug` | Slug lookup |
+| `plans_active_order_idx` | `is_active`, `display_order` | Catalog listing |
+| `subscriptions_tenant_idx` | `tenant_id` | Tenant-scoped lookup (UNIQUE constraint also covers this) |
+| `subscriptions_external_id_idx` | `external_subscription_id` | Webhook event routing |
+| `subscriptions_status_idx` | `status` | Background job filtering |
+| `billing_events_tenant_idx` | `tenant_id` | Tenant-scoped history |
+| `billing_events_external_event_idx` | `external_event_id` | Idempotency check |
+| `billing_events_subscription_idx` | `subscription_id` | Per-subscription history |
+
+### Constraints
+
+- UNIQUE on `tenant_subscriptions.tenant_id` — one active subscription record per tenant.
+- UNIQUE on `tenant_subscriptions.external_subscription_id` — prevents duplicate provider linkage.
+- UNIQUE on `billing_events.external_event_id` — enforces idempotency at DB level.
+- `plans.features` and `plans.limits` store JSON as `text`; parsing happens at the service layer.
+
+### Type exports
+
+```typescript
+export type Plan = typeof plans.$inferSelect;
+export type NewPlan = typeof plans.$inferInsert;
+
+export type TenantSubscription = typeof tenantSubscriptions.$inferSelect;
+export type NewTenantSubscription = typeof tenantSubscriptions.$inferInsert;
+
+export type BillingEvent = typeof billingEvents.$inferSelect;
+export type NewBillingEvent = typeof billingEvents.$inferInsert;
+```
+
+---
+
+## RLS policies
+
+### `plans`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `plans_select` | SELECT | `authenticated` | Always — plans are a public catalog |
+| `plans_insert` | INSERT | `service_role` | Service role only |
+| `plans_update` | UPDATE | `service_role` | Service role only |
+| `plans_delete` | DELETE | `service_role` | Service role only |
+
+### `tenant_subscriptions`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `subscriptions_select` | SELECT | `authenticated` | `tenant_id` matches JWT claim AND role IN (`owner`, `admin`) |
+| `subscriptions_insert` | INSERT | `service_role` | Service role only — created by webhook handler |
+| `subscriptions_update` | UPDATE | `service_role` | Service role only — updated by webhook handler |
+| `subscriptions_delete` | DELETE | — | No deletes — status transitions only |
+
+### `billing_events`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `billing_events_select` | SELECT | `authenticated` | `tenant_id` matches JWT claim AND role IN (`owner`, `admin`) |
+| `billing_events_insert` | INSERT | `service_role` | Service role only — written by webhook handler |
+| `billing_events_update` | UPDATE | — | Immutable after insert |
+| `billing_events_delete` | DELETE | — | No deletes — audit records |
+
+> **Note**: All subscription mutations (create, update) use the **admin client** (`service_role`) in the service layer because they originate from webhook events or internal service calls — never direct user mutations through an authenticated client.
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/billing.ts`
+
+### Output schemas
+
+```typescript
+import { z } from "zod";
+
+// Plan display shape
+export const planSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  priceMonthly: z.number().int(),
+  priceYearly: z.number().int(),
+  currency: z.string(),
+  features: z.string(), // JSON string
+  limits: z.string(),   // JSON string
+  isActive: z.boolean(),
+  displayOrder: z.number().int(),
+  trialDays: z.number().int(),
+});
+
+// Subscription display shape
+export const subscriptionSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  planId: z.string().uuid(),
+  status: z.enum(["trialing", "active", "past_due", "canceled", "unpaid"]),
+  billingCycle: z.enum(["monthly", "yearly"]),
+  currentPeriodStart: z.string().datetime(),
+  currentPeriodEnd: z.string().datetime(),
+  cancelAtPeriodEnd: z.boolean(),
+  canceledAt: z.string().datetime().nullable(),
+  trialEndsAt: z.string().datetime().nullable(),
+  graceEndsAt: z.string().datetime().nullable(),
+  externalSubscriptionId: z.string().nullable(),
+  externalCustomerId: z.string().nullable(),
+  plan: planSchema.optional(), // joined plan details
+});
+
+// Billing event display shape
+export const billingEventSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  subscriptionId: z.string().uuid().nullable(),
+  eventType: z.string(),
+  provider: z.string(),
+  externalEventId: z.string().nullable(),
+  processedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+```
+
+### Input schemas
+
+```typescript
+// Change plan
+export const changePlanSchema = z.object({
+  planId: z.string().uuid(),
+});
+
+// Cancel subscription
+export const cancelSubscriptionSchema = z.object({
+  cancelAtPeriodEnd: z.boolean().default(true),
+});
+
+// Billing history query
+export const billingHistoryQuerySchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+```
+
+### Type exports
+
+All DTOs derive types via `z.infer<typeof schema>`.
+
+---
+
+## Service layer
+
+Location: `packages/core/src/services/billing-service.ts`
+
+Pattern: function-based (per `packages/core/AGENTS.md`).
+
+### Service functions
+
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `listPlans` | `client` | `ServiceResult<Plan[]>` | SELECT open to all authenticated — RLS allows it |
+| `getSubscription` | `client, tenantId` | `ServiceResult<SubscriptionWithPlan>` | Joins subscription with plan; returns null if no subscription |
+| `changePlan` | `client, adminClient, tenantId, userId, input` | `ServiceResult<TenantSubscription>` | Calls payment adapter `changePlan`; syncs state; audit logs |
+| `cancelSubscription` | `client, adminClient, tenantId, userId, input` | `ServiceResult<TenantSubscription>` | Calls adapter `cancelSubscription`; sets `cancel_at_period_end`; audit logs |
+| `resumeSubscription` | `client, adminClient, tenantId, userId` | `ServiceResult<TenantSubscription>` | Calls adapter `resumeSubscription`; clears `cancel_at_period_end`; audit logs |
+| `processWebhookEvent` | `adminClient, event` | `ServiceResult<null>` | Idempotent; checks `external_event_id` uniqueness; routes to `syncSubscriptionState` |
+| `getBillingHistory` | `client, tenantId, query` | `ServiceResult<BillingEvent[]>` | Paginated billing event log |
+| `syncSubscriptionState` | `adminClient, tenantId, data` | `ServiceResult<TenantSubscription>` | Internal — upserts `tenant_subscriptions` from provider event payload |
+
+### Idempotency contract
+
+`processWebhookEvent` MUST:
+
+1. Check `billing_events.external_event_id` for the incoming event ID.
+2. If a row already exists, return `{ ok: true, data: null }` (no-op).
+3. Otherwise insert the event row first, then call `syncSubscriptionState`.
+4. Use the admin client for all writes — never the authenticated client.
+
+```
+Webhook flow:
+  Route Handler receives raw body + signature header
+    │
+    ├─ 1. Verify signature via adapter.verifyWebhookSignature()
+    ├─ 2. Parse event type and payload
+    ├─ 3. Call processWebhookEvent(adminClient, event)
+    │       ├─ Check external_event_id uniqueness
+    │       ├─ Insert billing_events row
+    │       └─ Call syncSubscriptionState(adminClient, tenantId, data)
+    └─ 4. Return HTTP 200 OK (always — to prevent provider retry on non-5xx)
+```
+
+---
+
+## Server Actions
+
+Location: `ui/features/billing/actions.ts`
+
+All actions follow the thin wrapper pattern:
+
+```
+validate input (Zod) → get authenticated client + admin client → call service → map to ActionResult → revalidatePath
+```
+
+### Actions list
+
+| Action | Schema | Service function | Sentry area |
+|--------|--------|-----------------|-------------|
+| `changePlanAction` | `changePlanSchema` | `changePlan` | `billing` |
+| `cancelSubscriptionAction` | `cancelSubscriptionSchema` | `cancelSubscription` | `billing` |
+| `resumeSubscriptionAction` | — | `resumeSubscription` | `billing` |
+| `getPortalUrlAction` | — | adapter `getPortalUrl` | `billing` |
+
+### Webhook route
+
+Location: `ui/app/api/webhooks/billing/route.ts`
+
+This is a Next.js **Route Handler** (not a Server Action). It:
+
+1. Reads the raw request body and signature header.
+2. Calls `adapter.verifyWebhookSignature(payload, signature)`.
+3. Parses event type and routes to `processWebhookEvent(adminClient, event)`.
+4. Always returns `200 OK` on success; `400` on invalid signature; `500` on unexpected errors.
+
+> **Critical**: Do NOT use `"use server"` in the webhook route file. It is a Route Handler (`export async function POST`), not a Server Action.
+
+### Sentry instrumentation
+
+Every Server Action wraps its body with `Sentry.withServerActionInstrumentation`. Non-validation errors call `captureActionError` with:
+- `actionName`: the action function name
+- `area`: `"billing"`
+- `tenantId`, `userId`, `userRole` from auth context
+- `inputShape`: `Object.keys(parsed.data)` — NEVER values
+- `errorCode`: from `ServiceResult.code`
+
+---
+
+## Sentry area registration
+
+Add `billing` to the `SentryArea` union in `ui/lib/sentry.ts`:
+
+```typescript
+export type SentryArea = "auth" | "billing" | "dashboard" | "resources" | "settings" | "team" | "webhook";
+```
+
+---
+
+## External adapter
+
+### Interface
+
+Location: `packages/core/src/services/ports/payment-provider-port.ts`
+
+```typescript
+export interface PaymentProviderPort {
+  createCustomer(params: {
+    tenantId: string;
+    tenantName: string;
+    email: string;
+  }): Promise<{ customerId: string }>;
+
+  createSubscription(params: {
+    customerId: string;
+    planId: string;
+    billingCycle: string;
+  }): Promise<{ subscriptionId: string; status: string }>;
+
+  changePlan(params: {
+    subscriptionId: string;
+    newPlanId: string;
+  }): Promise<{ success: boolean }>;
+
+  cancelSubscription(params: {
+    subscriptionId: string;
+    cancelAtPeriodEnd: boolean;
+  }): Promise<{ success: boolean }>;
+
+  resumeSubscription(params: {
+    subscriptionId: string;
+  }): Promise<{ success: boolean }>;
+
+  getPortalUrl(params: {
+    customerId: string;
+    returnUrl: string;
+  }): Promise<{ url: string }>;
+
+  verifyWebhookSignature(
+    payload: string,
+    signature: string,
+  ): Promise<boolean>;
+}
+```
+
+### Implementations
+
+| Adapter | Location | Behavior | Selection |
+|---------|----------|----------|-----------|
+| `LocalPaymentAdapter` | `packages/core/src/services/adapters/local-payment-adapter.ts` | In-memory state, console logs, instant status changes, always verifies signature | Default when `STRIPE_SECRET_KEY` is not set |
+| `StripePaymentAdapter` | `packages/core/src/services/adapters/stripe-payment-adapter.ts` | Real Stripe API calls, stripe-js webhook signature verification | When `STRIPE_SECRET_KEY` is set |
+
+### Adapter factory
+
+```typescript
+// packages/core/src/services/adapters/payment-adapter-factory.ts
+
+export function createPaymentAdapter(): PaymentProviderPort {
+  const stripeKey = process.env["STRIPE_SECRET_KEY"];
+  if (stripeKey) {
+    return new StripePaymentAdapter(stripeKey);
+  }
+  return new LocalPaymentAdapter();
+}
+```
+
+Selection is based on env var presence, NOT `NODE_ENV`.
+
+---
+
+## UI routes and components
+
+### Routes
+
+| Route | Component | Auth | Description |
+|-------|-----------|------|-------------|
+| `/billing` | `BillingPage` | Required, owner/admin | Billing dashboard: current plan, usage, history, upgrade CTA |
+
+### Feature module structure
+
+```
+ui/features/billing/
+├── actions.ts                         # Server Actions (thin wrappers)
+├── queries.ts                         # Server-side data fetching
+├── types.ts                           # Feature-local types
+├── components/
+│   ├── billing-page-header.tsx        # Header with title and manage billing CTA
+│   ├── current-plan-card.tsx          # Active plan display with status badge
+│   ├── plan-comparison.tsx            # Plan cards grid for upgrade/downgrade
+│   ├── billing-history-table.tsx      # Paginated billing events table
+│   ├── change-plan-dialog.tsx         # Confirmation dialog for plan change
+│   ├── cancel-subscription-dialog.tsx # Confirmation dialog for cancellation
+│   └── subscription-status-badge.tsx  # Status chip: active, trialing, past_due, etc.
+└── hooks/
+```
+
+### App routes
+
+```
+ui/app/(protected)/billing/
+├── page.tsx                           # Server Component — fetches data, passes to views
+└── error.tsx                          # Error boundary with Sentry
+
+ui/app/api/webhooks/billing/
+└── route.ts                           # Next.js Route Handler — webhook ingestion
+```
+
+> Route is registered in `ui/lib/routes.ts`:
+> ```typescript
+> billing: "/billing",
+> ```
+
+---
+
+## Seed data
+
+Location: additions to `supabase/seed.sql`
+
+### Seed plans
+
+```sql
+-- Free plan
+INSERT INTO public.plans (
+  id, name, slug, description,
+  price_monthly, price_yearly, currency,
+  features, limits,
+  is_active, display_order, trial_days,
+  created_at, updated_at
+) VALUES (
+  'b0000001-0000-0000-0000-000000000001',
+  'Free', 'free',
+  'Get started with the essentials.',
+  0, 0, 'usd',
+  '{"ai":false,"analytics":false}',
+  '{"members":3,"resources":10}',
+  true, 1, 0,
+  now(), now()
+);
+
+-- Pro plan ($29/mo, $290/yr)
+INSERT INTO public.plans (
+  id, name, slug, description,
+  price_monthly, price_yearly, currency,
+  features, limits,
+  is_active, display_order, trial_days,
+  created_at, updated_at
+) VALUES (
+  'b0000001-0000-0000-0000-000000000002',
+  'Pro', 'pro',
+  'For growing teams that need more power.',
+  2900, 29000, 'usd',
+  '{"ai":true,"analytics":true}',
+  '{"members":25,"resources":500}',
+  true, 2, 14,
+  now(), now()
+);
+
+-- Enterprise plan ($99/mo, $990/yr)
+INSERT INTO public.plans (
+  id, name, slug, description,
+  price_monthly, price_yearly, currency,
+  features, limits,
+  is_active, display_order, trial_days,
+  created_at, updated_at
+) VALUES (
+  'b0000001-0000-0000-0000-000000000003',
+  'Enterprise', 'enterprise',
+  'Unlimited scale with dedicated support.',
+  9900, 99000, 'usd',
+  '{"ai":true,"analytics":true,"sso":true,"audit":true}',
+  '{"members":-1,"resources":-1}',
+  true, 3, 0,
+  now(), now()
+);
+```
+
+### Seed subscription and events
+
+```sql
+-- Demo tenant on Pro plan, active, monthly
+INSERT INTO public.tenant_subscriptions (
+  id, tenant_id, plan_id, status, billing_cycle,
+  current_period_start, current_period_end,
+  cancel_at_period_end,
+  external_subscription_id, external_customer_id,
+  created_at, updated_at
+) VALUES (
+  'b0000002-0000-0000-0000-000000000001',
+  '<demo_tenant_id>',
+  'b0000001-0000-0000-0000-000000000002',
+  'active', 'monthly',
+  now() - interval '10 days',
+  now() + interval '20 days',
+  false,
+  'sub_local_demo', 'cus_local_demo',
+  now() - interval '10 days', now()
+);
+
+-- Event: subscription created
+INSERT INTO public.billing_events (
+  id, tenant_id, subscription_id,
+  event_type, provider, external_event_id,
+  payload, processed_at, created_at
+) VALUES (
+  'b0000003-0000-0000-0000-000000000001',
+  '<demo_tenant_id>',
+  'b0000002-0000-0000-0000-000000000001',
+  'subscription.created', 'local', 'evt_local_001',
+  '{"status":"active","plan":"pro"}',
+  now() - interval '10 days',
+  now() - interval '10 days'
+);
+
+-- Event: payment succeeded
+INSERT INTO public.billing_events (
+  id, tenant_id, subscription_id,
+  event_type, provider, external_event_id,
+  payload, processed_at, created_at
+) VALUES (
+  'b0000003-0000-0000-0000-000000000002',
+  '<demo_tenant_id>',
+  'b0000002-0000-0000-0000-000000000001',
+  'payment.succeeded', 'local', 'evt_local_002',
+  '{"amount":2900,"currency":"usd"}',
+  now() - interval '10 days',
+  now() - interval '10 days'
+);
+
+-- Event: plan upgraded
+INSERT INTO public.billing_events (
+  id, tenant_id, subscription_id,
+  event_type, provider, external_event_id,
+  payload, processed_at, created_at
+) VALUES (
+  'b0000003-0000-0000-0000-000000000003',
+  '<demo_tenant_id>',
+  'b0000002-0000-0000-0000-000000000001',
+  'plan.upgraded', 'local', 'evt_local_003',
+  '{"from":"free","to":"pro"}',
+  now() - interval '10 days',
+  now() - interval '10 days'
+);
+```
+
+> **Note**: `<demo_tenant_id>` references the existing deterministic seed ID from `seed.sql`.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/core/src/services/__tests__/billing-service.test.ts`
+
+| Test | What it verifies |
+|------|------------------|
+| `listPlans` returns active plans | Sorted by `display_order`; inactive plans excluded |
+| `getSubscription` with existing subscription | Returns subscription joined with plan |
+| `getSubscription` with no subscription | Returns `null` data, no error |
+| `changePlan` success | Calls adapter `changePlan`, upserts subscription, logs audit event |
+| `changePlan` with invalid plan ID | Returns validation error before adapter call |
+| `cancelSubscription` at period end | Sets `cancel_at_period_end = true`, calls adapter |
+| `cancelSubscription` immediate | Sets `cancel_at_period_end = false`, calls adapter |
+| `resumeSubscription` success | Clears `cancel_at_period_end`, calls adapter |
+| `resumeSubscription` already active | No-op — returns current state |
+| `processWebhookEvent` new event | Inserts billing event, calls `syncSubscriptionState` |
+| `processWebhookEvent` duplicate event | Returns success without duplicate insert (idempotent) |
+| `getBillingHistory` paginated | Returns correct page with limit/offset |
+
+### Contract tests
+
+Location: `packages/contracts/src/__tests__/billing.test.ts`
+
+Test all schemas for valid input, boundary values, and rejection of invalid input.
+
+### E2E tests
+
+Location: `ui/e2e/billing/billing.spec.ts`
+
+| Test | Tag | Flow |
+|------|-----|------|
+| Owner sees billing page | `@critical` | Login as owner → navigate to `/billing` → verify plan card |
+| Admin sees billing page | `@critical` | Login as admin → navigate to `/billing` → verify plan card |
+| Member cannot access billing | `@critical` | Login as member → navigate to `/billing` → verify redirect |
+| Owner sees plan comparison | | Login as owner → verify plan comparison grid |
+| Owner initiates plan change | | Login as owner → click upgrade → confirm dialog → verify updated plan |
+| Owner cancels subscription | | Login as owner → cancel → confirm dialog → verify `cancel_at_period_end` badge |
+| Owner resumes subscription | | Login as owner → resume after cancel → verify active state |
+| Billing history table renders | | Login as owner → verify billing history table has rows |
+| Billing history pagination | | Login as owner → navigate billing history pages |
 
 ---
 
 ## Trade-offs
 
-- **Chosen:** normalized subscription state for traceability.
-- **Not chosen:** storing only opaque provider payloads, because it hurts queryability and entitlement checks.
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Subscription source of truth | Normalized `tenant_subscriptions` table | Opaque provider payload blob | Queryable, entitlement checks, RLS-compatible |
+| Payment adapter selection | Env-var presence (`STRIPE_SECRET_KEY`) | `NODE_ENV` check | Explicit, testable in any environment |
+| Webhook mutations auth | Admin client (`service_role`) | Authenticated client | Webhooks have no user JWT context |
+| Idempotency enforcement | DB-level UNIQUE on `external_event_id` + service check | Service-only check | Defense in depth; DB prevents races |
+| Plan features/limits | JSON string columns (`text`) | JSONB or separate columns | Drizzle JSONB support variance; parsed at service layer |
+| Subscription per tenant | UNIQUE constraint on `tenant_id` | Multi-subscription support | Simpler model for v1; multi-plan is follow-up |
+| Payment service pattern | Function-based | Class-based | Consistent with `auth-service.ts` platform convention |
+
+---
 
 ## Risks
 
-- Delayed events can produce temporary plan mismatch.
-- Idempotency bugs can duplicate transitions.
-- Provider outage affects near-real-time state updates.
+| Risk | Mitigation |
+|------|------------|
+| Delayed webhook events produce temporary plan mismatch | Grace period window (`grace_ends_at`) defers enforcement; UI shows warning state |
+| Idempotency bug duplicates state transitions | UNIQUE constraint on `external_event_id` prevents DB-level duplicates; service also checks before insert |
+| Provider outage blocks subscription changes | `LocalPaymentAdapter` always works; Stripe unavailability surfaces as service error to user |
+| Webhook signature bypass | Signature always verified before payload parsing; invalid signature returns `400` without logging sensitive data |
+| RLS policy drift between `tenant_subscriptions` and `billing_events` | Both tables use `service_role` for writes; reads use same `tenantClaimMatchesColumn` helper |
+| Stripe plan ID ≠ internal plan slug mismatch | `external_subscription_id` and `external_customer_id` are stored; mapping is done in adapter, not in service layer |
 
 ---
 
-## Rollout and implementation phases
+## Implementation phases
 
-1. Plan and subscription schema with contracts.
-2. Billing service with idempotent event processing.
-3. UI integration for plan display and change requests.
-4. Entitlement enforcement integration with limits/quotas.
-
-## Open questions
-
-- Which events are mandatory for MVP parity across providers?
-- Should canceled subscriptions retain last entitlements during grace period?
-- What retry policy is required for failed webhook processing?
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Contracts: Zod schemas and types in `@enterprise/contracts` | None |
+| 2 | Data model: `billing.ts` Drizzle schema, enums, RLS policies, migration | Phase 1 |
+| 3 | Payment adapter: `PaymentProviderPort` interface + `LocalPaymentAdapter` + `StripePaymentAdapter` | Phase 1 |
+| 4 | Services: `billing-service.ts` + unit tests | Phases 1–3 |
+| 5 | Server Actions (`actions.ts`) + webhook Route Handler + Sentry area registration | Phase 4 |
+| 6 | UI: billing page, components, route registration in `routes.ts` | Phase 5 |
+| 7 | Seed data + E2E tests | Phase 6 |
 
 ---
 
-*Last updated: 2026-05-07*
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| New schema file or add to `platform.ts`? | New `billing.ts` file | Separation of concerns; billing schema grows independently |
+| `features` and `limits` as JSON string or typed columns? | JSON string (`text`) | Flexible schema without migrations for adding flags; parsed and validated at service layer |
+| Subscription immutable delete? | No deletes — status transitions only | Audit trail integrity; `canceled` is a status, not a row deletion |
+| Webhook route as Server Action or Route Handler? | Route Handler (`route.ts`) | Server Actions cannot read raw request body or custom headers (signature verification requires raw body) |
+| Stripe plan ID mapping? | Stored in `external_subscription_id`; slug is internal identifier | Decouples internal plan model from provider-specific plan IDs |
+| Grace period enforcement? | `grace_ends_at` column stored; enforcement is feature-level concern | Billing RFC owns data model; entitlement enforcement is a follow-up |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/brand-abstraction-layer/prd.md
+++ b/docs/features/brand-abstraction-layer/prd.md
@@ -1,0 +1,383 @@
+---
+title: "Brand abstraction layer PRD"
+description: "Defines product requirements for a provider-agnostic branding layer that lets the Enterprise Platform template support multiple visual identities from a single codebase."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Brand abstraction layer PRD
+
+## Purpose
+
+Define implementation-ready product requirements for a brand abstraction layer that lets the Enterprise Platform template host multiple visual identities (brands) from a single codebase, without requiring a separate Next.js application per brand. This layer sits above the existing theme system: the theme system provides design tokens (colors, typography, spacing, shadows), and the brand layer selects which theme to apply and adds the identity artifacts that surround it — name, logo, metadata, legal URLs, social links, and brand-scoped feature toggles.
+
+## Scope
+
+- Included: `BrandConfig` Zod schema in `@enterprise/contracts`, `BrandProvider` React context, `useBrand()` hook, brand resolution strategy (subdomain, path prefix, environment variable, static config), single-brand default ("enterprise" brand ships with the template), architecture that allows adopters to add brands via config with no code changes, integration with the existing theme system, admin-visible audit trail for brand config changes, and E2E coverage for brand rendering.
+- Excluded: runtime brand switching per end-user session, multi-tenant branding (one brand per tenant — covered by the theme system's `tenantId` field), visual brand editor UI, A/B testing across brands, brand-level analytics dashboards, and white-label billing (separate billing feature).
+
+---
+
+## Problem
+
+Template adopters who build multi-brand products (e.g., a product sold under multiple labels, a platform with regional sub-brands, a white-label offering) currently have no standard pattern for branding within the template. The common workaround — forking a separate Next.js app per brand — duplicates infrastructure, increases maintenance burden, and diverges codebases. The result is that adopters reimplement the same brand-switching primitives in isolation, often inconsistently.
+
+The theme system introduced JSON-configurable design tokens and a `ThemeProvider`, but it does not define what a "brand" is. It resolves colors and spacing; it does not capture the logo files, the legal URLs, the Open Graph metadata, or the feature toggles that differ across brands. That gap is what this layer fills.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| Template adopter (engineer) | A documented, config-driven pattern to add a second brand without touching shared code |
+| Product designer | A single place to register logo assets, color theme reference, and typography per brand |
+| Platform engineer | Reliable brand context throughout the component tree with zero prop-drilling |
+| End user | Consistent, correct brand identity rendered on every page they visit |
+| Platform admin | Audit visibility when brand configuration is changed in production |
+
+## Goals
+
+- Provide a `BrandConfig` schema (Zod) that is the single source of truth for what a brand is.
+- Deliver a `BrandProvider` + `useBrand()` hook that makes brand context available throughout the component tree.
+- Define and implement a brand resolution strategy that determines which brand to render per request, configurable via subdomain, path prefix, or environment variable.
+- Ship the template with exactly one brand out of the box ("enterprise") so adopters have a working starting point.
+- Design the architecture so that adding a second brand requires only a new config file — no code changes.
+
+---
+
+## Permission matrix
+
+The brand abstraction layer does not expose a management UI in MVP. Brand configuration is code-driven (committed config files). The permission matrix below applies to admin-visible audit records of brand config deployments and to any brand-config endpoints added in future iterations.
+
+| Action | Platform admin | Tenant owner | Tenant admin | Member | Guest |
+|--------|---------------|-------------|-------------|--------|-------|
+| Read active brand config (via `useBrand()`) | Yes | Yes | Yes | Yes | Yes |
+| View brand config audit events | Yes | No | No | No | No |
+| Modify brand config (code deploy) | Platform admin (dev workflow) | No | No | No | No |
+| Override brand per tenant (future) | Yes | No | No | No | No |
+
+> **Note**: In MVP, brand config changes are deployed via code commits. There is no runtime admin UI for editing brand config. The audit event is emitted at application startup when the resolved brand config is loaded.
+
+---
+
+## MVP scope
+
+### Core capabilities
+
+**BrandConfig schema (`@enterprise/contracts`)**
+
+A `brandConfigSchema` (Zod) with the following fields:
+
+- `slug` — URL-safe identifier, unique per brand (e.g., `"enterprise"`, `"acme"`)
+- `name` — Internal identifier used in audit events and logs
+- `displayName` — Human-readable brand name shown in UI headings and footers
+- `description` — Short description used in meta tags and internal docs
+- `logo` — Object with `light` and `dark` variants, each containing `src` (path or URL), `alt` text, and optional `width`/`height`
+- `favicon` — Path or URL to the favicon asset
+- `metadata` — Object with `titleTemplate` (e.g., `"%s | Acme"`), `defaultTitle`, `description` (default OG/meta description), and `ogImage` (path or URL)
+- `legal` — Object with `privacyUrl` and `termsUrl`
+- `social` — Optional object with `twitter`, `linkedin`, `github` (each a URL string)
+- `themeRef` — String key referencing which theme JSON file to apply (e.g., `"light"`, `"dark"`, `"acme-light"`). The theme system resolves this reference to load the corresponding token set.
+- `features` — Optional record of `string → boolean` for brand-scoped feature toggles (e.g., `{ "showPoweredBy": true, "enablePublicApi": false }`)
+
+**Brand config files (`packages/ui/src/brands/`)**
+
+Each brand is a TypeScript file (`{slug}.brand.ts`) that exports a `BrandConfig` object validated against `brandConfigSchema`. The template ships with `enterprise.brand.ts` as the only required brand. Adopters add brands by creating additional files in this directory.
+
+**BrandProvider (`packages/ui/src/brand/provider.tsx`)**
+
+A React Server Component-compatible provider that:
+
+1. Accepts a resolved `BrandConfig` as a prop (it does not resolve — resolution happens at the server boundary)
+2. Places the config into React context via `BrandContext`
+3. Applies the referenced theme by triggering the existing `ThemeProvider` with the `themeRef` value
+
+**useBrand() hook (`packages/ui/src/brand/provider.tsx`)**
+
+A client-side hook that reads `BrandContext` and returns the full `BrandConfig`. Throws if called outside a `BrandProvider`.
+
+**Brand resolution (`packages/ui/src/brand/resolve.ts`)**
+
+A server-side utility `resolveBrand(request?: Request): BrandConfig` that determines which brand to render using the following priority order:
+
+1. `BRAND_SLUG` environment variable — highest priority; forces a single brand regardless of request context (suitable for single-brand deployments)
+2. Subdomain matching — extracts the first subdomain segment from the request hostname and matches it against registered brand slugs (e.g., `acme.platform.com` → slug `"acme"`)
+3. Path prefix matching — matches the first path segment against registered brand slugs (e.g., `/acme/dashboard` → slug `"acme"`)
+4. Default brand — falls back to the brand with `isDefault: true` in the brand registry, or to `"enterprise"` if no default is declared
+
+The brand registry is a static import of all `*.brand.ts` files in `packages/ui/src/brands/`. There is no database lookup in MVP.
+
+**Theme integration**
+
+`BrandProvider` reads `themeRef` from the resolved `BrandConfig` and passes it to `ThemeProvider` as the initial theme. The theme system's existing token resolution pipeline (`resolve.ts`, `generate-css.ts`) handles the rest. Brands that want a custom theme create a new `{slug}-light.json` / `{slug}-dark.json` in `packages/ui/src/themes/` and reference them in `themeRef`. Brands that share the default theme simply point `themeRef` to `"light"` or `"dark"`.
+
+**Integration in the Next.js app**
+
+`ui/app/layout.tsx` calls `resolveBrand()` at the server component level, passes the result to `BrandProvider`, and wraps children. This makes brand context available to all pages and layouts below it with no per-route changes required.
+
+### Out of scope (MVP)
+
+- Runtime brand switching per authenticated session (each request resolves a brand; the user cannot toggle it).
+- Admin UI for editing or creating brand configs without a code deploy.
+- Database-driven brand config storage.
+- Brand-level A/B experimentation.
+- Brand inheritance or partial override from a parent brand.
+- Per-tenant brand assignment (a tenant always sees the brand the platform resolves for the request).
+- Automated asset optimization or CDN upload for brand logos.
+- Brand-specific routing namespaces (e.g., separate sitemaps per brand).
+
+---
+
+## UX specification
+
+### Route
+
+No dedicated route. The brand abstraction layer is infrastructure — it affects every page rendered by the app. There is no `/brand` settings page in MVP.
+
+### Page layout (brand impact on rendered pages)
+
+The brand layer affects the following layout zones on every page:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ <head>                                                           │
+│   <title>{brand.metadata.titleTemplate} → resolved per page</title>│
+│   <meta name="description" content="{brand.metadata.description}">│
+│   <link rel="icon" href="{brand.favicon}">                       │
+│   <meta property="og:image" content="{brand.metadata.ogImage}">  │
+├──────────────────────────────────────────────────────────────────┤
+│ Navigation / header                                              │
+│   <img src="{brand.logo[mode].src}" alt="{brand.logo[mode].alt}" │
+│        width="{brand.logo[mode].width}" />                       │
+├──────────────────────────────────────────────────────────────────┤
+│ Page content (theme tokens resolved from brand.themeRef)         │
+│   CSS variables from the referenced theme JSON are active here   │
+├──────────────────────────────────────────────────────────────────┤
+│ Footer                                                           │
+│   {brand.displayName}  ·  Privacy  ·  Terms                     │
+│   (links from brand.legal.privacyUrl / brand.legal.termsUrl)     │
+│   Social icons (brand.social.*)                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **BrandProvider** | Server-side: wraps the entire app in `ui/app/layout.tsx`. Accepts resolved `BrandConfig` prop. Internally renders `ThemeProvider` with `themeRef`. No visible UI. |
+| **BrandLogo** | Reads `useBrand()`, reads current theme mode from `useTheme()`, renders `<img>` with the correct light/dark logo `src` and `alt`. Falls back to `displayName` text if `src` is empty. |
+| **BrandMeta** (Next.js `generateMetadata`) | A server-side metadata generator helper that reads the resolved `BrandConfig` and returns a Next.js `Metadata` object — title template, description, favicon, and OG image. |
+| **BrandFooter** | Reads `useBrand()`, renders `displayName`, legal links from `brand.legal`, and social icon links from `brand.social`. |
+| **useBrand()** | Client hook. Returns the full `BrandConfig` from context. Throws if called outside `BrandProvider`. |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Single brand (default)** | `BRAND_SLUG=enterprise` or no config overrides. All pages render the "enterprise" brand. |
+| **Multi-brand via subdomain** | Request to `acme.platform.com` resolves to `"acme"` brand. Logo, theme, metadata, and legal links all reflect the Acme brand. |
+| **Unknown brand slug** | `resolveBrand()` falls back to the default brand and emits a warning log. No error page. |
+| **Missing logo asset** | `BrandLogo` renders brand `displayName` as text fallback. No broken image tag. |
+| **themeRef not found** | `ThemeProvider` falls back to the built-in light theme and emits a warning. No crash. |
+
+### Role-specific visibility
+
+Brand configuration is not role-gated in MVP. All users who access a URL receive the brand resolved for that URL. There is no per-user brand selection.
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: Brand context is available throughout the component tree
+
+**As** a platform engineer, **I want** brand config to be injected at the root layout so every component can access it without prop-drilling.
+
+Acceptance criteria:
+1. `BrandProvider` wraps `ui/app/layout.tsx` and receives the resolved `BrandConfig`.
+2. Any client component can call `useBrand()` and receive the full `BrandConfig` object.
+3. Calling `useBrand()` outside a `BrandProvider` throws a descriptive error with the component name in the message.
+4. `BrandProvider` renders `ThemeProvider` internally with the theme referenced by `themeRef`.
+
+### US-2: Logo renders the correct variant for the active theme mode
+
+**As** an end user, **I want** to see a logo that is legible in both light and dark mode so the brand identity is always clear.
+
+Acceptance criteria:
+1. `BrandLogo` reads `useTheme().mode` and `useBrand().logo`.
+2. When mode is `"light"`, the `logo.light.src` image is rendered.
+3. When mode is `"dark"`, the `logo.dark.src` image is rendered.
+4. When the `src` field is empty or undefined, `BrandLogo` renders `brand.displayName` as a text fallback.
+5. The `alt` attribute is always set to `logo[mode].alt`.
+
+### US-3: Page metadata reflects the active brand
+
+**As** a product designer, **I want** every page's `<title>`, favicon, and Open Graph image to match the active brand so SEO and social sharing are brand-accurate.
+
+Acceptance criteria:
+1. `generateMetadata` in `ui/app/layout.tsx` uses the resolved `BrandConfig` to set `title.template`, `title.default`, `description`, `icons.icon`, and `openGraph.images`.
+2. The title template formats correctly: a page titled "Dashboard" with template `"%s | Acme"` produces `"Dashboard | Acme"`.
+3. Changing `brand.metadata.ogImage` to a different URL is reflected in `<meta property="og:image">` without any code change.
+
+### US-4: Legal footer links always match the active brand
+
+**As** a legal team member, **I want** every page's footer to link to the correct privacy policy and terms of service for the active brand so there is no cross-brand legal liability.
+
+Acceptance criteria:
+1. The footer reads `useBrand().legal.privacyUrl` and `useBrand().legal.termsUrl`.
+2. Both links are rendered as `<a>` elements with the exact URLs defined in the brand config.
+3. When a URL is an empty string, the corresponding link is not rendered.
+
+### US-5: Adopter adds a second brand with no code changes
+
+**As** a template adopter, **I want** to add a new brand by creating a single config file so I can serve multiple brands without forking shared code.
+
+Acceptance criteria:
+1. Creating `packages/ui/src/brands/acme.brand.ts` with a valid `BrandConfig` object is sufficient to register the brand.
+2. The brand becomes resolvable via subdomain (`acme.localhost`) or path prefix (`/acme`) without any other changes.
+3. The `brandConfigSchema` Zod validation rejects the file at startup if any required field is missing, with a descriptive error message identifying the field and the brand slug.
+4. The template's unit tests include a test verifying that the default "enterprise" brand validates against the schema.
+
+### US-6: Brand resolves correctly from subdomain
+
+**As** a platform engineer, **I want** the brand to be automatically selected based on the request subdomain so I can serve multiple brands from one deployment.
+
+Acceptance criteria:
+1. A request to `acme.platform.com` resolves to the brand with `slug: "acme"`.
+2. A request to `platform.com` (no recognized subdomain) falls back to the default brand.
+3. A request to `unknown.platform.com` where `"unknown"` has no matching brand also falls back to the default brand, and a `console.warn` is emitted with the unrecognized slug.
+4. The `BRAND_SLUG` environment variable overrides subdomain resolution when set.
+
+### US-7: Brand resolves correctly from environment variable
+
+**As** a platform engineer, **I want** to force a single brand via environment variable for single-brand deployments so I do not need subdomain configuration.
+
+Acceptance criteria:
+1. Setting `BRAND_SLUG=enterprise` causes all requests to resolve to the "enterprise" brand, regardless of subdomain or path.
+2. Setting `BRAND_SLUG` to an unrecognized slug throws a startup error with a message identifying the invalid slug and listing available slugs.
+3. When `BRAND_SLUG` is not set, resolution falls through to subdomain and then path prefix strategies.
+
+### US-8: Brand feature toggles are accessible in components
+
+**As** a platform engineer, **I want** to define brand-specific boolean feature toggles in the brand config so I can conditionally show UI elements that differ across brands.
+
+Acceptance criteria:
+1. `useBrand().features` returns the record of feature toggles defined in the brand config.
+2. A component can read `brand.features["showPoweredBy"]` and conditionally render a "Powered by Enterprise" badge.
+3. An undefined feature key returns `undefined` (not a thrown error).
+4. Feature toggles in `BrandConfig` are validated as `z.record(z.string(), z.boolean())` — non-boolean values are rejected by the schema.
+
+### US-9: Brand config schema rejects invalid configs at startup
+
+**As** a platform engineer, **I want** invalid brand configs to be caught before the app starts serving traffic so misconfigured brands never reach end users.
+
+Acceptance criteria:
+1. The `resolveBrand()` utility validates all registered brand configs against `brandConfigSchema` at module initialization.
+2. If any brand config fails validation, the process throws with a detailed Zod error including the brand slug and the specific failing field path.
+3. Valid configs pass through without performance impact (validation is build-time or startup-time, not per-request).
+
+---
+
+## Success metrics
+
+- Time for an adopter to add a second brand (target: under 30 minutes, measured from starting to the brand rendering in a local dev environment).
+- Number of hardcoded brand strings found outside `BrandConfig` files after implementation (target: 0 — verified by grep in CI).
+- Percentage of E2E test runs that correctly render brand-specific logo, metadata, and legal links for each registered brand (target: 100%).
+- Zero cross-brand metadata leaks (page of brand A never renders metadata from brand B, verified by E2E assertions on `<title>` and OG tags).
+- Adoption rate by template forks that create more than one brand (tracked via optional telemetry if adopters opt in — not required).
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Subdomain resolution fails in local development where `localhost` has no subdomains | Provide path-prefix resolution as local dev fallback; document the `BRAND_SLUG` env var as the simplest local override |
+| Brand config grows large and complex, making it hard to manage | Keep `BrandConfig` intentionally flat; reject any complex nesting that can live in the theme JSON instead |
+| Adopters bypass `BrandProvider` and hardcode brand strings in components | Lint rule (custom Biome rule or grep in CI) that fails the build if specific string literals appear outside brand config files |
+| `themeRef` points to a non-existent theme file, causing a silent fallback | `resolveBrand()` validates that `themeRef` resolves to an existing theme file at startup; throws if not found |
+| Multiple brands sharing the same slug cause a registry collision | `brandConfigSchema` enforces that slug is unique across all registered files; startup throws on duplicate slugs |
+| Logo images are large and slow down initial page load | Documentation guidance to use SVGs for logos; `BrandLogo` accepts `width`/`height` for explicit sizing; no automatic optimization in MVP |
+| Brand resolution adds latency to every request | Resolution is pure in-memory lookup (no I/O, no DB); performance impact is negligible |
+| Server Component / Client Component boundary breaks brand context | `BrandProvider` is a Server Component that initializes the context; `useBrand()` is a Client hook — documented clearly with a usage example |
+
+---
+
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `brand.config_loaded` | Application startup — brand config files are validated and the registry is built | `{ brandSlugs: string[], defaultBrand: string, resolvedAt: ISO8601 }` |
+| `brand.resolution_fallback` | `resolveBrand()` falls back to the default brand because the requested slug is not recognized | `{ requestedSlug: string, resolvedSlug: string, strategy: "subdomain" \| "path" }` |
+| `brand.config_invalid` | A brand config file fails Zod validation at startup | `{ brandSlug: string, validationErrors: ZodIssue[] }` — process exits after this event |
+
+> **Note**: In MVP, brand config is code-driven. Audit events are application-lifecycle events, not user-action events. They are emitted to the server log (structured JSON) and to the Sentry breadcrumb trail. A future admin UI for runtime brand management would add user-action audit events.
+
+### Sentry
+
+- Area: `brand`
+- Instrumented actions: `resolveBrand()` (wraps the full resolution pipeline), `BrandProvider` initialization, `useBrand()` hook (when thrown outside provider)
+- Captured errors: invalid brand config at startup, missing `themeRef` target, unrecognized brand slug when fallback is disabled, `useBrand()` called outside `BrandProvider`
+- PII exclusions: no user PII is associated with brand config; `requestedSlug` from subdomain/path is not user PII and is safe to capture
+- Allowed metadata: `brandSlug`, `themeRef`, `resolvedStrategy` (`"env"` | `"subdomain"` | `"path"` | `"default"`), `availableSlugs`, `errorCode`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Brand config | `valid` | `enterprise.brand.ts` — default brand; `slug: "enterprise"`, `themeRef: "light"`, logo uses placeholder SVG, legal URLs point to `#` (to be replaced by adopter) |
+| Brand config | `example` | `acme.brand.ts` — second brand included as a commented-out example file; demonstrates adding a brand with a different `themeRef: "acme-light"` and distinct logo paths |
+| Theme JSON | `valid` | `packages/ui/src/themes/light.json` and `dark.json` — already exists; referenced by `enterprise` brand |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|-----------------|
+| Default brand renders on root request | Anonymous user | Page title matches `enterprise.metadata.titleTemplate`, favicon matches `enterprise.favicon`, footer shows `enterprise.legal.privacyUrl` and `enterprise.legal.termsUrl` |
+| Logo switches when theme mode is toggled | Authenticated user | Clicking the theme toggle causes `BrandLogo` to render `logo.dark.src` in dark mode and `logo.light.src` in light mode |
+| Path-prefix brand resolution | Anonymous user | Navigating to `/acme/dashboard` (with acme brand registered) renders Acme `displayName` in the header logo alt text |
+| BRAND_SLUG env var forces single brand | System | Setting `BRAND_SLUG=enterprise` in `.env.test` causes all requests (including to `acme.*` subdomains) to render the enterprise brand |
+| Invalid brand slug falls back gracefully | Anonymous user | Navigating with an unknown subdomain or path prefix renders the default brand with no error page |
+| Missing logo src renders text fallback | Anonymous user | When `logo.light.src` is empty string, `BrandLogo` renders the `displayName` as a text node instead of a broken `<img>` |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Brand config source | Static file system — `packages/ui/src/brands/*.brand.ts` | In-process module imports; no network call | Same — static imports bundled at build time | `BRAND_SLUG` (optional override) |
+| Logo assets | Static file reference (`src` field in `BrandConfig`) | Local path (e.g., `/images/logo-light.svg` served by Next.js) | CDN URL or Vercel-served static asset | No env var — path is in the brand config file |
+
+### Production readiness
+
+- [ ] `brandConfigSchema` unit tests cover all required fields, optional fields, and invalid cases (wrong types, empty slug, malformed URL)
+- [ ] `resolveBrand()` unit tests cover: `BRAND_SLUG` override, subdomain match, path-prefix match, fallback to default, and unknown-slug warning
+- [ ] `BrandProvider` + `useBrand()` integration test verifies context availability and throws correctly outside provider
+- [ ] `BrandLogo` unit test verifies light/dark variant switching and text fallback when src is empty
+- [ ] E2E tests pass for all defined flows
+- [ ] `enterprise.brand.ts` validates against `brandConfigSchema` in CI (schema snapshot test)
+- [ ] No hardcoded brand strings outside `*.brand.ts` files (enforced by CI grep step)
+- [ ] `BRAND_SLUG` environment variable documented in `.env.example` with a comment explaining the resolution strategy
+- [ ] `packages/ui/src/brands/` directory documented in `packages/ui/AGENTS.md` with the pattern for adding new brands
+- [ ] `BrandProvider` wrapping order documented: `BrandProvider` → `ThemeProvider` (internal) → app children
+- [ ] Startup validation logs are structured JSON and captured by the observability pipeline
+- [ ] Sentry area `brand` registered; `resolveBrand()` and `BrandProvider` instrumented
+- [ ] `brand.config_loaded` audit event visible in server logs on clean startup with the default brand
+- [ ] Logo asset paths use absolute `/public/` paths or full CDN URLs — no relative paths
+- [ ] `BrandConfig.legal.privacyUrl` and `termsUrl` placeholder values are replaced in `enterprise.brand.ts` before go-live (checked by adopter onboarding guide)
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Where does brand config live — DB or code? | Static config files (`*.brand.ts`) in MVP | Brand identity changes are infrequent and require design review; code-driven config gets git history, PR review, and type safety for free. DB-driven config is a follow-up for runtime admin management. |
+| One package or new `@enterprise/brand`? | Brand provider and resolver live in `@enterprise/ui`; schema lives in `@enterprise/contracts` | Avoids a new package for MVP. `@enterprise/ui` already owns `ThemeProvider` and the design token layer — `BrandProvider` is a natural neighbor. If the brand API grows significantly, extracting to `@enterprise/brand` is a clean future step. |
+| How does brand select a theme? | `themeRef` string field that names a theme JSON file | Decouples brand identity from theme tokens. A brand does not embed token values; it declares which token set to use. Adopters can share themes across brands or create brand-specific themes independently. |
+| Resolution priority order? | Env var → subdomain → path prefix → default | Env var is the simplest override (single-brand deploys). Subdomain is the canonical multi-brand pattern (one domain per brand). Path prefix is the local dev fallback. Default brand prevents hard failures. |
+| Should `BrandProvider` be a Server Component? | Yes — it receives a pre-resolved `BrandConfig` from the server boundary | Brand resolution must happen at the server boundary to avoid client-side flickering. `BrandProvider` itself uses React context, which requires a Client Component context object, but the resolution and prop-passing happen server-side. |
+| Are brand feature toggles in `BrandConfig` or in the feature flags system? | Both are valid; brand-scoped toggles live in `BrandConfig.features` for brand-specific UI differences | Feature flags (the feature-flags system) control rollout and experimentation across tenants. Brand toggles in `BrandConfig` control structural UI differences between brands (e.g., whether a brand shows a "Powered by" badge). They serve different purposes. |
+| Should unknown slugs throw or fall back? | Fall back to default brand + emit a warning | Throwing on an unknown slug would break the app for misconfigured subdomains (e.g., CDN health check subdomains). Silent fallback with a warning allows the app to continue serving and gives operators the signal they need. |
+| Is `BrandConfig` validated per-request or at startup? | At startup (module initialization) | Per-request validation would add latency and repeated Zod overhead. Brand configs are static; validating once at startup is sufficient and produces a fast fail with a clear error message. |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/brand-abstraction-layer/rfc.md
+++ b/docs/features/brand-abstraction-layer/rfc.md
@@ -1,0 +1,1033 @@
+---
+title: "Brand abstraction layer RFC"
+description: "Defines the implementation-ready technical architecture for a provider-agnostic brand abstraction layer that lets the Enterprise Platform template host multiple visual identities from a single codebase."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Brand abstraction layer RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for a brand abstraction layer that sits above the existing theme system, aligned with the service layer, contracts, and traceability conventions of the Enterprise Platform. The brand layer owns everything that makes a visual identity distinct beyond design tokens: name, logo, favicon, Open Graph metadata, legal links, social links, and brand-scoped feature toggles. The theme system remains the authoritative source of design tokens; the brand layer selects which token set to apply.
+
+## Scope
+
+- Included: `brandConfigSchema` Zod schema in `@enterprise/contracts`, `BrandConfig` TypeScript types, brand config files in `packages/ui/src/brands/`, `BrandProvider` React context, `useBrand()` hook, brand resolution strategy (`resolveBrand()` utility), `BrandLogo` component, `BrandMeta` server-side metadata helper, `BrandFooter` component, brand registry with startup validation, integration with the existing `ThemeProvider`, a default `enterprise.brand.ts` config, an example `acme.brand.ts` commented-out file, audit events at startup, Sentry instrumentation for the `brand` area, and E2E coverage for brand rendering.
+- Excluded: runtime brand switching per authenticated user session, admin UI for editing brand configs without a code deploy, database-driven brand config storage, per-tenant brand assignment, brand-level A/B experimentation, brand inheritance or partial override from a parent brand, automated asset optimization or CDN upload, brand-specific routing namespaces or sitemaps, and visual brand editor tooling.
+
+---
+
+## Summary
+
+Implement the brand abstraction layer as a purely static, code-driven module living in `@enterprise/ui`. Brand identity is declared in TypeScript config files (`*.brand.ts`) that are validated against a `brandConfigSchema` Zod schema defined in `@enterprise/contracts`. At application startup, a brand registry loads all configs, validates them, and exposes a `resolveBrand(request?)` utility that determines which brand to render per request using a priority chain: `BRAND_SLUG` environment variable → subdomain extraction → path prefix → default brand. The resolved `BrandConfig` is passed as a prop to `BrandProvider`, which is a React Server Component wrapper that seeds `BrandContext` and internally renders the existing `ThemeProvider` with the `themeRef` value from the config. Client components consume brand context through the `useBrand()` hook. The template ships with exactly one functional brand (`"enterprise"`) so adopters have a working starting point; adding a second brand requires only a new config file.
+
+## Technical objectives
+
+- `brandConfigSchema` in `@enterprise/contracts` is the single source of truth for what a brand is — all fields typed, all constraints enforced at startup.
+- Brand resolution is pure in-memory lookup with no I/O, no database calls, and no per-request overhead beyond a map lookup.
+- The `BrandProvider` / `useBrand()` boundary is explicit and safe: calling `useBrand()` outside a provider throws a descriptive error with guidance.
+- Theme integration is declarative: `BrandProvider` passes `themeRef` to `ThemeProvider`; no brand-specific CSS is written manually.
+- Adding a second brand requires creating one `*.brand.ts` file — zero changes to shared code.
+- Invalid brand configs are caught at startup with a Zod error that identifies the brand slug and the failing field path, before any request is served.
+- All brand-related instrumentation (startup audit, resolution fallback, provider throw) is captured by Sentry under the `brand` area.
+- The `BRAND_SLUG` environment variable allows single-brand deployments without any subdomain or path configuration.
+
+---
+
+## Data model
+
+The brand abstraction layer does not own a database table. Brand configuration is static — committed TypeScript files. There is no Drizzle schema for this feature in MVP. The persistence layer is the git repository itself.
+
+### Brand config registry (runtime, in-memory)
+
+At module initialization, `packages/ui/src/brand/registry.ts` imports all `*.brand.ts` files from `packages/ui/src/brands/`, validates each against `brandConfigSchema`, checks for duplicate slugs, and exposes an immutable `Map<string, BrandConfig>` keyed by slug.
+
+```typescript
+// packages/ui/src/brand/registry.ts
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { brandConfigSchema } from "@enterprise/contracts";
+
+// Static import of all brand config modules
+// Build tools (Next.js + Webpack) resolve this at bundle time
+import * as brandModules from "./brands/index";
+
+function buildRegistry(): Map<string, BrandConfig> {
+  const registry = new Map<string, BrandConfig>();
+
+  for (const [moduleName, mod] of Object.entries(brandModules)) {
+    const raw = (mod as { default?: unknown }).default ?? mod;
+    const result = brandConfigSchema.safeParse(raw);
+
+    if (!result.success) {
+      throw new Error(
+        `[brand] Invalid brand config in module "${moduleName}":\n${result.error.toString()}`,
+      );
+    }
+
+    const config = result.data;
+
+    if (registry.has(config.slug)) {
+      throw new Error(
+        `[brand] Duplicate brand slug "${config.slug}" detected. ` +
+          `Each brand must have a unique slug.`,
+      );
+    }
+
+    registry.set(config.slug, config);
+  }
+
+  return registry;
+}
+
+export const brandRegistry: Map<string, BrandConfig> = buildRegistry();
+
+export function getDefaultBrand(): BrandConfig {
+  for (const brand of brandRegistry.values()) {
+    if (brand.isDefault) return brand;
+  }
+  // Fallback: return the "enterprise" brand if no isDefault is declared
+  const enterprise = brandRegistry.get("enterprise");
+  if (!enterprise) {
+    throw new Error(
+      '[brand] No default brand found and no "enterprise" brand registered. ' +
+        "Ensure at least one brand config exists in packages/ui/src/brands/.",
+    );
+  }
+  return enterprise;
+}
+```
+
+### Indexes
+
+Not applicable — in-memory `Map` keyed by slug. O(1) lookup per request.
+
+### Constraints
+
+- Slug uniqueness is enforced at registry initialization. Duplicate slugs throw before the process serves any request.
+- All registered brand configs are validated against `brandConfigSchema`. A single invalid config prevents startup.
+- `themeRef` is validated to resolve against an existing theme JSON file at startup (see the resolution section).
+
+### Type exports
+
+```typescript
+// Inferred from brandConfigSchema in @enterprise/contracts
+export type BrandConfig = z.infer<typeof brandConfigSchema>;
+export type BrandLogoVariant = z.infer<typeof brandLogoVariantSchema>;
+export type BrandLogo = z.infer<typeof brandLogoSchema>;
+export type BrandMetadata = z.infer<typeof brandMetadataSchema>;
+export type BrandLegal = z.infer<typeof brandLegalSchema>;
+export type BrandSocial = z.infer<typeof brandSocialSchema>;
+```
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/schemas/brand.ts`
+
+### Schemas (Zod)
+
+```typescript
+import { z } from "zod";
+
+// ============================================================================
+// Logo variant — a single light or dark logo asset
+// ============================================================================
+
+export const brandLogoVariantSchema = z.object({
+  /** Absolute path or full CDN URL for the logo image. Empty string triggers text fallback. */
+  src: z.string(),
+  /** Alt text for the <img> element — required for accessibility. */
+  alt: z.string().min(1, "Logo alt text must not be empty"),
+  /** Optional explicit width in pixels. Used to prevent layout shift. */
+  width: z.number().int().positive().optional(),
+  /** Optional explicit height in pixels. */
+  height: z.number().int().positive().optional(),
+});
+
+// ============================================================================
+// Logo — light + dark variants
+// ============================================================================
+
+export const brandLogoSchema = z.object({
+  light: brandLogoVariantSchema,
+  dark: brandLogoVariantSchema,
+});
+
+// ============================================================================
+// Metadata — Open Graph and page title configuration
+// ============================================================================
+
+export const brandMetadataSchema = z.object({
+  /**
+   * Next.js title template. Use "%s" as the placeholder for the page title.
+   * Example: "%s | Acme Platform"
+   */
+  titleTemplate: z.string().min(1),
+  /**
+   * Default page title used when no per-page title is set.
+   * Also used for the home page <title> tag.
+   */
+  defaultTitle: z.string().min(1),
+  /**
+   * Default meta description. Used as og:description when no page-level
+   * description is provided.
+   */
+  description: z.string().min(1),
+  /**
+   * Absolute path or full URL for the Open Graph image.
+   * Used as og:image on all pages unless overridden per-page.
+   */
+  ogImage: z.string(),
+});
+
+// ============================================================================
+// Legal — privacy policy and terms of service URLs
+// ============================================================================
+
+export const brandLegalSchema = z.object({
+  /** Full URL to the privacy policy page. Empty string suppresses the link. */
+  privacyUrl: z.string(),
+  /** Full URL to the terms of service page. Empty string suppresses the link. */
+  termsUrl: z.string(),
+});
+
+// ============================================================================
+// Social links — optional external profile URLs
+// ============================================================================
+
+export const brandSocialSchema = z.object({
+  /** Twitter / X profile URL */
+  twitter: z.string().url().optional(),
+  /** LinkedIn company page URL */
+  linkedin: z.string().url().optional(),
+  /** GitHub organization or user profile URL */
+  github: z.string().url().optional(),
+});
+
+// ============================================================================
+// BrandConfig — top-level schema
+// ============================================================================
+
+export const brandConfigSchema = z.object({
+  /**
+   * URL-safe unique identifier. Must be lowercase, alphanumeric with hyphens.
+   * Used for subdomain matching, path prefix matching, and the BRAND_SLUG env var.
+   * Example: "enterprise", "acme", "acme-eu"
+   */
+  slug: z
+    .string()
+    .min(1)
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      "Slug must be lowercase alphanumeric with optional hyphens (e.g. \"acme-eu\")",
+    ),
+
+  /**
+   * Internal identifier used in audit events, Sentry tags, and log output.
+   * Human-readable but not shown to end users.
+   */
+  name: z.string().min(1),
+
+  /**
+   * Human-readable brand name shown in UI headings, footers, and browser tabs.
+   * Example: "Acme Platform", "Enterprise"
+   */
+  displayName: z.string().min(1),
+
+  /**
+   * Short description of the brand. Used in internal docs and meta tags
+   * when no page-level description is provided.
+   */
+  description: z.string().min(1),
+
+  /** Light and dark logo variants. */
+  logo: brandLogoSchema,
+
+  /**
+   * Path or URL to the favicon asset.
+   * Recommended: SVG or 32×32 ICO. Example: "/images/enterprise/favicon.svg"
+   */
+  favicon: z.string().min(1),
+
+  /** Open Graph and page title configuration. */
+  metadata: brandMetadataSchema,
+
+  /** Legal link URLs for privacy policy and terms of service. */
+  legal: brandLegalSchema,
+
+  /** Optional external social profile links. */
+  social: brandSocialSchema.optional(),
+
+  /**
+   * Key that references which theme JSON file to apply.
+   * Must match the "metadata.name" field of a theme JSON in packages/ui/src/themes/.
+   * Examples: "light", "dark", "acme-light"
+   * The brand layer does not embed token values — it declares which token set to use.
+   */
+  themeRef: z.string().min(1),
+
+  /**
+   * Optional brand-scoped feature toggles.
+   * Keys are feature names; values are boolean flags.
+   * Example: { "showPoweredBy": true, "enablePublicApi": false }
+   * These control structural UI differences between brands — not rollout/experimentation,
+   * which belongs to the feature-flags system.
+   */
+  features: z.record(z.string(), z.boolean()).optional(),
+
+  /**
+   * When true, this brand is returned as the fallback when no slug matches.
+   * At most one brand in the registry should set this to true.
+   * If no brand has isDefault=true, the "enterprise" slug is used as the default.
+   */
+  isDefault: z.boolean().optional(),
+});
+```
+
+### Type exports
+
+```typescript
+// packages/contracts/src/schemas/brand.ts — colocated type exports
+
+export type BrandConfig = z.infer<typeof brandConfigSchema>;
+export type BrandLogoVariant = z.infer<typeof brandLogoVariantSchema>;
+export type BrandLogo = z.infer<typeof brandLogoSchema>;
+export type BrandMetadata = z.infer<typeof brandMetadataSchema>;
+export type BrandLegal = z.infer<typeof brandLegalSchema>;
+export type BrandSocial = z.infer<typeof brandSocialSchema>;
+```
+
+Export from the contracts barrel (`packages/contracts/src/index.ts`):
+
+```typescript
+// Brand system — schemas and types
+export {
+  brandConfigSchema,
+  brandLegalSchema,
+  brandLogoSchema,
+  brandLogoVariantSchema,
+  brandMetadataSchema,
+  brandSocialSchema,
+} from "./schemas/brand";
+
+export type {
+  BrandConfig,
+  BrandLegal,
+  BrandLogo,
+  BrandLogoVariant,
+  BrandMetadata,
+  BrandSocial,
+} from "./schemas/brand";
+```
+
+---
+
+## Service layer
+
+The brand abstraction layer does not define a service in `@enterprise/core`. There is no business logic, no database I/O, and no mutation pathway. The resolution logic is a pure utility (`resolveBrand`) that lives in `@enterprise/ui/src/brand/resolve.ts` and is called directly from the Next.js root layout server component.
+
+If future iterations introduce database-driven brand config (runtime admin management), a `brand-service.ts` in `@enterprise/core` would be the correct home for that logic. The registry and resolution utilities would then become adapters consumed by the service.
+
+---
+
+## Server Actions
+
+No Server Actions are defined for this feature in MVP. Brand configuration is code-driven (committed files). There are no mutations exposed to the UI. All interaction with brand config is read-only via `useBrand()` on the client and `resolveBrand()` on the server.
+
+---
+
+## UI routes and components
+
+### Routes
+
+The brand abstraction layer has no dedicated route in MVP. It is infrastructure that affects every rendered page. The brand layer does not add any entry to `ui/lib/routes.ts`.
+
+### Components
+
+| Component | Location | Exported from | Purpose |
+|-----------|----------|---------------|---------|
+| `BrandProvider` | `packages/ui/src/brand/provider.tsx` | `@enterprise/ui/brand/provider` | Root wrapper that seeds `BrandContext` and renders `ThemeProvider` with `themeRef` |
+| `BrandContext` | `packages/ui/src/brand/context.ts` | `@enterprise/ui/brand/context` | React context object for brand config |
+| `useBrand()` | `packages/ui/src/brand/provider.tsx` | `@enterprise/ui/brand/provider` | Client hook to read `BrandConfig` from context |
+| `BrandLogo` | `packages/ui/src/brand/brand-logo.tsx` | `@enterprise/ui/brand/brand-logo` | Renders the correct logo variant for the active theme mode |
+| `BrandFooter` | `packages/ui/src/brand/brand-footer.tsx` | `@enterprise/ui/brand/brand-footer` | Renders `displayName`, legal links, and social icon links |
+
+### Feature module structure (file tree)
+
+```
+packages/ui/src/brand/
+├── context.ts                    # BrandContext — React context object and type
+├── provider.tsx                  # BrandProvider + useBrand()
+├── resolve.ts                    # resolveBrand() — server-side brand resolution utility
+├── registry.ts                   # buildRegistry() — loads and validates all *.brand.ts files
+├── brand-logo.tsx                # BrandLogo — light/dark logo switcher
+├── brand-footer.tsx              # BrandFooter — legal links and social icons
+├── brand-meta.ts                 # generateBrandMetadata() — Next.js Metadata helper
+└── __tests__/
+    ├── resolve.test.ts           # Unit tests for resolveBrand()
+    ├── registry.test.ts          # Unit tests for buildRegistry() and validation
+    └── brand-logo.test.tsx       # Unit tests for BrandLogo component
+
+packages/ui/src/brands/
+├── index.ts                      # Re-exports all brand configs for registry consumption
+├── enterprise.brand.ts           # Default brand — required, ships with the template
+└── acme.brand.ts                 # Example second brand — commented out; adopter reference
+```
+
+### App routes (file tree)
+
+```
+ui/app/
+└── layout.tsx                    # Root layout — calls resolveBrand(), wraps with BrandProvider
+```
+
+No new page or route files are added. The root layout is modified to call `resolveBrand()` and wrap its children with `BrandProvider`.
+
+---
+
+## Package structure
+
+Brand functionality lives entirely within `@enterprise/ui`. No new package is created in MVP. The rationale: `@enterprise/ui` already owns `ThemeProvider` and the design token pipeline — `BrandProvider` is a natural neighbor. If the brand API grows significantly in future iterations (e.g., database-driven admin, brand-level analytics, per-tenant assignment), extracting to an `@enterprise/brand` package is a clean follow-up step that the dependency direction already permits.
+
+### Full brand directory within `@enterprise/ui`
+
+```
+packages/ui/
+├── src/
+│   ├── brand/                            # Brand abstraction layer
+│   │   ├── context.ts
+│   │   ├── provider.tsx
+│   │   ├── resolve.ts
+│   │   ├── registry.ts
+│   │   ├── brand-logo.tsx
+│   │   ├── brand-footer.tsx
+│   │   ├── brand-meta.ts
+│   │   └── __tests__/
+│   ├── brands/                           # Brand config files
+│   │   ├── index.ts
+│   │   ├── enterprise.brand.ts
+│   │   └── acme.brand.ts                 # (commented-out example)
+│   ├── theme/                            # Existing theme system (unchanged)
+│   │   ├── provider.tsx
+│   │   ├── context.ts
+│   │   └── ...
+│   └── themes/                           # Theme JSON sources (existing)
+│       ├── light.json
+│       └── dark.json
+```
+
+### Subpath exports (`packages/ui/package.json`)
+
+```json
+{
+  "exports": {
+    "./brand/provider": "./src/brand/provider.tsx",
+    "./brand/context": "./src/brand/context.ts",
+    "./brand/brand-logo": "./src/brand/brand-logo.tsx",
+    "./brand/brand-footer": "./src/brand/brand-footer.tsx",
+    "./brand/brand-meta": "./src/brand/brand-meta.ts",
+    "./brand/resolve": "./src/brand/resolve.ts"
+  }
+}
+```
+
+Client Components that call `useBrand()` import from `@enterprise/ui/brand/provider`. Server utilities import from `@enterprise/ui/brand/resolve`. The barrel (`@enterprise/ui`) also re-exports the brand symbols:
+
+```typescript
+// packages/ui/src/index.ts — additions
+export type { BrandConfig } from "@enterprise/contracts";
+export { BrandContext } from "./brand/context";
+export type { BrandContextValue } from "./brand/context";
+export { BrandFooter } from "./brand/brand-footer";
+export { BrandLogo } from "./brand/brand-logo";
+export { BrandProvider, useBrand } from "./brand/provider";
+```
+
+---
+
+## Integration with theme system
+
+The brand layer selects a theme; the theme system applies it. This separation is enforced by a single-direction dependency: `BrandProvider` reads `themeRef` from `BrandConfig` and passes it as the `defaultMode` — or more precisely, as a theme name — to `ThemeProvider`.
+
+### How `BrandProvider` connects to `ThemeProvider`
+
+```typescript
+// packages/ui/src/brand/provider.tsx
+
+"use client";
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { createContext, useContext } from "react";
+import { ThemeProvider } from "../theme/provider";
+
+export interface BrandContextValue {
+  brand: BrandConfig;
+}
+
+export const BrandContext = createContext<BrandContextValue | null>(null);
+
+export interface BrandProviderProps {
+  children: React.ReactNode;
+  /**
+   * The resolved BrandConfig — provided by the server boundary (root layout).
+   * BrandProvider does NOT resolve the brand; resolution happens in resolveBrand().
+   */
+  brand: BrandConfig;
+  /**
+   * Initial theme mode before localStorage hydration.
+   * Derived from the brand's themeRef: "light" or "dark" suffix.
+   * Falls back to "dark" if themeRef does not end in "light".
+   */
+  defaultMode?: "light" | "dark";
+}
+
+export function BrandProvider({ children, brand, defaultMode }: BrandProviderProps) {
+  // Derive initial theme mode from themeRef if not explicitly provided
+  const resolvedDefaultMode: "light" | "dark" =
+    defaultMode ?? (brand.themeRef.endsWith("light") ? "light" : "dark");
+
+  return (
+    <BrandContext value={{ brand }}>
+      <ThemeProvider defaultMode={resolvedDefaultMode}>{children}</ThemeProvider>
+    </BrandContext>
+  );
+}
+
+export function useBrand(): BrandConfig {
+  const ctx = useContext(BrandContext);
+  if (ctx === null) {
+    throw new Error(
+      "useBrand() must be called inside a <BrandProvider>. " +
+        "Ensure the root layout wraps its children with <BrandProvider brand={...}>.",
+    );
+  }
+  return ctx.brand;
+}
+```
+
+### Wrapping order in root layout
+
+```tsx
+// ui/app/layout.tsx (relevant portion)
+import { BrandProvider } from "@enterprise/ui/brand/provider";
+import { resolveBrand } from "@enterprise/ui/brand/resolve";
+import { generateBrandMetadata } from "@enterprise/ui/brand/brand-meta";
+
+export async function generateMetadata() {
+  const brand = await resolveBrand();
+  return generateBrandMetadata(brand);
+}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const brand = await resolveBrand();
+
+  return (
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <body>
+        {/* BrandProvider wraps ThemeProvider internally */}
+        <BrandProvider brand={brand}>
+          {children}
+        </BrandProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### Custom theme per brand
+
+Brands that share the default platform theme point `themeRef` to `"light"` or `"dark"`. Brands that need a distinct visual identity create a new theme JSON file in `packages/ui/src/themes/` and reference it by its `metadata.name` value. The existing theme build pipeline (`pnpm build:theme`) generates CSS and TypeScript tokens from all theme JSONs in that directory.
+
+Example for a brand with a custom theme:
+
+1. Create `packages/ui/src/themes/acme-light.json` with custom color primitives and semantics.
+2. Set `"metadata": { "name": "acme-light", "mode": "light", ... }` in the JSON.
+3. Run `pnpm --filter @enterprise/ui build:theme` to regenerate `theme-generated.css` with the new `[data-theme="acme-light"]` selector block.
+4. Set `themeRef: "acme-light"` in `acme.brand.ts`.
+
+The `ThemeProvider` already handles `setMode()` — for brand-specific themes with a `"light"` default mode, the theme toggle would switch to the platform `"dark"` theme unless a corresponding `acme-dark.json` is also created and the toggle logic is extended per brand. In MVP, brands that use custom themes are expected to provide both light and dark variants if they want theme toggling to remain brand-consistent. This is documented in `packages/ui/AGENTS.md`.
+
+---
+
+## Brand resolution strategy
+
+`resolveBrand()` is a server-side async utility. It reads environment variables, inspects the Next.js `headers()` object for the hostname and path, and performs a pure in-memory lookup against the brand registry.
+
+### Resolution algorithm
+
+```
+Priority 1 — BRAND_SLUG env var
+  if process.env.BRAND_SLUG is set:
+    look up slug in registry
+    if found → return brand config
+    if not found → throw Error with slug and list of available slugs (startup-time fail)
+
+Priority 2 — Subdomain matching
+  read Host header from request
+  extract first subdomain segment (hostname.split(".")[0])
+  if segment exists in registry → return brand config
+  emit console.warn("[brand] Unrecognized subdomain slug: {slug}. Falling back to default brand.")
+
+Priority 3 — Path prefix matching
+  read pathname from URL (Next.js headers() or Request.url)
+  extract first path segment (pathname.split("/")[1])
+  if segment exists in registry → return brand config
+  emit console.warn("[brand] Unrecognized path prefix slug: {slug}. Falling back to default brand.")
+
+Priority 4 — Default brand
+  call getDefaultBrand() from registry
+  return the brand with isDefault=true, or "enterprise" if none declared
+```
+
+### Implementation
+
+```typescript
+// packages/ui/src/brand/resolve.ts
+
+import { headers } from "next/headers";
+import type { BrandConfig } from "@enterprise/contracts";
+import { brandRegistry, getDefaultBrand } from "./registry";
+
+export async function resolveBrand(): Promise<BrandConfig> {
+  // Priority 1: BRAND_SLUG environment variable
+  const envSlug = process.env["BRAND_SLUG"];
+  if (envSlug) {
+    const brand = brandRegistry.get(envSlug);
+    if (!brand) {
+      const available = Array.from(brandRegistry.keys()).join(", ");
+      throw new Error(
+        `[brand] BRAND_SLUG="${envSlug}" does not match any registered brand. ` +
+          `Available slugs: ${available}`,
+      );
+    }
+    return brand;
+  }
+
+  const headerList = await headers();
+  const host = headerList.get("host") ?? "";
+  const pathname = headerList.get("x-invoke-path") ?? "/";
+
+  // Priority 2: Subdomain matching
+  // Strip port from host, split by ".", take first segment
+  const hostWithoutPort = host.split(":")[0] ?? "";
+  const subdomainSegments = hostWithoutPort.split(".");
+  if (subdomainSegments.length > 2) {
+    const subdomainSlug = subdomainSegments[0] ?? "";
+    const brand = brandRegistry.get(subdomainSlug);
+    if (brand) return brand;
+    console.warn(
+      `[brand] Unrecognized subdomain slug: "${subdomainSlug}". Falling back to default brand.`,
+    );
+  }
+
+  // Priority 3: Path prefix matching
+  const firstPathSegment = pathname.split("/")[1] ?? "";
+  if (firstPathSegment) {
+    const brand = brandRegistry.get(firstPathSegment);
+    if (brand) return brand;
+    // Only warn if the segment looks like an intentional brand slug (no dots, no file extension)
+    if (!firstPathSegment.includes(".")) {
+      console.warn(
+        `[brand] Path prefix "${firstPathSegment}" did not match any brand slug. ` +
+          `Falling back to default brand.`,
+      );
+    }
+  }
+
+  // Priority 4: Default brand
+  return getDefaultBrand();
+}
+```
+
+### Resolution strategy per environment
+
+| Environment | Recommended approach | Example |
+|-------------|---------------------|---------|
+| Local development (single brand) | Set `BRAND_SLUG=enterprise` in `.env.local` | Simplest — no subdomain config needed |
+| Local development (multi-brand) | Use path prefix: `/acme/dashboard` | Subdomains require hosts file edits; path prefix requires no system config |
+| Staging (single brand) | Set `BRAND_SLUG` in deployment env vars | Forces the brand regardless of subdomain |
+| Production (multi-brand) | Wildcard subdomain DNS (`*.platform.com`) + no `BRAND_SLUG` | Canonical multi-brand production setup |
+| Vercel preview deployments | Set `BRAND_SLUG` per deployment or use path prefix | Avoids needing per-preview DNS wildcard |
+
+### Localhost subdomain alternative
+
+For local multi-brand development without editing `/etc/hosts`, developers can use path prefix resolution. The `BRAND_SLUG` env var is the simplest override for local single-brand work. Documentation in `packages/ui/AGENTS.md` covers both approaches with examples.
+
+---
+
+## Default brand config
+
+```typescript
+// packages/ui/src/brands/enterprise.brand.ts
+
+import type { BrandConfig } from "@enterprise/contracts";
+
+const enterpriseBrand: BrandConfig = {
+  slug: "enterprise",
+  name: "enterprise",
+  displayName: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  logo: {
+    light: {
+      src: "/images/enterprise/logo-light.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+    dark: {
+      src: "/images/enterprise/logo-dark.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+  },
+  favicon: "/images/enterprise/favicon.svg",
+  metadata: {
+    titleTemplate: "%s | Enterprise Platform",
+    defaultTitle: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template for modern teams.",
+    ogImage: "/images/enterprise/og-image.png",
+  },
+  legal: {
+    // Replace these placeholder URLs with your actual legal pages before go-live
+    privacyUrl: "#",
+    termsUrl: "#",
+  },
+  social: {
+    github: "https://github.com/your-org",
+  },
+  themeRef: "light",
+  features: {
+    showPoweredBy: true,
+  },
+  isDefault: true,
+};
+
+export default enterpriseBrand;
+```
+
+---
+
+## BrandLogo component
+
+```typescript
+// packages/ui/src/brand/brand-logo.tsx
+
+"use client";
+
+import { useBrand } from "./provider";
+import { useTheme } from "../theme/provider";
+
+export interface BrandLogoProps {
+  className?: string;
+}
+
+export function BrandLogo({ className }: BrandLogoProps) {
+  const brand = useBrand();
+  const { mode } = useTheme();
+
+  const logoVariant = mode === "light" ? brand.logo.light : brand.logo.dark;
+
+  // Text fallback when src is empty or undefined
+  if (!logoVariant.src) {
+    return (
+      <span className={className} aria-label={logoVariant.alt}>
+        {brand.displayName}
+      </span>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={logoVariant.src}
+      alt={logoVariant.alt}
+      width={logoVariant.width}
+      height={logoVariant.height}
+      className={className}
+    />
+  );
+}
+```
+
+---
+
+## BrandMeta server helper
+
+```typescript
+// packages/ui/src/brand/brand-meta.ts
+
+import type { Metadata } from "next";
+import type { BrandConfig } from "@enterprise/contracts";
+
+/**
+ * Generates a Next.js Metadata object from a resolved BrandConfig.
+ * Call this from generateMetadata() in ui/app/layout.tsx.
+ *
+ * @example
+ * export async function generateMetadata() {
+ *   const brand = await resolveBrand();
+ *   return generateBrandMetadata(brand);
+ * }
+ */
+export function generateBrandMetadata(brand: BrandConfig): Metadata {
+  return {
+    title: {
+      template: brand.metadata.titleTemplate,
+      default: brand.metadata.defaultTitle,
+    },
+    description: brand.metadata.description,
+    icons: {
+      icon: brand.favicon,
+    },
+    openGraph: {
+      title: brand.metadata.defaultTitle,
+      description: brand.metadata.description,
+      images: brand.metadata.ogImage ? [brand.metadata.ogImage] : [],
+    },
+  };
+}
+```
+
+---
+
+## BrandFooter component
+
+```typescript
+// packages/ui/src/brand/brand-footer.tsx
+
+"use client";
+
+import { useBrand } from "./provider";
+
+export interface BrandFooterProps {
+  className?: string;
+}
+
+export function BrandFooter({ className }: BrandFooterProps) {
+  const brand = useBrand();
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={className}>
+      <p>
+        © {currentYear} {brand.displayName}
+      </p>
+
+      <nav aria-label="Legal links">
+        {brand.legal.privacyUrl && (
+          <a href={brand.legal.privacyUrl} rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+        )}
+        {brand.legal.termsUrl && (
+          <a href={brand.legal.termsUrl} rel="noopener noreferrer">
+            Terms of Service
+          </a>
+        )}
+      </nav>
+
+      {brand.social && (
+        <nav aria-label="Social links">
+          {brand.social.twitter && (
+            <a href={brand.social.twitter} rel="noopener noreferrer" aria-label="Twitter">
+              Twitter
+            </a>
+          )}
+          {brand.social.linkedin && (
+            <a href={brand.social.linkedin} rel="noopener noreferrer" aria-label="LinkedIn">
+              LinkedIn
+            </a>
+          )}
+          {brand.social.github && (
+            <a href={brand.social.github} rel="noopener noreferrer" aria-label="GitHub">
+              GitHub
+            </a>
+          )}
+        </nav>
+      )}
+
+      {brand.features?.["showPoweredBy"] && (
+        <p>
+          <small>Powered by Enterprise Platform</small>
+        </p>
+      )}
+    </footer>
+  );
+}
+```
+
+---
+
+## Build pipeline
+
+The brand abstraction layer has no standalone build pipeline. Brand configs are TypeScript files — they are type-checked by the existing `pnpm typecheck` step. The `brandConfigSchema` validation runs at module initialization (when the registry is first imported), which happens at Next.js server startup and during E2E test runs.
+
+The existing theme build pipeline (`pnpm --filter @enterprise/ui build:theme`) handles custom theme JSON files when adopters create brand-specific themes. No new Turborepo tasks are required for the brand layer itself.
+
+### Startup validation sequence
+
+```
+Next.js server starts
+  │
+  ├─ Imports root layout (ui/app/layout.tsx)
+  │     └─ imports resolveBrand from @enterprise/ui/brand/resolve
+  │           └─ imports brandRegistry from ./registry
+  │                 └─ imports all *.brand.ts via brands/index.ts
+  │                       ├─ brandConfigSchema.safeParse() for each config
+  │                       ├─ Duplicate slug check
+  │                       └─ themeRef existence check
+  │                             ├─ PASS → registry Map is populated
+  │                             └─ FAIL → process throws; server does not start
+  │
+  └─ First request: resolveBrand() → O(1) Map lookup → BrandProvider renders
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+#### Registry tests — `packages/ui/src/brand/__tests__/registry.test.ts`
+
+| Test | What it verifies |
+|------|-----------------|
+| Valid `enterprise.brand.ts` passes validation | Schema accepts the default brand config without errors |
+| Missing required field (`slug`) throws on registry build | `buildRegistry()` throws with field path in error message |
+| Invalid slug format (uppercase) is rejected | Slug regex rejects `"Enterprise"` with descriptive error |
+| Duplicate slug throws before registry is returned | Two configs with `slug: "enterprise"` cause `buildRegistry()` to throw |
+| `isDefault: true` on one brand makes it the default | `getDefaultBrand()` returns the brand with `isDefault: true` |
+| No `isDefault` declared falls back to "enterprise" slug | `getDefaultBrand()` returns the `"enterprise"` brand when no `isDefault` is set |
+| No "enterprise" brand and no `isDefault` throws | `getDefaultBrand()` throws with a descriptive error |
+| `features` record rejects non-boolean values | `{ showPoweredBy: "yes" }` fails `z.record(z.string(), z.boolean())` |
+| Empty `slug` string is rejected | `z.string().min(1)` produces a validation error identifying the field |
+| `social.twitter` with invalid URL is rejected | `z.string().url()` rejects `"not-a-url"` |
+
+#### Resolution tests — `packages/ui/src/brand/__tests__/resolve.test.ts`
+
+| Test | What it verifies |
+|------|-----------------|
+| `BRAND_SLUG=enterprise` returns enterprise brand | Env var priority is highest; subdomain and path are not evaluated |
+| `BRAND_SLUG=unknown` throws with available slugs in message | Startup error prevents serving when env var points to nonexistent brand |
+| Subdomain `acme.platform.com` resolves to "acme" brand | First subdomain segment matched against registry |
+| `platform.com` (no qualifying subdomain) falls back to default | Single-segment host triggers path/default fallback |
+| `acme.localhost` does not resolve (only 1 dot) | Two-dot minimum for subdomain detection is correct |
+| Path prefix `/acme/dashboard` resolves to "acme" brand | First path segment matched against registry |
+| Unknown path prefix emits `console.warn` and falls back | Warning logged; default brand returned without throwing |
+| `BRAND_SLUG` overrides subdomain (acme host + enterprise env var) | Env var wins regardless of request context |
+| Static asset paths (`/favicon.ico`) do not emit brand warnings | File extension check suppresses false-positive path-prefix warnings |
+
+#### BrandLogo tests — `packages/ui/src/brand/__tests__/brand-logo.test.tsx`
+
+| Test | What it verifies |
+|------|-----------------|
+| Renders `logo.light.src` in light mode | `mode === "light"` causes `light` variant `src` to be rendered |
+| Renders `logo.dark.src` in dark mode | `mode === "dark"` causes `dark` variant `src` to be rendered |
+| `alt` attribute matches the active variant's `alt` field | Accessibility — alt is always from the correct variant |
+| Empty `src` renders `displayName` text instead of `<img>` | Text fallback prevents broken image tag |
+| `width` and `height` are passed to `<img>` when provided | Prevents layout shift |
+| `className` prop is applied to root element | Consumer override works for both img and text fallback |
+| Throws descriptive error outside `BrandProvider` | `useBrand()` throw message includes component name guidance |
+
+#### Contract schema tests — `packages/contracts/src/__tests__/brand.test.ts`
+
+| Test | What it verifies |
+|------|-----------------|
+| Full valid `BrandConfig` object passes | All required fields; all optional fields present |
+| Minimal valid config (only required fields) passes | Optional fields (`social`, `features`, `isDefault`) are truly optional |
+| Missing `slug` field is rejected with correct path | `ZodError.issues[0].path` includes `["slug"]` |
+| Missing `logo.light.alt` is rejected | Nested field validation works; path is `["logo", "light", "alt"]` |
+| `themeRef: ""` is rejected | `z.string().min(1)` catches empty string |
+| `slug: "My Brand"` (spaces) is rejected | Slug regex rejects spaces and uppercase |
+| `features: { enabled: 1 }` is rejected | `z.boolean()` rejects numeric value |
+| `social.linkedin: "not-a-url"` is rejected | `z.string().url()` rejects non-URL strings |
+| `metadata.titleTemplate: ""` is rejected | Empty title template is rejected |
+
+### Contract tests
+
+Schema validation tests in `packages/contracts/src/__tests__/brand.test.ts` serve as the contract test layer. They verify that the schema enforces all invariants independently of any runtime behavior, giving future consumers of `brandConfigSchema` a stable reference for what the schema accepts and rejects.
+
+### E2E tests
+
+Location: `ui/e2e/brand/brand.spec.ts`
+
+| Test | Tag | Flow |
+|------|-----|------|
+| Default brand renders on root request | `@critical` | Navigate to `/` → assert `<title>` matches `enterprise.metadata.defaultTitle`, favicon `href` matches `enterprise.favicon`, footer contains `enterprise.legal.privacyUrl` link |
+| Logo renders in light mode | `@critical` | Toggle theme to light → assert `BrandLogo` renders `<img>` with `src` matching `enterprise.logo.light.src` |
+| Logo renders in dark mode | `@critical` | Toggle theme to dark → assert `BrandLogo` renders `<img>` with `src` matching `enterprise.logo.dark.src` |
+| Text fallback when logo src is empty | | Set `BRAND_SLUG` to a test brand with empty `logo.light.src` → assert text node with `displayName` is rendered, no `<img>` tag |
+| `BRAND_SLUG` env var forces single brand | | Set `BRAND_SLUG=enterprise` in `.env.test` → navigate to any path → assert enterprise brand metadata is rendered |
+| Path-prefix brand resolution (acme) | | Register `acme` brand in test registry → navigate to `/acme/dashboard` → assert acme `displayName` appears in header logo alt |
+| Unknown subdomain falls back gracefully | | Navigate with unknown subdomain (via host header mock or path override) → assert default brand renders, no error page |
+| Footer legal links use brand URLs | | Assert footer `<a>` elements have `href` matching `enterprise.legal.privacyUrl` and `termsUrl` |
+| `showPoweredBy` feature toggle hides badge | | Create a test brand with `features: { showPoweredBy: false }` → assert "Powered by" text is not rendered |
+| Title template applies correctly | | Navigate to a page that sets a page title → assert browser `<title>` is `"Dashboard | Enterprise Platform"` |
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Brand config location | Static `*.brand.ts` files in `packages/ui/src/brands/` | Database-driven config | Code-driven config gets git history, PR review, and Zod type safety for free. DB-driven config is a follow-up for runtime admin management. Infrequent brand identity changes do not justify the operational overhead of a DB in MVP. |
+| Package ownership | Brand layer in `@enterprise/ui` | New `@enterprise/brand` package | Avoids a new package for MVP. `@enterprise/ui` already owns `ThemeProvider` — `BrandProvider` is a natural neighbor. Package extraction is a clean, non-breaking future step. |
+| Theme integration approach | `themeRef` string field naming a theme JSON | Brand embeds token values directly | Decouples brand identity from design tokens. A brand declares which token set to use, not what the tokens are. This allows multiple brands to share a theme, and theme changes do not require brand config edits. |
+| Resolution priority order | Env var → subdomain → path prefix → default | Any other order | Env var is the most explicit override (single-brand deploys). Subdomain is the canonical multi-brand production pattern. Path prefix is the local dev fallback. Default prevents hard failures. |
+| Unknown slugs: throw or fall back | Fall back to default + emit `console.warn` | Throw a 500 error | Throwing on an unknown slug would break the app for CDN health-check subdomains, Vercel preview URLs, and DNS misconfiguration. Silent fallback with a warning gives operators the signal they need without breaking production. |
+| Schema validation timing | Startup (module initialization) | Per-request validation | Per-request validation adds Zod overhead to every render. Brand configs are static; validating once at startup produces a fast fail with a clear error and zero per-request cost thereafter. |
+| `BrandProvider` as a Server Component or Client Component | Client Component (wraps `ThemeProvider` which requires client) | Pure Server Component | `ThemeProvider` is a Client Component (uses `useState`). `BrandProvider` renders `ThemeProvider` internally, so it must also be a Client Component. Brand resolution (the server-side part) is separated into `resolveBrand()`, which runs in the Server Component (root layout). |
+| Brand feature toggles location | `BrandConfig.features` record | Feature flags system | The feature flags system controls rollout and experimentation. Brand toggles control structural UI differences between brands (e.g., whether a brand shows a "Powered by" badge). Different concerns, different systems. |
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Subdomain resolution fails in local development | Developer cannot test multi-brand locally via subdomain | Document path-prefix resolution as the local dev alternative; document `BRAND_SLUG` env var as the simplest single-brand override. |
+| Adopters bypass `BrandProvider` and hardcode brand strings | Cross-brand inconsistencies; legal liability from wrong legal links | CI grep step that fails the build if specific brand string literals appear outside `*.brand.ts` files; linting guidance in `packages/ui/AGENTS.md`. |
+| `themeRef` points to a non-existent theme JSON | Silent fallback to wrong theme or visual regression | `buildRegistry()` validates that `themeRef` resolves to an existing theme JSON file at startup; throws if not found, preventing the server from starting with a misconfigured brand. |
+| Multiple brands with the same slug cause a registry collision | One brand silently overwrites another | `buildRegistry()` checks for duplicate slugs and throws before returning the registry. No request is ever served with an ambiguous registry. |
+| Server Component / Client Component boundary breaks brand context | `useBrand()` returns null or throws unexpectedly | `BrandProvider` is a Client Component; `BrandContext` is initialized on the client; `useBrand()` throw error includes actionable guidance. Server-side brand access uses `resolveBrand()` directly — not the context. |
+| Logo images are large and slow down initial page load | Poor Core Web Vitals; brand identity degrades UX | Documentation guidance to use SVGs for logos; `BrandLogo` accepts `width`/`height` for explicit sizing to prevent layout shift; adopter onboarding guide recommends SVG or optimized PNG. |
+| Brand resolution adds latency to every request | Higher TTFB | Resolution is a pure in-memory Map lookup after startup; there is no I/O. Overhead is sub-millisecond. The `headers()` call adds one async operation, which is shared with other middleware already. |
+| Placeholder legal URLs (`#`) shipped to production | Legal liability; broken links on live sites | Checklist item in `enterprise.brand.ts` comments; adopter onboarding guide flags this as a required pre-launch step; CI can grep for `privacyUrl: "#"` as a warning. |
+| Brand configs grow complex with deeply nested fields | Hard to maintain; adopters make mistakes | `brandConfigSchema` intentionally keeps all fields at one or two levels; complexity that belongs in theme JSON (colors, spacing) is explicitly excluded from `BrandConfig`. |
+| Next.js `headers()` behaves differently in edge vs. Node.js runtimes | `resolveBrand()` fails in edge runtime deployments | Document the Node.js runtime requirement for `resolveBrand()`; if edge runtime is needed, adopt `Request` parameter variant and pass the request from the layout. |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | **Contracts**: `brandConfigSchema` Zod schema and all sub-schemas in `packages/contracts/src/schemas/brand.ts`; type exports; unit tests for schema validation; barrel export in `packages/contracts/src/index.ts` | None |
+| 2 | **Registry and resolution**: `packages/ui/src/brand/registry.ts` (build registry, validate configs, duplicate slug check); `packages/ui/src/brand/resolve.ts` (`resolveBrand()` utility); default `enterprise.brand.ts`; `brands/index.ts` barrel; unit tests for registry and resolution | Phase 1 |
+| 3 | **Brand context and provider**: `packages/ui/src/brand/context.ts`; `packages/ui/src/brand/provider.tsx` (`BrandProvider` + `useBrand()`); subpath exports in `packages/ui/package.json`; integration with root layout (`ui/app/layout.tsx`); `generateBrandMetadata()` helper; unit tests for provider and hook | Phase 2, existing `ThemeProvider` |
+| 4 | **Brand UI components**: `BrandLogo` (light/dark variant switcher with text fallback); `BrandFooter` (legal links, social icons, optional "Powered by" badge); barrel export additions to `packages/ui/src/index.ts`; unit tests for each component; Sentry area `brand` registered | Phase 3 |
+| 5 | **Seed data, E2E tests, and documentation**: `acme.brand.ts` example file (commented out); E2E tests in `ui/e2e/brand/brand.spec.ts` for all defined flows; `BRAND_SLUG` documented in `.env.example`; brand workflow documented in `packages/ui/AGENTS.md`; audit event `brand.config_loaded` emitted at startup via structured log | Phase 4 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Where does brand config live — DB or code? | Static `*.brand.ts` files in MVP | Brand identity changes are infrequent and require design review. Code-driven config gets git history, PR review, and type safety for free. DB-driven config is a follow-up for runtime admin management. |
+| One package or new `@enterprise/brand`? | Brand provider and resolver live in `@enterprise/ui`; schema lives in `@enterprise/contracts` | Avoids a new package for MVP. `@enterprise/ui` already owns `ThemeProvider` and the design token layer. If the brand API grows significantly, extracting to `@enterprise/brand` is a clean future step that the dependency direction already permits. |
+| How does brand select a theme? | `themeRef` string field naming a theme JSON by its `metadata.name` | Decouples brand identity from theme tokens. A brand does not embed token values; it declares which token set to use. Adopters can share themes across brands or create brand-specific themes independently. |
+| Resolution priority order? | Env var → subdomain → path prefix → default | Env var is the simplest override for single-brand deploys. Subdomain is the canonical multi-brand production pattern. Path prefix is the local dev fallback that requires no system configuration. Default brand prevents hard failures. |
+| Should `BrandProvider` be a Server Component? | Client Component — it wraps `ThemeProvider` which requires `useState` | The resolution and prop-passing happen server-side in the root layout. `BrandProvider` itself must be a Client Component because it renders `ThemeProvider`. The separation is: resolve on the server, provide on the client. |
+| Are brand feature toggles in `BrandConfig` or the feature flags system? | Brand-scoped toggles in `BrandConfig.features`; rollout toggles in the feature-flags system | They serve different purposes. `BrandConfig.features` controls structural UI differences between brands (e.g., "Powered by" badge). The feature-flags system controls rollout, experimentation, and tenant-level gates. |
+| Should unknown slugs throw or fall back? | Fall back to default brand + emit `console.warn` | Throwing on an unknown slug would break the app for CDN health-check subdomains, Vercel preview URLs, and DNS misconfiguration scenarios. Silent fallback with a warning allows the app to continue serving and gives operators the signal they need. |
+| Is `BrandConfig` validated per-request or at startup? | At startup (module initialization when registry is first imported) | Per-request validation adds Zod overhead to every render. Brand configs are static; validating once at startup is sufficient and produces a fast fail with a clear error message before any request is served. |
+| Should `resolveBrand()` accept a `Request` parameter? | Optional `Request` parameter reserved for future edge runtime support; MVP uses `next/headers` | The `next/headers` API covers all Node.js runtime use cases. If edge runtime support is needed in a future iteration, the `Request` variant is a non-breaking extension: `resolveBrand(request?: Request)`. |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/brand-isolation-package/prd.md
+++ b/docs/features/brand-isolation-package/prd.md
@@ -1,0 +1,379 @@
+---
+title: "Brand isolation package PRD"
+description: "Defines package structure, dependency rules, and CI enforcement to guarantee that brand-specific code never leaks into shared infrastructure packages."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Brand isolation package PRD
+
+## Purpose
+
+Define the structural and enforcement rules that keep brand-specific code — logos, color palettes, metadata, legal copy, feature toggles — in a dedicated `@enterprise/brand` package. This PRD is about WHERE brand code lives and HOW the monorepo prevents it from leaking into business logic or infrastructure, not about WHAT a brand is (that is the Brand Abstraction Layer PRD).
+
+## Scope
+
+- Included: new `packages/brand/` package structure, dependency graph rules for `@enterprise/brand`, updated `check-boundaries.mjs` to enforce brand isolation in CI, decision tree for classifying new code into brand vs. ui vs. core, package scaffold requirements (AGENTS.md, tsconfig, exports), and documentation for template adopters.
+- Excluded: runtime capabilities delivered by the Brand Abstraction Layer (brand context, BrandProvider, token injection), design token definitions (Theme System PRD), feature-flag evaluation logic (Feature Flags PRD), and any brand-specific business rules that belong in individual brand packages outside this template.
+
+---
+
+## Problem
+
+Without an explicit package boundary, brand-specific concerns creep into shared infrastructure over multiple pull requests. The pattern appears in three recurring failure modes.
+
+First, the service layer accumulates conditional branches: `if (brand === 'acme') { sendEmail(...) }` inside `packages/core/src/services/`. This makes services untestable in isolation and forces every brand switch to touch business logic.
+
+Second, the database schema acquires brand-specific columns in otherwise generic tables — a `brand_theme_override` column on `tenants`, or a brand-scoped lookup table that only one deployment ever uses. This pollutes `@enterprise/db` with deployment-specific knowledge it should not hold.
+
+Third, contracts (Zod DTOs) grow brand-specific optional fields that only one deployment exercises. Every adopter of the template then carries dead fields and must understand which fields apply to their brand context.
+
+The root cause is the absence of a dedicated home for brand code. When there is no `@enterprise/brand`, the developer's natural instinct is to put brand logic wherever it fits — which ends up being `core`, `db`, or `contracts`. Making the boundary explicit and machine-enforced in CI is the only durable solution.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| Template maintainer | A single authoritative place for brand code; CI that catches regressions before review |
+| Template adopter | A clear scaffold to follow when adding a new brand; confidence that their brand changes will not touch shared packages |
+| New contributor | A decision tree that answers "where does this code go?" without requiring architect-level knowledge |
+| Reviewer | A short, mechanical checklist to verify brand isolation in every PR |
+
+## Goals
+
+- Provide a `packages/brand/` scaffold that is the only valid home for brand-specific TypeScript code.
+- Define an explicit, documented dependency graph that `@enterprise/brand` follows and that prevents it from importing `@enterprise/core` or `@enterprise/db`.
+- Update `scripts/check-boundaries.mjs` to enforce brand isolation rules in CI so violations fail the build rather than appearing in code review.
+- Give every developer a decision tree to determine whether a piece of code belongs in `brand`, `ui`, or `core` without ambiguity.
+
+---
+
+## Dependency graph (enforced)
+
+```
+@enterprise/brand
+  ├── MAY import: @enterprise/contracts   (brand config schema, DTO types)
+  ├── MAY import: @enterprise/ui          (theme token types for CSS variable injection)
+  ├── MUST NOT import: @enterprise/core   (no business logic dependency)
+  ├── MUST NOT import: @enterprise/db     (no schema dependency)
+  └── MUST NOT import: @enterprise/web    (no app dependency — rule already enforced)
+
+@enterprise/core
+  ├── MAY import: @enterprise/contracts
+  ├── MAY import: @enterprise/db
+  ├── MUST NOT import: @enterprise/brand  (core is brand-agnostic)
+  └── MUST NOT import: @enterprise/ui
+
+@enterprise/db
+  ├── MAY import: drizzle-orm ONLY
+  └── MUST NOT import: @enterprise/brand
+
+@enterprise/contracts
+  ├── MAY import: zod ONLY
+  └── MUST NOT import: @enterprise/brand
+
+@enterprise/ui
+  ├── MAY import: @enterprise/contracts   (theme schemas)
+  └── MUST NOT import: @enterprise/brand  (ui is brand-agnostic; brand imports ui, not vice versa)
+
+ui/ (Next.js app)
+  ├── MAY import: @enterprise/brand       (at layout level only)
+  ├── MAY import: @enterprise/contracts
+  ├── MAY import: @enterprise/core
+  ├── MAY import: @enterprise/ui
+  └── MAY import: @enterprise/db
+```
+
+The key invariant: **brand flows in one direction only.** `@enterprise/brand` consumes from the infrastructure packages; nothing in the infrastructure packages imports back from `@enterprise/brand`.
+
+---
+
+## MVP scope
+
+### Core capabilities
+
+**Package scaffold (`packages/brand/`)**
+
+The new `packages/brand/` directory is added to the monorepo with the following structure:
+
+```
+packages/brand/
+├── AGENTS.md              # Brand package agent instructions
+├── package.json           # name: @enterprise/brand, private: true
+├── tsconfig.json          # extends ../../tsconfig.json
+└── src/
+    ├── index.ts           # Barrel export
+    ├── config/
+    │   └── default.ts     # DefaultBrandConfig — fallback values for local dev
+    ├── components/
+    │   ├── brand-logo.tsx          # Logo component, brand-config-driven
+    │   ├── brand-name.tsx          # Typographic brand name component
+    │   └── legal-footer.tsx        # Legal/copyright text component
+    └── types/
+        └── brand-config.ts         # Re-export of BrandConfig type from @enterprise/contracts
+```
+
+`@enterprise/brand` is listed as a dependency in `ui/package.json` with `workspace:*` protocol. It is added to `ui/next.config.ts` `transpilePackages` because it contains JSX.
+
+**Brand-specific components**
+
+The following components move out of `ui/` (or are created here for the first time) and live exclusively in `@enterprise/brand`:
+
+- `BrandLogo` — renders the brand's logotype. Accepts `variant` (`full | mark`) and `size` props. Sources image path and alt text from `BrandConfig`.
+- `BrandName` — renders the brand's display name as a styled `<span>`. Sources the name string from `BrandConfig`.
+- `LegalFooter` — renders the copyright notice, legal entity name, and optional links (privacy policy, terms). Sources all strings from `BrandConfig`.
+
+None of these components import from `@enterprise/core` or `@enterprise/db`. They are pure presentational components that receive brand configuration as props or via the `BrandProvider` context defined in the Brand Abstraction Layer.
+
+**Updated `check-boundaries.mjs`**
+
+`scripts/check-boundaries.mjs` is extended to add `packages/brand` to the allowed workspace map and enforce the brand-isolation invariants:
+
+```
+"packages/brand": ["@enterprise/contracts", "@enterprise/ui"],
+```
+
+The existing `ui` entry is extended:
+
+```
+ui: [
+  "@enterprise/contracts",
+  "@enterprise/core",
+  "@enterprise/ui",
+  "@enterprise/db",
+  "@enterprise/brand",    // added — ui may consume brand at layout level
+],
+```
+
+Two new negative rules are added to the loop body:
+
+1. If `sourceWorkspace` is `packages/core`, `packages/db`, or `packages/contracts` and `targetPackage` is `@enterprise/brand`, record a violation: `"{sourceWorkspace} MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic"`.
+2. If `sourceWorkspace` is `packages/ui` and `targetPackage` is `@enterprise/brand`, record a violation: `"@enterprise/ui MUST NOT import @enterprise/brand — brand imports ui, not vice versa"`.
+
+These two rules encode the core invariant mechanically and run on every CI push.
+
+**Decision tree for new code**
+
+Every developer must answer three questions when deciding where a piece of code belongs:
+
+```
+Is this code specific to one deployment's brand identity?
+│
+├── YES → Does it render UI? (component, icon, styled text)
+│          ├── YES → @enterprise/brand/components/
+│          └── NO  → Is it configuration? (name, color, URL, legal string)
+│                     ├── YES → brand config object in brand package
+│                     └── NO  → Is it a feature toggle tied to a brand?
+│                                ├── YES → @enterprise/brand/config/features.ts
+│                                └── NO  → Contact architecture team
+│
+└── NO  → Is it a generic UI primitive? (button, card, input)
+           ├── YES → @enterprise/ui/components/
+           └── NO  → Is it business logic? (service, query, computation)
+                      ├── YES → @enterprise/core/services/
+                      └── NO  → Is it a data contract? (DTO, schema)
+                                 ├── YES → @enterprise/contracts/
+                                 └── NO  → Is it a table definition?
+                                            ├── YES → @enterprise/db/
+                                            └── NO  → Contact architecture team
+```
+
+**AGENTS.md for `packages/brand/`**
+
+A new `packages/brand/AGENTS.md` is created with the following mandatory rules:
+
+- NEVER import from `@enterprise/core` or `@enterprise/db` — violations fail CI.
+- NEVER import from `@enterprise/web` — same rule as all packages.
+- Brand-specific feature toggles live here, never in `@enterprise/core`.
+- Components in this package MUST be purely presentational — no Server Actions, no direct Supabase calls.
+- All brand configuration MUST be typed against `BrandConfig` from `@enterprise/contracts`.
+
+**`packages/brand/` added to Turborepo**
+
+`turbo.json` build graph treats `@enterprise/brand` as a standard package dependency. Because it contains JSX, its `build` task must complete before the `ui` build begins (`dependsOn: ["^build"]` is already the default and covers this case without extra configuration).
+
+### Out of scope (MVP)
+
+- Runtime brand-switching between brands within the same deployment (covered by Brand Abstraction Layer).
+- Per-brand Supabase RLS policies or tenant-scoped brand overrides.
+- Brand-specific email templates (those belong in a notifications adapter, not in `@enterprise/brand`).
+- Automated lint rule via an ESLint or Biome plugin (the `check-boundaries.mjs` script is sufficient for MVP; a dedicated lint plugin is a follow-up).
+- Brand asset pipeline (image optimization, SVG sprite generation).
+- Storybook stories for brand components.
+
+---
+
+## User stories and acceptance criteria (from the developer perspective)
+
+### US-1: Template adopter adds a new brand without touching shared packages
+
+**As** a template adopter, **I want** to add a new brand configuration without modifying `@enterprise/core`, `@enterprise/db`, or `@enterprise/contracts`, so that shared packages remain stable across all my deployments.
+
+Acceptance criteria:
+1. Creating a new brand means adding files only inside `packages/brand/src/config/` and the consuming app (`ui/`).
+2. No changes to `packages/core/src/services/`, `packages/db/src/`, or `packages/contracts/src/` are required to introduce a new brand.
+3. `pnpm check-boundaries` passes after adding the new brand config without additional allowlist modifications.
+4. The new brand config is typed against `BrandConfig` from `@enterprise/contracts` and a TypeScript error appears if required fields are missing.
+
+### US-2: Developer receives a CI failure when brand code leaks into core
+
+**As** a developer, **I want** the CI pipeline to fail with a clear error when I accidentally import `@enterprise/brand` from `@enterprise/core`, so that I catch the leak before it reaches code review.
+
+Acceptance criteria:
+1. Adding `import { BrandName } from "@enterprise/brand"` to any file inside `packages/core/src/` causes `pnpm check-boundaries` to exit with code 1.
+2. The error message identifies the violating file path and the specific rule broken: `"packages/core MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic"`.
+3. The same failure occurs for imports of `@enterprise/brand` in `packages/db/` and `packages/contracts/`.
+4. The CI `lint` job runs `check-boundaries.mjs` and is marked as failed, blocking merge.
+
+### US-3: Developer receives a CI failure when @enterprise/ui imports brand
+
+**As** a developer, **I want** the CI pipeline to fail when `@enterprise/ui` tries to import from `@enterprise/brand`, so that the ui package remains a brand-agnostic primitive library.
+
+Acceptance criteria:
+1. Adding `import { BrandLogo } from "@enterprise/brand"` to any file inside `packages/ui/src/` causes `pnpm check-boundaries` to exit with code 1.
+2. The error message states: `"@enterprise/ui MUST NOT import @enterprise/brand — brand imports ui, not vice versa"`.
+3. `@enterprise/brand` may freely import from `@enterprise/ui` without triggering any violation.
+
+### US-4: Reviewer uses a decision tree to classify new code in a PR
+
+**As** a code reviewer, **I want** a documented decision tree in `packages/brand/AGENTS.md` so I can verify in under 30 seconds whether new code in a PR is in the correct package.
+
+Acceptance criteria:
+1. `packages/brand/AGENTS.md` contains the full decision tree (brand vs. ui vs. core vs. contracts vs. db).
+2. The tree is written as a text diagram that renders correctly in GitHub Markdown.
+3. The AGENTS.md includes at least one concrete example of a boundary violation and the correct resolution.
+4. The root `AGENTS.md` dependency direction table is updated to include `@enterprise/brand` in the correct position.
+
+### US-5: BrandLogo renders the correct asset per brand config
+
+**As** a developer building a brand deployment, **I want** the `BrandLogo` component to derive its image source and alt text entirely from `BrandConfig` so I never hardcode asset paths in layout files.
+
+Acceptance criteria:
+1. `BrandLogo` accepts a `config: BrandConfig` prop (or reads from `BrandContext` when context is available).
+2. Rendering `<BrandLogo variant="full" />` with a given config uses `config.logoUrl` for `src` and `config.name` for `alt`.
+3. Rendering `<BrandLogo variant="mark" />` uses `config.logoMarkUrl` when defined, falling back to `config.logoUrl`.
+4. `BrandLogo` has no import from `@enterprise/core` or `@enterprise/db`. TypeScript compilation passes with `strict: true`.
+5. A unit test verifies that the correct `src` is rendered for both `full` and `mark` variants.
+
+### US-6: LegalFooter renders brand-specific legal copy without hardcoding strings
+
+**As** a developer building a brand deployment, **I want** the `LegalFooter` component to render the legal entity name, copyright year, and policy links from `BrandConfig` so legal strings are never scattered across layout files.
+
+Acceptance criteria:
+1. `LegalFooter` accepts a `config: BrandConfig` prop (or reads from `BrandContext`).
+2. It renders `© {currentYear} {config.legalName}. All rights reserved.` where `currentYear` is derived at render time.
+3. When `config.privacyPolicyUrl` is defined, it renders a "Privacy Policy" link to that URL.
+4. When `config.termsUrl` is defined, it renders a "Terms of Service" link to that URL.
+5. Neither link renders when the corresponding config field is absent.
+6. `LegalFooter` has no import from `@enterprise/core` or `@enterprise/db`.
+
+### US-7: Default brand config allows local development without brand-specific values
+
+**As** a template maintainer, **I want** a `defaultBrandConfig` object exported from `@enterprise/brand` so that local development works out of the box without requiring a brand-specific config to be wired in.
+
+Acceptance criteria:
+1. `packages/brand/src/config/default.ts` exports a `defaultBrandConfig` satisfying `BrandConfig` from `@enterprise/contracts`.
+2. All required `BrandConfig` fields have sensible placeholder values (e.g., `name: "Enterprise Platform"`, `legalName: "Enterprise Platform Inc."`).
+3. `defaultBrandConfig` is re-exported from `packages/brand/src/index.ts`.
+4. The seed data and local dev setup use `defaultBrandConfig` without requiring any additional configuration step.
+
+### US-8: New package is registered in the monorepo toolchain
+
+**As** a template maintainer, **I want** `@enterprise/brand` to be a first-class workspace member so that Turborepo, TypeScript, and pnpm all resolve it correctly without manual path hackery.
+
+Acceptance criteria:
+1. `packages/brand/package.json` sets `"name": "@enterprise/brand"` and `"private": true` with a `workspace:*` dependency protocol in consuming packages.
+2. `packages/brand/tsconfig.json` extends `../../tsconfig.json` and passes `pnpm --filter @enterprise/brand typecheck`.
+3. `ui/next.config.ts` lists `@enterprise/brand` in `transpilePackages`.
+4. `pnpm build --filter @enterprise/brand` succeeds from a clean state.
+5. `scripts/check-boundaries.mjs` includes `"packages/brand"` in `allowedWorkspaceImports` and the CI `lint` job runs it.
+
+---
+
+## Success metrics
+
+- Boundary violation incidents reaching `main` per quarter (target: 0 — every leak is caught in CI before merge).
+- Time for a contributor to correctly classify a new piece of brand code using the decision tree, without asking for help (target: under 2 minutes).
+- Number of adopter PRs that require a reviewer to manually move brand code to the correct package (target: 0 after the first month following template release).
+- CI run time overhead introduced by the updated `check-boundaries.mjs` (target: under 3 seconds added to the `lint` task).
+- Ratio of TypeScript errors caught at compile time vs. runtime for `BrandConfig` misuse (target: 100% compile-time — the type system should make runtime brand config errors impossible).
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Developers bypass `check-boundaries.mjs` by committing with `--no-verify` | Script runs in CI as part of the `lint` job, not just as a git hook — local bypass does not prevent CI failure |
+| `@enterprise/brand` grows its own business logic over time (creeping complexity) | `packages/brand/AGENTS.md` explicitly forbids Server Actions and Supabase calls; reviewers are directed to check this rule; follow-up: add negative assertion to boundary check for Supabase client imports |
+| Brand config schema drifts between `@enterprise/contracts` and actual usage in `@enterprise/brand` | `BrandConfig` in `@enterprise/contracts` is the single source of truth; `defaultBrandConfig` and all brand configs are typed against it — TypeScript catches drift at build time |
+| Template adopters create `packages/brand-acme/` parallel packages that reintroduce leaks | AGENTS.md and developer guide document the single-package pattern; `check-boundaries.mjs` can be extended to enforce custom package names follow a naming convention |
+| `@enterprise/ui` maintainers inadvertently import brand components for convenience | CI violation rule explicitly blocks `@enterprise/ui → @enterprise/brand`; the error message explains the direction of the dependency |
+| Brand isolation is enforced in `check-boundaries.mjs` but not in the IDE | The package.json `dependencies` field for `packages/ui`, `packages/core`, `packages/db`, and `packages/contracts` intentionally omits `@enterprise/brand` — TypeScript will fail to resolve the import even in the IDE before CI runs |
+
+---
+
+## Traceability
+
+### Audit events (if applicable)
+
+Brand isolation is a structural, build-time concern. There are no runtime user-facing mutations and therefore no audit events for this feature. The CI boundary check produces a structured exit code and console log that serves as the audit trail for violations caught pre-merge.
+
+### Sentry
+
+No Sentry instrumentation is required. Brand isolation is enforced at build time and has no runtime failure path. If a future runtime brand-config loading mechanism is introduced (e.g., remote config fetch), Sentry instrumentation would be added at that point under the `brand` area tag.
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| `defaultBrandConfig` | Exported constant | `name: "Enterprise Platform"`, `legalName: "Enterprise Platform Inc."`, placeholder logo paths pointing to `public/` assets included in the template |
+
+No database seed data is required — brand configuration in MVP is a compile-time constant, not a database record.
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|-----------------|
+| App shell renders with default brand config | Developer (local dev) | `BrandLogo`, `BrandName`, and `LegalFooter` render without runtime errors using `defaultBrandConfig` |
+| `check-boundaries.mjs` blocks a brand leak | CI system | Script exits with code 1 and a violation message when a test file importing `@enterprise/brand` from `packages/core/` is introduced |
+| App builds successfully after package scaffold | Developer | `pnpm build` completes with no TypeScript errors after `@enterprise/brand` is added to the workspace |
+
+Full Playwright E2E tests are not required for this PRD. The brand components are static and their correctness is verified through unit tests and the boundary check script. Visual correctness is covered by the Brand Abstraction Layer E2E suite, which exercises the full `BrandProvider` integration.
+
+### External adapters
+
+None. Brand isolation is a monorepo-internal structural concern. No external services, APIs, or environment variables are introduced by this package.
+
+### Production readiness
+
+- [ ] `packages/brand/` scaffold committed with all required files (`package.json`, `tsconfig.json`, `src/index.ts`, `AGENTS.md`)
+- [ ] `scripts/check-boundaries.mjs` updated with brand isolation rules and the two new negative checks
+- [ ] `check-boundaries.mjs` run added to the `lint` CI job (verify in `.github/workflows/`)
+- [ ] `@enterprise/brand` added to `ui/next.config.ts` `transpilePackages`
+- [ ] `@enterprise/brand` listed as `workspace:*` dependency in `ui/package.json`
+- [ ] `packages/brand/AGENTS.md` includes decision tree and boundary rules
+- [ ] Root `AGENTS.md` dependency direction table updated to include `@enterprise/brand`
+- [ ] `defaultBrandConfig` exported and used in local dev setup
+- [ ] Unit tests pass for `BrandLogo` (both variants) and `LegalFooter` (with and without optional links)
+- [ ] `pnpm --filter @enterprise/brand typecheck` passes
+- [ ] `pnpm check-boundaries` passes after scaffold with no false positives
+- [ ] Developer guide entry written explaining the decision tree and the boundary enforcement mechanism
+- [ ] Verified that `packages/core`, `packages/db`, `packages/contracts`, and `packages/ui` have no `@enterprise/brand` in their `package.json` dependencies
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| New `@enterprise/brand` package vs. extending `@enterprise/ui` with a brand sub-path | New dedicated `packages/brand/` package | Extending `@enterprise/ui` would conflate generic primitives with brand-specific assets; a separate package makes the dependency direction unambiguous and allows the boundary checker to enforce it mechanically |
+| `check-boundaries.mjs` script vs. ESLint/Biome plugin | `check-boundaries.mjs` script (existing mechanism) | The script already exists and runs in CI; adding a Biome plugin would require a custom plugin that is not yet mature in the ecosystem; consistency with the existing enforcement mechanism is preferred in MVP |
+| `@enterprise/brand` allowed to import `@enterprise/ui`? | Yes — brand imports ui, never the reverse | Brand components need theme token types and primitives from `@enterprise/ui`; the reverse direction (ui importing brand) is explicitly forbidden to keep ui a generic library |
+| `@enterprise/brand` allowed to import `@enterprise/core`? | No — explicitly forbidden | Brand components must be purely presentational; any data needs come from props or context, not from direct service calls; enforced in CI |
+| Brand config as compile-time constant vs. database record | Compile-time constant for MVP | Simplest approach; avoids schema changes; adopters can elevate to DB-driven config if they need runtime switching (that is the Brand Abstraction Layer's responsibility) |
+| Where do brand-specific feature toggles live? | `packages/brand/src/config/features.ts` | Feature toggles tied to brand identity (e.g., a feature enabled only for one brand) belong in the brand package, not in `@enterprise/core`; this prevents `if (brand === X)` in the service layer |
+| Should `@enterprise/ui` be updated to list `@enterprise/brand` as a forbidden dependency in its `package.json`? | Yes — omit `@enterprise/brand` from ui's dependencies entirely | TypeScript cannot resolve an import from a package not listed in `dependencies`; this provides IDE-level enforcement before CI runs, in addition to the boundary script |
+| Who owns the decision tree? | Architecture team, documented in `packages/brand/AGENTS.md` | The decision tree must be discoverable at the point of contribution; colocating it in the brand package AGENTS.md and linking from the root AGENTS.md maximizes visibility |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/brand-isolation-package/rfc.md
+++ b/docs/features/brand-isolation-package/rfc.md
@@ -1,0 +1,940 @@
+---
+title: "Brand isolation package RFC"
+description: "Defines the package scaffold, dependency rules, CI enforcement, and component interfaces that guarantee brand-specific code lives exclusively in @enterprise/brand and never leaks into shared infrastructure."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Brand isolation package RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for the `@enterprise/brand` package: its directory scaffold, `package.json` shape, TypeScript exports, brand-aware components, and the exact `check-boundaries.mjs` changes that mechanically enforce the brand isolation invariant in CI.
+
+This RFC is about **enforcement and structure**. It defines where brand code lives and how the monorepo toolchain prevents it from leaking into shared infrastructure. Runtime capabilities — `BrandProvider`, token injection, and brand context switching — are addressed in the Brand Abstraction Layer RFC.
+
+## Scope
+
+- Included: `packages/brand/` directory scaffold, `package.json`, `tsconfig.json`, subpath exports map, `BrandConfig` type re-export, `defaultBrandConfig`, `BrandLogo` / `BrandName` / `LegalFooter` component interfaces and implementations, updated `check-boundaries.mjs` rules (exact diff), updated dependency direction diagram for the full monorepo, `packages/brand/AGENTS.md` content, decision tree for code classification, Turborepo and `transpilePackages` wiring, and unit testing strategy for boundary enforcement.
+- Excluded: runtime brand-switching and `BrandProvider` (Brand Abstraction Layer), design token definitions (Theme System RFC), feature-flag evaluation logic (Feature Flags RFC), brand-specific email templates, automated Biome/ESLint plugin for import enforcement, brand asset pipeline (image optimization, SVG sprites), and Storybook stories.
+
+---
+
+## Summary
+
+Add a new `packages/brand/` workspace member named `@enterprise/brand`. The package is a thin presentational layer: it holds the `defaultBrandConfig`, three brand-aware components (`BrandLogo`, `BrandName`, `LegalFooter`), and a re-export of the `BrandConfig` type from `@enterprise/contracts`. It may import from `@enterprise/contracts` and `@enterprise/ui`, and MUST NOT import from `@enterprise/core`, `@enterprise/db`, or `@enterprise/web`. The `check-boundaries.mjs` script is extended with one new allowlist entry and two new negative rules that fail the CI `lint` job on any violation. No other package's `package.json` lists `@enterprise/brand` as a dependency except `ui/package.json`, which gives TypeScript IDE-level enforcement before CI runs.
+
+## Technical objectives
+
+- The monorepo has exactly one valid home for brand-specific TypeScript code, discoverable in under 30 seconds.
+- Every attempted import of `@enterprise/brand` from `@enterprise/core`, `@enterprise/db`, `@enterprise/contracts`, or `@enterprise/ui` fails `pnpm check-boundaries` with an actionable error message before merging to `main`.
+- Adding a new brand requires changes only inside `packages/brand/src/config/` and `ui/` — no shared package is touched.
+- `BrandConfig` in `@enterprise/contracts` is the single source of truth; TypeScript catches schema drift at build time, not runtime.
+- `pnpm check-boundaries` completes in under 3 seconds of added wall time on the CI `lint` job.
+
+---
+
+## Package structure
+
+### `packages/brand/` layout
+
+```
+packages/brand/
+├── AGENTS.md
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts
+    ├── config/
+    │   └── default.ts
+    ├── components/
+    │   ├── brand-logo.tsx
+    │   ├── brand-name.tsx
+    │   └── legal-footer.tsx
+    └── types/
+        └── brand-config.ts
+```
+
+**File responsibilities:**
+
+| File | Responsibility |
+|------|---------------|
+| `src/index.ts` | Barrel export — re-exports everything the consuming app needs |
+| `src/types/brand-config.ts` | Re-exports `BrandConfig` type from `@enterprise/contracts`; the single import point for brand type consumers inside this package |
+| `src/config/default.ts` | Exports `defaultBrandConfig` — a fully-typed `BrandConfig` with placeholder values for local development |
+| `src/components/brand-logo.tsx` | `BrandLogo` component — renders brand logotype from config |
+| `src/components/brand-name.tsx` | `BrandName` component — renders brand display name from config |
+| `src/components/legal-footer.tsx` | `LegalFooter` component — renders copyright, legal entity, and policy links from config |
+| `AGENTS.md` | Brand package agent instructions including decision tree, boundary rules, and one concrete violation example |
+| `package.json` | `name: "@enterprise/brand"`, `private: true`, dependencies: `@enterprise/contracts` + `@enterprise/ui` |
+| `tsconfig.json` | Extends `../../tsconfig.json`; includes `src/**/*.ts` and `src/**/*.tsx` |
+
+### `package.json`
+
+```json
+{
+  "name": "@enterprise/brand",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./components/brand-logo": "./src/components/brand-logo.tsx",
+    "./components/brand-name": "./src/components/brand-name.tsx",
+    "./components/legal-footer": "./src/components/legal-footer.tsx",
+    "./config/default": "./src/config/default.ts",
+    "./types": "./src/types/brand-config.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "cd ../.. && vitest run --project brand",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@enterprise/contracts": "workspace:*",
+    "@enterprise/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}
+```
+
+**Dependency rationale:**
+
+| Dependency | Why |
+|------------|-----|
+| `@enterprise/contracts` | `BrandConfig` type and schema live here — the source of truth |
+| `@enterprise/ui` | Brand components use `cn()` from `@enterprise/ui/lib/utils` and may use shadcn/ui primitives (e.g., `Image`-equivalent wrappers) |
+| NOT `@enterprise/core` | No business logic — intentional omission enforces the boundary |
+| NOT `@enterprise/db` | No schema access — intentional omission enforces the boundary |
+
+### `tsconfig.json`
+
+```json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+---
+
+## Dependency graph (enforced)
+
+### Updated dependency direction diagram
+
+```
+Dependency direction (arrows = "may import"):
+
+@enterprise/contracts ──────────────────────────────────────┐
+   │ (zod only)                                              │
+   │                                                         ▼
+@enterprise/db                          @enterprise/ui ◄────┐
+   │ (drizzle-orm only)                    │ (contracts)     │
+   │                                       │                 │
+   ▼                                       │          @enterprise/brand
+@enterprise/core ◄─────────────────────────┘              │
+   │ (contracts + db + supabase)                           │
+   │                                                       │
+   └──────────────────────────────────────┐                │
+                                          ▼                ▼
+                                    @enterprise/web (ui/)
+                              (contracts + core + ui + db + brand)
+
+Legend:
+  ──► may import
+  ✗   MUST NOT import (enforced by check-boundaries.mjs)
+
+Enforcement summary:
+  @enterprise/brand    → @enterprise/contracts   ✅
+  @enterprise/brand    → @enterprise/ui          ✅
+  @enterprise/brand    → @enterprise/core        ✗  (CI blocks)
+  @enterprise/brand    → @enterprise/db          ✗  (CI blocks)
+  @enterprise/brand    → @enterprise/web         ✗  (CI blocks — existing rule)
+  @enterprise/core     → @enterprise/brand       ✗  (CI blocks — NEW rule)
+  @enterprise/db       → @enterprise/brand       ✗  (CI blocks — NEW rule)
+  @enterprise/contracts → @enterprise/brand      ✗  (CI blocks — NEW rule)
+  @enterprise/ui       → @enterprise/brand       ✗  (CI blocks — NEW rule)
+  @enterprise/web (ui) → @enterprise/brand       ✅ (layout level only)
+```
+
+### `check-boundaries.mjs` changes
+
+The complete updated `allowedWorkspaceImports` map and the two new negative rule blocks are shown below as an exact diff against the current file.
+
+**Change 1 — add `packages/brand` to the allowlist map and extend `ui`:**
+
+```diff
+ const allowedWorkspaceImports = {
+   "packages/contracts": [],
+   "packages/db": [],
+   "packages/core": ["@enterprise/contracts", "@enterprise/db"],
+   "packages/ui": ["@enterprise/contracts"],
++  "packages/brand": ["@enterprise/contracts", "@enterprise/ui"],
+-  ui: ["@enterprise/contracts", "@enterprise/core", "@enterprise/ui", "@enterprise/db"],
++  ui: [
++    "@enterprise/contracts",
++    "@enterprise/core",
++    "@enterprise/ui",
++    "@enterprise/db",
++    "@enterprise/brand",
++  ],
+ };
+```
+
+**Change 2 — add two new negative rules inside the per-import loop, after the existing `@enterprise/web` check:**
+
+```diff
+       if (targetPackage === "@enterprise/web" && sourceWorkspace !== "ui") {
+         violations.push({
+           filePath,
+           reason: "Packages MUST NOT import from @enterprise/web",
+         });
+         continue;
+       }
+
++      // Brand isolation: infrastructure packages must not import from @enterprise/brand
++      const brandIsolatedSources = ["packages/core", "packages/db", "packages/contracts"];
++      if (brandIsolatedSources.includes(sourceWorkspace) && targetPackage === "@enterprise/brand") {
++        violations.push({
++          filePath,
++          reason: `${sourceWorkspace} MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic`,
++        });
++        continue;
++      }
++
++      // Brand direction: ui package must not import from @enterprise/brand
++      if (sourceWorkspace === "packages/ui" && targetPackage === "@enterprise/brand") {
++        violations.push({
++          filePath,
++          reason: "@enterprise/ui MUST NOT import @enterprise/brand — brand imports ui, not vice versa",
++        });
++        continue;
++      }
+
+       if (sourceWorkspace === "ui") {
+```
+
+**Result of the two new rules:**
+
+| Violating import | Error message |
+|-----------------|---------------|
+| `packages/core/src/**` imports `@enterprise/brand` | `packages/core MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic` |
+| `packages/db/src/**` imports `@enterprise/brand` | `packages/db MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic` |
+| `packages/contracts/src/**` imports `@enterprise/brand` | `packages/contracts MUST NOT import @enterprise/brand — keep infrastructure brand-agnostic` |
+| `packages/ui/src/**` imports `@enterprise/brand` | `@enterprise/ui MUST NOT import @enterprise/brand — brand imports ui, not vice versa` |
+
+No changes are needed to the deep-import check (`/^@enterprise\/[a-z-]+\/(src|schema\/platform)/`) — it already blocks deep subpath imports for all packages including `@enterprise/brand`.
+
+---
+
+## Brand-aware components
+
+All three components follow the same contract:
+- Pure presentational — no Server Actions, no Supabase calls, no direct DB access.
+- Props-driven: they accept a `config: BrandConfig` prop. When the Brand Abstraction Layer is wired (its own RFC), components may additionally read from `BrandContext` via a hook. For MVP, the prop is required.
+- No import from `@enterprise/core` or `@enterprise/db`.
+- TypeScript strict mode passes — all props are fully typed against `BrandConfig` from `@enterprise/contracts`.
+
+### `BrandConfig` type (re-export in `src/types/brand-config.ts`)
+
+This file re-exports the type from contracts so that brand package internals have a single local import point. The source of truth is `@enterprise/contracts` — this file MUST NOT redefine the type.
+
+```typescript
+// packages/brand/src/types/brand-config.ts
+
+// Re-export only — BrandConfig is defined in @enterprise/contracts.
+// NEVER redefine this type locally.
+export type { BrandConfig } from "@enterprise/contracts";
+```
+
+The `BrandConfig` schema in `@enterprise/contracts` must expose at minimum:
+
+```typescript
+// packages/contracts/src/dto/brand.ts  (new file — owned by Brand Abstraction Layer RFC)
+import { z } from "zod";
+
+export const brandConfigSchema = z.object({
+  /** Display name shown in the UI (e.g., "Acme Corp") */
+  name: z.string().min(1),
+  /** Legal entity name used in copyright notices (e.g., "Acme Corporation Inc.") */
+  legalName: z.string().min(1),
+  /** Full logotype URL — used as <img src> for variant="full" */
+  logoUrl: z.string().url(),
+  /** Mark/icon-only URL — used as <img src> for variant="mark"; falls back to logoUrl */
+  logoMarkUrl: z.string().url().optional(),
+  /** Privacy policy URL — renders Privacy Policy link when present */
+  privacyPolicyUrl: z.string().url().optional(),
+  /** Terms of service URL — renders Terms of Service link when present */
+  termsUrl: z.string().url().optional(),
+});
+
+export type BrandConfig = z.infer<typeof brandConfigSchema>;
+```
+
+### `BrandLogo`
+
+**File:** `packages/brand/src/components/brand-logo.tsx`
+
+**Props interface:**
+
+```typescript
+import type { BrandConfig } from "../types/brand-config";
+
+export interface BrandLogoProps {
+  /** Brand configuration object. Required. Source: BrandContext or defaultBrandConfig. */
+  config: BrandConfig;
+  /**
+   * "full"  — renders the complete logotype (default).
+   * "mark"  — renders the icon/mark only; falls back to logoUrl when logoMarkUrl is absent.
+   */
+  variant?: "full" | "mark";
+  /** Pixel width of the rendered image. Default: 120 for "full", 40 for "mark". */
+  width?: number;
+  /** Pixel height of the rendered image. Default: 40 for both variants. */
+  height?: number;
+  /** Additional CSS classes merged via cn(). */
+  className?: string;
+}
+```
+
+**Implementation:**
+
+```typescript
+// packages/brand/src/components/brand-logo.tsx
+import { cn } from "@enterprise/ui/lib/utils";
+import type { BrandLogoProps } from "./brand-logo";
+
+export function BrandLogo({
+  config,
+  variant = "full",
+  width,
+  height = 40,
+  className,
+}: BrandLogoProps) {
+  const src = variant === "mark" ? (config.logoMarkUrl ?? config.logoUrl) : config.logoUrl;
+  const resolvedWidth = width ?? (variant === "mark" ? 40 : 120);
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={config.name}
+      width={resolvedWidth}
+      height={height}
+      className={cn("object-contain", className)}
+    />
+  );
+}
+```
+
+**Design notes:**
+- Uses a plain `<img>` rather than `next/image` because `@enterprise/brand` must not depend on Next.js (it is a package, not an app). The consuming `ui/` layout wraps or replaces this with `next/image` if remote image optimization is needed.
+- `alt` is always derived from `config.name` — never an empty string or hardcoded value.
+- The `mark` variant falls back to `logoUrl` when `logoMarkUrl` is absent, making it safe to call without configuring a separate mark asset.
+
+### `BrandName`
+
+**File:** `packages/brand/src/components/brand-name.tsx`
+
+**Props interface:**
+
+```typescript
+import type { BrandConfig } from "../types/brand-config";
+
+export interface BrandNameProps {
+  /** Brand configuration object. Required. */
+  config: BrandConfig;
+  /** HTML element to render. Default: "span". Use "h1" for landmark headings. */
+  as?: "span" | "h1" | "h2" | "p";
+  /** Additional CSS classes merged via cn(). */
+  className?: string;
+}
+```
+
+**Implementation:**
+
+```typescript
+// packages/brand/src/components/brand-name.tsx
+import { cn } from "@enterprise/ui/lib/utils";
+import type { BrandNameProps } from "./brand-name";
+
+export function BrandName({ config, as: Tag = "span", className }: BrandNameProps) {
+  return (
+    <Tag className={cn("font-semibold tracking-tight", className)}>
+      {config.name}
+    </Tag>
+  );
+}
+```
+
+**Design notes:**
+- The polymorphic `as` prop lets callers render the brand name as a heading for landmark purposes (e.g., the marketing landing page `<h1>`) or as an inline `<span>` inside the nav bar — without duplicating the config read.
+- Default styling (`font-semibold tracking-tight`) is minimal and composable. Callers override via `className`.
+
+### `LegalFooter`
+
+**File:** `packages/brand/src/components/legal-footer.tsx`
+
+**Props interface:**
+
+```typescript
+import type { BrandConfig } from "../types/brand-config";
+
+export interface LegalFooterProps {
+  /** Brand configuration object. Required. */
+  config: BrandConfig;
+  /** Additional CSS classes for the outer container. */
+  className?: string;
+}
+```
+
+**Implementation:**
+
+```typescript
+// packages/brand/src/components/legal-footer.tsx
+import { cn } from "@enterprise/ui/lib/utils";
+import type { LegalFooterProps } from "./legal-footer";
+
+export function LegalFooter({ config, className }: LegalFooterProps) {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer
+      className={cn(
+        "flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm text-muted-foreground",
+        className,
+      )}
+    >
+      <span>
+        &copy; {currentYear} {config.legalName}. All rights reserved.
+      </span>
+
+      {config.privacyPolicyUrl ? (
+        <a
+          href={config.privacyPolicyUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-4 hover:text-foreground transition-colors"
+        >
+          Privacy Policy
+        </a>
+      ) : null}
+
+      {config.termsUrl ? (
+        <a
+          href={config.termsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-4 hover:text-foreground transition-colors"
+        >
+          Terms of Service
+        </a>
+      ) : null}
+    </footer>
+  );
+}
+```
+
+**Design notes:**
+- `currentYear` is computed at render time — no stale copyright years.
+- Policy links are conditionally rendered: when `privacyPolicyUrl` or `termsUrl` is absent from `BrandConfig`, no element is rendered (not an empty anchor).
+- `rel="noopener noreferrer"` is always applied to external links per security convention.
+- Styling uses semantic tokens (`text-muted-foreground`, `hover:text-foreground`) so the component adapts to light/dark mode automatically.
+
+### `defaultBrandConfig` (`src/config/default.ts`)
+
+```typescript
+// packages/brand/src/config/default.ts
+import type { BrandConfig } from "../types/brand-config";
+
+/**
+ * Fallback brand configuration for local development and test environments.
+ * Template adopters replace this with their own brand config when deploying.
+ * All required BrandConfig fields must have a value here — TypeScript will
+ * produce a compile error if a new required field is added to BrandConfig
+ * without updating this object.
+ */
+export const defaultBrandConfig: BrandConfig = {
+  name: "Enterprise Platform",
+  legalName: "Enterprise Platform Inc.",
+  logoUrl: "/brand/logo-full.svg",
+  logoMarkUrl: "/brand/logo-mark.svg",
+  privacyPolicyUrl: undefined,
+  termsUrl: undefined,
+};
+```
+
+The placeholder image paths (`/brand/logo-full.svg`, `/brand/logo-mark.svg`) reference SVG assets that must be committed to `ui/public/brand/` as part of the package scaffold. They are generic placeholder SVGs — template adopters replace them with their own assets.
+
+### Barrel export (`src/index.ts`)
+
+```typescript
+// packages/brand/src/index.ts
+
+// Types
+export type { BrandConfig } from "./types/brand-config";
+
+// Default config
+export { defaultBrandConfig } from "./config/default";
+
+// Components
+export { BrandLogo } from "./components/brand-logo";
+export type { BrandLogoProps } from "./components/brand-logo";
+
+export { BrandName } from "./components/brand-name";
+export type { BrandNameProps } from "./components/brand-name";
+
+export { LegalFooter } from "./components/legal-footer";
+export type { LegalFooterProps } from "./components/legal-footer";
+```
+
+---
+
+## Decision tree: brand vs. ui vs. core
+
+Use this tree when deciding where a new piece of code belongs. Answer each question top-to-bottom and stop at the first terminal node.
+
+```
+Is this code specific to one deployment's brand identity?
+│  (brand identity = logo, name, color palette, legal entity, brand-only features)
+│
+├── YES
+│    │
+│    ├── Does it render UI? (component, icon, styled text, image)
+│    │    │
+│    │    ├── YES → @enterprise/brand/components/
+│    │    │         Example: BrandLogo, BrandName, LegalFooter, brand-specific
+│    │    │         illustration, branded CTA button variant
+│    │    │
+│    │    └── NO
+│    │         │
+│    │         ├── Is it configuration? (name string, URL, color value, legal copy)
+│    │         │    │
+│    │         │    ├── YES → Add field to BrandConfig in @enterprise/contracts,
+│    │         │    │         then set value in packages/brand/src/config/default.ts
+│    │         │    │         (or a brand-specific config file for adopters)
+│    │         │    │
+│    │         │    └── NO
+│    │         │         │
+│    │         │         └── Is it a feature toggle tied to brand identity?
+│    │         │              (e.g., feature enabled ONLY for this brand)
+│    │         │              │
+│    │         │              ├── YES → packages/brand/src/config/features.ts
+│    │         │              │         Example: const BRAND_FEATURES = { aiEnabled: true }
+│    │         │              │
+│    │         │              └── NO → Contact architecture team before adding code
+│    │
+│    └── (If unsure whether it's brand-specific: ask "would every deployment
+│          need this?" — if YES, it is generic, not brand-specific)
+│
+└── NO (generic, needed by all deployments)
+     │
+     ├── Is it a generic UI primitive? (button, card, input, dialog, badge)
+     │    │
+     │    ├── YES → @enterprise/ui/components/
+     │    │         Example: Button, Card, Input, Select, Table
+     │    │
+     │    └── NO
+     │         │
+     │         ├── Is it business logic? (service, query, computation, workflow)
+     │         │    │
+     │         │    ├── YES → @enterprise/core/src/services/{feature}-service.ts
+     │         │    │         Example: createTenant(), getSubscription(), sendInvite()
+     │         │    │
+     │         │    └── NO
+     │         │         │
+     │         │         ├── Is it a data contract? (DTO, Zod schema, shared type)
+     │         │         │    │
+     │         │         │    ├── YES → @enterprise/contracts/src/dto/{domain}.ts
+     │         │         │    │         Example: createResourceSchema, BrandConfig,
+     │         │         │    │         ActionResult<T>
+     │         │         │    │
+     │         │         │    └── NO
+     │         │         │         │
+     │         │         │         └── Is it a table definition? (Drizzle schema)
+     │         │         │              │
+     │         │         │              ├── YES → @enterprise/db/src/schema/{domain}.ts
+     │         │         │              │         Example: tenants, profiles, resources
+     │         │         │              │
+     │         │         │              └── NO → Contact architecture team before adding code
+     │         │
+     │         └── Is it a Supabase client, auth helper, or env utility?
+     │              │
+     │              ├── YES → @enterprise/core/src/supabase/ or src/utils/
+     │              │
+     │              └── NO → Is it a page, layout, or Server Action?
+     │                        │
+     │                        ├── YES → ui/app/ or ui/features/{feature}/
+     │                        │
+     │                        └── NO → Contact architecture team before adding code
+
+Common misclassification examples:
+  "if (brand === 'acme') send email"     → WRONG: belongs in brand feature toggle,
+                                            not in @enterprise/core service
+  Hardcoded "© 2026 Acme Corp."          → WRONG: belongs in LegalFooter via BrandConfig,
+                                            not in a layout file
+  Logo path string in layout.tsx          → WRONG: belongs in defaultBrandConfig.logoUrl,
+                                            not hardcoded in ui/
+  Brand color hex in globals.css          → WRONG: belongs in brand theme config,
+                                            not in the shared stylesheet
+```
+
+---
+
+## AGENTS.md for `packages/brand/`
+
+> This is the complete content for `packages/brand/AGENTS.md`.
+
+```markdown
+# @enterprise/brand — Agent Instructions
+
+## Purpose
+
+Brand-specific presentational layer. This package holds the `defaultBrandConfig`,
+brand-aware components (`BrandLogo`, `BrandName`, `LegalFooter`), and the
+`BrandConfig` type re-export. It is the ONLY valid home for brand-specific
+TypeScript code in this monorepo.
+
+---
+
+## Critical Rules — Non-Negotiable
+
+### Dependency boundary (CI-enforced)
+
+- NEVER import from `@enterprise/core` — violations fail `pnpm check-boundaries` in CI.
+- NEVER import from `@enterprise/db` — same rule.
+- NEVER import from `@enterprise/web` — same rule as all packages.
+- You MAY import from `@enterprise/contracts` (for `BrandConfig` type and schema).
+- You MAY import from `@enterprise/ui` (for `cn()` and shadcn/ui primitives).
+
+If you add a forbidden import and CI fails, the error message will identify the
+violating file and the exact rule. Fix the import — do not silence the check.
+
+### Component rules
+
+- Components in this package MUST be purely presentational — no Server Actions,
+  no direct Supabase calls, no `"use server"` directive.
+- Components receive brand configuration via a `config: BrandConfig` prop.
+  They may additionally read from `BrandContext` when the Brand Abstraction Layer
+  is wired, but the prop always takes precedence.
+- Brand-specific feature toggles live in `src/config/features.ts`, NOT in
+  `@enterprise/core`. Feature toggles that apply to ALL deployments belong in the
+  Feature Flags package.
+
+### BrandConfig is the source of truth
+
+- `BrandConfig` is defined in `@enterprise/contracts`. Do NOT redefine it here.
+- `src/types/brand-config.ts` re-exports it — use that as the local import.
+- All config objects (including `defaultBrandConfig`) MUST satisfy `BrandConfig`.
+  TypeScript will error at build time if a required field is missing.
+
+---
+
+## Decision tree: where does this code go?
+
+```
+Is this code specific to one deployment's brand identity?
+│
+├── YES
+│    ├── Renders UI?         → src/components/
+│    ├── Configuration?      → BrandConfig field in @enterprise/contracts,
+│    │                         value in src/config/default.ts
+│    └── Feature toggle?     → src/config/features.ts
+│
+└── NO (generic, needed by all deployments)
+     ├── UI primitive?       → @enterprise/ui/components/
+     ├── Business logic?     → @enterprise/core/src/services/
+     ├── Data contract?      → @enterprise/contracts/src/dto/
+     └── Table definition?   → @enterprise/db/src/schema/
+```
+
+---
+
+## Concrete violation example
+
+**Violation:** A developer adds a "send welcome email with brand logo" feature
+and puts the email logic in `@enterprise/core/src/services/email-service.ts`,
+importing the logo URL from `@enterprise/brand`:
+
+```typescript
+// packages/core/src/services/email-service.ts  ← WRONG
+import { defaultBrandConfig } from "@enterprise/brand"; // ← violation
+
+export async function sendWelcomeEmail(email: string) {
+  await mailer.send({
+    logoUrl: defaultBrandConfig.logoUrl, // brand-specific data in core
+    to: email,
+  });
+}
+```
+
+**CI output:**
+
+```
+Boundary check failed:
+
+- packages/core/src/services/email-service.ts — packages/core MUST NOT import
+  @enterprise/brand — keep infrastructure brand-agnostic
+```
+
+**Correct resolution:** Pass the logo URL as a parameter to the service function,
+sourcing it at the call site (in `ui/` or via a brand config lookup):
+
+```typescript
+// packages/core/src/services/email-service.ts  ← CORRECT
+export async function sendWelcomeEmail(email: string, logoUrl: string) {
+  await mailer.send({ logoUrl, to: email });
+}
+
+// ui/features/onboarding/actions.ts  ← brand config consumed here
+import { defaultBrandConfig } from "@enterprise/brand";
+await sendWelcomeEmail(user.email, defaultBrandConfig.logoUrl);
+```
+
+---
+
+## Project structure
+
+```
+packages/brand/
+├── AGENTS.md
+├── package.json
+├── tsconfig.json
+└── src/
+    ├── index.ts                    # Barrel export
+    ├── types/
+    │   └── brand-config.ts         # Re-exports BrandConfig from @enterprise/contracts
+    ├── config/
+    │   ├── default.ts              # defaultBrandConfig — fallback for local dev
+    │   └── features.ts             # Brand-specific feature toggles (create when needed)
+    └── components/
+        ├── brand-logo.tsx          # Logotype component
+        ├── brand-name.tsx          # Display name component
+        └── legal-footer.tsx        # Copyright and policy links component
+```
+
+---
+
+## Commands
+
+```bash
+pnpm --filter @enterprise/brand typecheck    # TypeScript compilation
+pnpm --filter @enterprise/brand test         # Vitest unit tests
+pnpm check-boundaries                        # Full monorepo boundary check
+```
+
+---
+
+## QA checklist (before commit)
+
+- [ ] No import from `@enterprise/core` or `@enterprise/db` in any file
+- [ ] No `"use server"` directive anywhere in this package
+- [ ] Components receive `config: BrandConfig` as a prop
+- [ ] `BrandConfig` NOT redefined locally — re-exported from `@enterprise/contracts`
+- [ ] `defaultBrandConfig` satisfies `BrandConfig` (TypeScript error if not)
+- [ ] `pnpm check-boundaries` passes with no violations
+- [ ] `pnpm --filter @enterprise/brand typecheck` passes
+- [ ] Unit tests exist for component rendering (both variant paths for BrandLogo,
+      both optional-link states for LegalFooter)
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/brand/src/components/__tests__/`
+
+Tests use Vitest with a minimal React rendering setup (no Next.js App Router — this package has no Next.js dependency).
+
+#### `brand-logo.test.tsx`
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Renders `full` variant with `config.logoUrl` | `<img src>` equals `config.logoUrl`; `alt` equals `config.name` |
+| Renders `mark` variant with `config.logoMarkUrl` | `<img src>` equals `config.logoMarkUrl` when defined |
+| Renders `mark` variant falls back to `logoUrl` | When `logoMarkUrl` is absent, `<img src>` equals `config.logoUrl` |
+| Applies default width for `full` variant | `width` attribute equals `120` when not provided |
+| Applies default width for `mark` variant | `width` attribute equals `40` when not provided |
+| Merges `className` prop | Custom class appears in rendered element |
+
+#### `brand-name.test.tsx`
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Renders `config.name` as text content | Text node matches `config.name` |
+| Defaults to `<span>` element | Rendered tag is `span` |
+| Renders as `<h1>` when `as="h1"` | Rendered tag is `h1` |
+| Merges `className` prop | Custom class appears in rendered element |
+
+#### `legal-footer.test.tsx`
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Renders copyright with `config.legalName` and current year | Text contains `© {year} {legalName}` |
+| Renders Privacy Policy link when `privacyPolicyUrl` is set | Anchor with correct `href` and `target="_blank"` |
+| Renders Terms of Service link when `termsUrl` is set | Anchor with correct `href` and `target="_blank"` |
+| Does NOT render Privacy Policy link when `privacyPolicyUrl` is absent | No "Privacy Policy" anchor in DOM |
+| Does NOT render Terms of Service link when `termsUrl` is absent | No "Terms of Service" anchor in DOM |
+| Merges `className` prop | Custom class appears on footer element |
+
+#### `default.test.ts`
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| `defaultBrandConfig` satisfies `BrandConfig` schema | `brandConfigSchema.parse(defaultBrandConfig)` does not throw |
+| `defaultBrandConfig.name` is non-empty | `name` field is a non-empty string |
+| `defaultBrandConfig.legalName` is non-empty | `legalName` field is a non-empty string |
+| `defaultBrandConfig.logoUrl` is a non-empty string | `logoUrl` field is present |
+
+### Boundary tests (CI)
+
+The boundary check runs as part of the `lint` CI job via `pnpm check-boundaries` (which calls `node scripts/check-boundaries.mjs`). No additional test setup is required.
+
+To verify the new rules locally:
+
+```bash
+# Verify the boundary check passes with no violations:
+pnpm check-boundaries
+
+# Verify the new rules catch violations (smoke test — revert after):
+# 1. Temporarily add to packages/core/src/index.ts:
+#    import {} from "@enterprise/brand";
+# 2. Run:
+pnpm check-boundaries
+# Expected output:
+# Boundary check failed:
+# - packages/core/src/index.ts — packages/core MUST NOT import @enterprise/brand
+#   — keep infrastructure brand-agnostic
+# 3. Revert the temporary import.
+```
+
+**CI job placement:** `check-boundaries.mjs` is already invoked in the `lint` job of `.github/workflows/`. No new job is needed — the script is called via the `pnpm check-boundaries` script defined in the root `package.json`. Verify this entry exists:
+
+```json
+// root package.json scripts
+{
+  "check-boundaries": "node scripts/check-boundaries.mjs"
+}
+```
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Dedicated `packages/brand/` vs. sub-path in `@enterprise/ui` | Dedicated package | Brand sub-path in `@enterprise/ui` | Separate package makes the dependency direction unambiguous — `check-boundaries.mjs` can enforce it mechanically; mixing brand code with generic primitives in `@enterprise/ui` would prohibit the `ui → brand` direction enforcement |
+| `check-boundaries.mjs` script vs. Biome/ESLint import plugin | Existing script | New lint plugin | The script already runs in CI and requires no ecosystem dependency; a Biome import plugin is not yet mature; consistency with the existing enforcement mechanism is preferred for MVP |
+| `BrandConfig` in `@enterprise/contracts` vs. defined in `@enterprise/brand` | Defined in `@enterprise/contracts` | Defined in brand package | `@enterprise/contracts` is the single source of truth for all data shapes; `@enterprise/brand` re-exports the type — this keeps the dependency graph acyclic and allows other consumers (e.g., a server-side brand loader) to type-check against `BrandConfig` without depending on the brand package |
+| `@enterprise/brand` may import `@enterprise/ui` | Allowed | Forbidden | Brand components need `cn()` and may use shadcn/ui primitives; the reverse direction (`ui → brand`) is explicitly blocked by CI |
+| `@enterprise/brand` may import `@enterprise/core` | Forbidden | Allowed | Brand components must be purely presentational; service calls belong in Server Actions in `ui/`, not in the brand package; enforced in CI and by the absence of `@enterprise/core` from `package.json` dependencies |
+| Brand config as compile-time constant vs. DB record | Compile-time constant (MVP) | DB-driven record | Simplest approach; avoids schema changes in `@enterprise/db`; runtime switching is the Brand Abstraction Layer's responsibility |
+| Plain `<img>` vs. `next/image` in `BrandLogo` | Plain `<img>` | `next/image` | `@enterprise/brand` must not depend on Next.js; the consuming `ui/` layout can wrap or replace `BrandLogo` with a `next/image`-based override if needed |
+| Brand-specific feature toggles | `packages/brand/src/config/features.ts` | `@enterprise/core` feature flags | Feature toggles tied to a single brand's identity belong in the brand package — prevents `if (brand === 'x')` branches in the service layer |
+| `@enterprise/brand` omitted from `packages/ui/`, `packages/core/`, `packages/db/`, `packages/contracts/` `package.json` dependencies | Intentionally omitted | Allowed as an optional dep | TypeScript cannot resolve an import from a package not listed in `dependencies`; IDE-level enforcement before CI runs, in addition to the boundary script — defense in depth |
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Developers bypass `check-boundaries.mjs` via `--no-verify` git hook | Brand leaks reach `main` | Script runs in CI `lint` job, not just as a git hook — local bypass does not prevent CI failure; PR cannot be merged while CI is red |
+| `@enterprise/brand` accumulates business logic over time (creeping complexity) | Core isolation guarantee erodes | `packages/brand/AGENTS.md` explicitly forbids Server Actions and Supabase calls; PR reviewers are directed to verify this rule; follow-up: add a negative assertion to `check-boundaries.mjs` that blocks Supabase client imports from `packages/brand/` |
+| `BrandConfig` schema drift between `@enterprise/contracts` and `defaultBrandConfig` | Runtime brand config errors; TypeScript is the safety net | `defaultBrandConfig` is typed `const x: BrandConfig = { ... }` — TypeScript compile error when a required field is added to `BrandConfig` without updating `defaultBrandConfig`; CI runs `pnpm typecheck` |
+| Template adopters create parallel packages (`packages/brand-acme/`) that reintroduce leaks | Multiple brand packages pollute the boundary model | `AGENTS.md` and the developer guide document the single-package pattern; `check-boundaries.mjs` can be extended to enforce that any `packages/brand-*` workspace follows the same allowlist rules |
+| `@enterprise/ui` maintainers import brand components for convenience | `ui → brand` dependency direction inverted | CI violation rule explicitly blocks `@enterprise/ui → @enterprise/brand`; error message explains the direction; absence of `@enterprise/brand` from `packages/ui/package.json` prevents TypeScript resolution in IDE |
+| Brand isolation enforced at build time but not visible in IDE until compile | Developer confusion during authoring | The absence of `@enterprise/brand` from forbidden packages' `dependencies` fields means TypeScript shows "Cannot find module" in the IDE before CI runs — builds on the package.json-as-enforcer pattern already used by `@enterprise/contracts` (zod only) |
+| `BrandLogo` renders broken image in local dev (placeholder SVG paths missing) | Poor local DX | Two placeholder SVG files (`logo-full.svg`, `logo-mark.svg`) are committed to `ui/public/brand/` as part of the package scaffold; `defaultBrandConfig` paths reference them |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | `BrandConfig` Zod schema and type added to `packages/contracts/src/dto/brand.ts`; exported from `packages/contracts/src/index.ts` | None |
+| 2 | `packages/brand/` scaffold: `package.json`, `tsconfig.json`, `AGENTS.md`, `src/index.ts`, `src/types/brand-config.ts` | Phase 1 |
+| 3 | `packages/brand/src/config/default.ts` with `defaultBrandConfig`; placeholder SVG assets in `ui/public/brand/` | Phase 1 |
+| 4 | `BrandLogo`, `BrandName`, `LegalFooter` components with unit tests | Phases 2–3 |
+| 5 | `scripts/check-boundaries.mjs` updated with new `packages/brand` allowlist entry and two negative rules; smoke test verified locally | Phase 2 |
+| 6 | `ui/package.json` adds `"@enterprise/brand": "workspace:*"`; `ui/next.config.ts` adds `"@enterprise/brand"` to `transpilePackages` | Phases 2, 5 |
+| 7 | Root `AGENTS.md` dependency direction table updated; `packages/brand/AGENTS.md` committed | Phase 2 |
+| 8 | Developer guide entry written; production readiness checklist verified | Phases 1–7 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| New `@enterprise/brand` package vs. extending `@enterprise/ui` with brand sub-path | New dedicated `packages/brand/` | Separate package allows `check-boundaries.mjs` to enforce the direction mechanically; conflating brand-specific assets with generic primitives in `@enterprise/ui` would make the `ui → brand` rule unenforceable |
+| `check-boundaries.mjs` script vs. ESLint/Biome import plugin | Existing `check-boundaries.mjs` script | Script already exists and runs in CI; Biome import plugin ecosystem is not yet mature enough for a production-critical enforcement mechanism; MVP consistency wins |
+| `@enterprise/brand` allowed to import `@enterprise/ui`? | Yes | Brand components need `cn()` and may compose shadcn/ui primitives; the reverse direction is forbidden and CI-enforced |
+| `@enterprise/brand` allowed to import `@enterprise/core`? | No — explicitly forbidden | Brand components are purely presentational; data needs are fulfilled by props or context, never by direct service calls; enforced in CI and package.json |
+| `BrandConfig` lives in `@enterprise/contracts` or `@enterprise/brand`? | `@enterprise/contracts` — re-exported from brand | Contracts is the single source of truth for all data shapes; placing `BrandConfig` there allows future consumers (e.g., a DB-backed brand loader) to type-check without depending on the brand package |
+| Plain `<img>` vs. `next/image` in `BrandLogo`? | Plain `<img>` | `@enterprise/brand` must not depend on Next.js; adopters may wrap or replace `BrandLogo` with a `next/image`-based component in `ui/` |
+| Brand-specific feature toggles location | `packages/brand/src/config/features.ts` | Prevents `if (brand === 'x')` conditionals in `@enterprise/core` services; keeps feature toggles colocated with the brand they govern |
+| `@enterprise/ui` omits `@enterprise/brand` from its `package.json` dependencies | Yes — intentional omission | TypeScript cannot resolve an import that is not listed in `package.json`; this adds IDE-level enforcement before CI runs; defense in depth alongside the boundary script |
+| Who owns the decision tree? | Architecture team; documented in `packages/brand/AGENTS.md` and linked from the root `AGENTS.md` | Decision tree must be discoverable at the point of contribution; colocation with the brand package maximises visibility for new contributors |
+| Placeholder SVG assets location | `ui/public/brand/` | Next.js serves `public/` as static assets; `defaultBrandConfig` references `/brand/logo-full.svg` — a path directly accessible to the dev server without additional configuration |
+
+---
+
+## File inventory
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `packages/brand/AGENTS.md` | Brand package agent instructions, decision tree, boundary rules, violation example |
+| `packages/brand/package.json` | Package manifest: `@enterprise/brand`, deps, exports, scripts |
+| `packages/brand/tsconfig.json` | TypeScript config extending root tsconfig |
+| `packages/brand/src/index.ts` | Barrel export |
+| `packages/brand/src/types/brand-config.ts` | Re-exports `BrandConfig` from `@enterprise/contracts` |
+| `packages/brand/src/config/default.ts` | `defaultBrandConfig` — typed fallback for local dev |
+| `packages/brand/src/components/brand-logo.tsx` | `BrandLogo` component |
+| `packages/brand/src/components/brand-name.tsx` | `BrandName` component |
+| `packages/brand/src/components/legal-footer.tsx` | `LegalFooter` component |
+| `packages/brand/src/components/__tests__/brand-logo.test.tsx` | Unit tests for `BrandLogo` |
+| `packages/brand/src/components/__tests__/brand-name.test.tsx` | Unit tests for `BrandName` |
+| `packages/brand/src/components/__tests__/legal-footer.test.tsx` | Unit tests for `LegalFooter` |
+| `packages/brand/src/config/__tests__/default.test.ts` | Validates `defaultBrandConfig` satisfies `BrandConfig` |
+| `packages/contracts/src/dto/brand.ts` | `brandConfigSchema` + `BrandConfig` type (owned by Brand Abstraction Layer RFC; referenced here) |
+| `ui/public/brand/logo-full.svg` | Placeholder full logotype SVG for local dev |
+| `ui/public/brand/logo-mark.svg` | Placeholder mark/icon SVG for local dev |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `scripts/check-boundaries.mjs` | Add `"packages/brand"` allowlist entry; extend `ui` allowlist with `@enterprise/brand`; add two negative rules (infrastructure → brand, ui → brand) |
+| `ui/package.json` | Add `"@enterprise/brand": "workspace:*"` to `dependencies` |
+| `ui/next.config.ts` | Add `"@enterprise/brand"` to `transpilePackages` array |
+| `packages/contracts/src/index.ts` | Re-export `BrandConfig` and `brandConfigSchema` from `./dto/brand` |
+| `AGENTS.md` (root) | Update dependency direction table to include `@enterprise/brand` row; link to `packages/brand/AGENTS.md` |
+| `docs/adr/004-package-dependencies.md` | Add `@enterprise/brand` to allowed dependencies and forbidden dependencies tables |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/deployment-provider-decoupling/prd.md
+++ b/docs/features/deployment-provider-decoupling/prd.md
@@ -1,0 +1,307 @@
+---
+title: "Deployment provider decoupling PRD"
+description: "Makes the Enterprise Platform Template deployable to different hosting providers (Vercel, Docker/self-hosted, AWS, Cloudflare) without requiring changes in the application layer."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Deployment provider decoupling PRD
+
+## Purpose
+
+Define implementation-ready requirements for making the Enterprise Platform Template provider-agnostic at the deployment layer. Today the template ships Vercel-first by default; adopters who want to deploy to Docker, AWS, or Cloudflare must reverse-engineer the deployment coupling themselves. This PRD establishes a configuration-based approach — not a code-level abstraction — so that switching deployment targets requires only config and environment changes, never application code changes.
+
+## Scope
+
+- Included: Next.js standalone build output for Docker/self-hosted, Dockerfile and docker-compose for local dev and production self-hosting, `next.config.ts` conditional configuration driven by a `DEPLOY_TARGET` environment variable, image optimization strategy per provider, GitHub Actions workflow templates for Vercel (existing) and Docker/self-hosted (new), environment variable documentation per provider, middleware compatibility notes for non-Vercel runtimes.
+- Excluded: AWS CDK or Pulumi infrastructure-as-code modules (follow-up), Cloudflare Pages/Workers adapter (follow-up), Kubernetes Helm charts (follow-up), multi-region routing or edge caching strategies per provider, Supabase hosting decoupling (separate feature), cost optimization guidance per provider, automated provider detection at runtime.
+
+---
+
+## Problem
+
+The Enterprise Platform Template is currently Vercel-first: `vercel.json` defines the build pipeline, `next.config.ts` is optimized for Vercel's image CDN and Edge Runtime, and environment variable documentation only describes the Vercel dashboard workflow. When an adopter wants to deploy to AWS ECS, a VPS, or a container platform, they must:
+
+1. Discover that Next.js requires `output: "standalone"` for Docker — this is not obvious from the template.
+2. Write a Dockerfile from scratch without guidance on monorepo workspace resolution.
+3. Figure out how to replicate Vercel's image optimization layer (missing outside Vercel).
+4. Translate `vercel.json` secrets into provider-specific environment injection patterns.
+5. Recreate a CI/CD pipeline that the template does not provide for non-Vercel targets.
+
+Each adopter solves the same set of problems in isolation. The cost is high, the results are inconsistent, and the template's value proposition — "start with a solid foundation, not a blank slate" — breaks down at the deployment boundary.
+
+The Vercel coupling in this template is primarily configuration-level (lighter than the Supabase coupling), which means the fix is also configuration-level: add the right defaults, ship a Dockerfile, and document the env patterns per provider. No application code changes are required.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| Template adopter (Docker/self-hosted) | Run `docker compose up` and have a working application without reverse-engineering Next.js standalone builds |
+| Template adopter (AWS) | A CI/CD template and build output they can wire to ECS, Fargate, or App Runner without starting from scratch |
+| Template adopter (Cloudflare) | Clarity on what works and what does not in the Cloudflare Pages environment |
+| Template adopter (Vercel) | Zero regression — Vercel must remain the default and fully supported target |
+| Platform engineering | A `DEPLOY_TARGET` convention that keeps target-specific config isolated so it does not pollute application code |
+
+## Goals
+
+- Enable adopters to deploy to Docker/self-hosted environments by running a single `docker compose up` command with a populated `.env` file.
+- Keep Vercel as the default and reference deployment target with no regressions.
+- Isolate all deployment-target-specific configuration in `vercel.json`, `Dockerfile`, `docker-compose.yml`, and `next.config.ts` conditionals — never in application source files.
+- Document environment variable patterns for each supported provider so adopters can configure secrets correctly without guesswork.
+- Ship GitHub Actions workflow templates for Docker/self-hosted (build, push to registry, deploy) alongside the existing Vercel-managed CI.
+
+---
+
+## MVP scope
+
+### Core capabilities
+
+**1. Next.js standalone build output**
+
+Add `output: "standalone"` to `next.config.ts` when `DEPLOY_TARGET` is set to `docker` or `self-hosted`. Standalone output bundles only the code needed to run the server (no `node_modules` duplication), making Docker images dramatically smaller. Vercel ignores this field and continues to use its own build pipeline.
+
+**2. Dockerfile for the `ui` workspace**
+
+Provide a production-ready multi-stage `Dockerfile` at the monorepo root targeting the `@enterprise/web` Next.js application. Stages: `deps` (install with pnpm), `builder` (compile with turbo), `runner` (copy standalone output, minimal image). The runner stage uses `node:20-alpine`, sets `NODE_ENV=production`, and runs as a non-root user.
+
+**3. docker-compose.yml for local dev and self-hosted**
+
+Provide a `docker-compose.yml` that starts the Next.js application container. Local dev profile: mounts `.env.local`, exposes port 3000. Production/self-hosted profile: reads from a `.env.production` file, configures restart policy. No Supabase containers are included — the template uses Supabase Cloud or the adopter's own Supabase instance.
+
+**4. `next.config.ts` conditional configuration**
+
+Introduce a `DEPLOY_TARGET` environment variable with values `vercel` (default), `docker`, `self-hosted`, and `cloudflare` (stub only in MVP). The `next.config.ts` file reads this variable and applies target-specific settings:
+
+| Setting | `vercel` | `docker` / `self-hosted` | `cloudflare` (stub) |
+|---------|----------|--------------------------|---------------------|
+| `output` | (unset — Vercel default) | `"standalone"` | (follow-up) |
+| `images.loader` | `"default"` (Vercel CDN) | `"custom"` with `loaderFile` | (follow-up) |
+| `images.unoptimized` | `false` | `false` (custom loader active) | `true` (stub) |
+| `experimental.serverActions` | (default) | (default) | (default) |
+
+**5. Image optimization strategy per provider**
+
+Next.js `<Image />` optimization is handled natively by Vercel's CDN. Outside Vercel, a custom image loader is required. MVP ships a `sharp`-based custom loader file at `ui/lib/image-loader.ts` that proxies optimization through the Next.js server itself (no external CDN dependency). This loader is activated automatically when `DEPLOY_TARGET=docker` or `self-hosted`. Adopters who want a CDN (Cloudflare Images, imgix, AWS CloudFront + Lambda@Edge) can swap the loader file.
+
+**6. GitHub Actions workflow for Docker/self-hosted**
+
+Add `.github/workflows/deploy-docker.yml`: builds the Docker image, tags with the Git SHA and `latest`, pushes to GitHub Container Registry (GHCR), and triggers a deploy webhook or SSH command to the target host. The workflow is disabled by default (uses `workflow_dispatch` trigger) so it does not interfere with adopters using Vercel. Environment secrets are documented in comments inside the workflow file.
+
+**7. Environment variable documentation per provider**
+
+Extend `docs/developer-guide/environment-guide.mdx` with a provider-specific section documenting how to inject environment variables for each target:
+
+- Vercel: dashboard + `vercel.json` secrets reference (already documented, link only)
+- Docker: `.env` file mounted at runtime or `--env-file` flag; `docker-compose.yml` `env_file` directive
+- Self-hosted (VPS/systemd): environment file at `/etc/enterprise-platform/env`, loaded by systemd unit
+- AWS: ECS task definition `environment` and `secrets` blocks referencing AWS Secrets Manager
+- Cloudflare Pages: `wrangler.toml` `[vars]` + `wrangler secret put` for sensitive values
+
+**8. Middleware compatibility**
+
+Verify and document that `ui/middleware.ts` (Supabase session refresh) runs correctly in Node.js runtime (Docker/self-hosted). The middleware must not use Vercel-specific APIs (`waitUntil`, Edge Config). If any Vercel-specific imports are found, they must be guarded with `DEPLOY_TARGET` conditionals or extracted behind an adapter.
+
+### Out of scope (MVP)
+
+- AWS CDK, Pulumi, or Terraform infrastructure-as-code for AWS deployment.
+- Cloudflare Workers/Pages full adapter (needs `@cloudflare/next-on-pages` — complex, follow-up).
+- Kubernetes manifests or Helm charts.
+- Multi-region deployment strategies and edge caching per provider.
+- Automated rollback and blue/green deployment pipelines.
+- Cost estimation or provider comparison guides.
+- Supabase self-hosting inside Docker Compose (adopters use Supabase Cloud or their own Supabase instance).
+- Automated provider detection — `DEPLOY_TARGET` is always set explicitly by the adopter.
+
+---
+
+## User stories and acceptance criteria (from the template ADOPTER perspective)
+
+### US-1: Adopter deploys to Docker/self-hosted with docker compose up
+
+**As** a template adopter who wants to self-host, **I want** to run `docker compose up` with a populated `.env` file so I can have a running application without writing build infrastructure from scratch.
+
+Acceptance criteria:
+1. The repository includes a `Dockerfile` at the monorepo root that builds the Next.js application using the standalone output mode.
+2. The repository includes a `docker-compose.yml` that references the built image and accepts environment variables from an `.env` file.
+3. Running `docker compose up` with a valid `.env` file starts the application on port 3000 and serves the application correctly.
+4. The built Docker image is smaller than 500 MB (standalone output removes unused `node_modules`).
+5. The container runs as a non-root user.
+6. The `README` or `docs/deployment/docker.md` includes the exact steps: copy `.env.example` → fill values → `docker compose up`.
+
+### US-2: Adopter uses Vercel with no regressions
+
+**As** a template adopter deploying to Vercel, **I want** the default behavior to be unchanged so that the new Docker support does not break my existing Vercel deployment.
+
+Acceptance criteria:
+1. When `DEPLOY_TARGET` is unset or set to `vercel`, `next.config.ts` does not add `output: "standalone"`.
+2. Image optimization uses Vercel's default CDN loader (no custom `loaderFile`).
+3. `vercel.json` remains unchanged and the Vercel deployment continues to work via `pnpm build`.
+4. The `ci.yml` GitHub Actions workflow is unaffected by new Docker workflow files.
+5. No new required environment variables are added for Vercel adopters.
+
+### US-3: Adopter configures environment variables for Docker deployment
+
+**As** a template adopter deploying to Docker/self-hosted, **I want** clear documentation on which environment variables to set and how to inject them so I do not have to reverse-engineer the `vercel.json` secrets configuration.
+
+Acceptance criteria:
+1. `docs/developer-guide/environment-guide.mdx` includes a "Docker / self-hosted" section listing all required environment variables with their expected values for production.
+2. The section explains how to use `.env` files with Docker Compose (`env_file` directive).
+3. The section notes that `DEPLOY_TARGET=docker` must be set so `next.config.ts` applies the correct build configuration.
+4. A `.env.docker.example` file is provided in the repository with placeholder values and descriptive comments for every required variable.
+5. The documentation warns about variables that must NOT be `NEXT_PUBLIC_` for security in self-hosted environments (e.g., service role keys).
+
+### US-4: Adopter uses GitHub Actions to build and push a Docker image
+
+**As** a template adopter with a self-hosted server, **I want** a GitHub Actions workflow that builds and pushes my Docker image to a registry so I can automate deployment without writing the workflow from scratch.
+
+Acceptance criteria:
+1. `.github/workflows/deploy-docker.yml` exists and is triggered by `workflow_dispatch` (manual) by default.
+2. The workflow builds the Docker image using the monorepo `Dockerfile`.
+3. The workflow tags the image with the Git SHA and `latest`.
+4. The workflow pushes the image to GitHub Container Registry (GHCR) using `GITHUB_TOKEN` (no extra credentials required for GHCR).
+5. The workflow includes commented-out steps and documentation for: triggering a deploy webhook, SSH-based pull-and-restart, and AWS ECS service update.
+6. The workflow file includes inline comments explaining every secret that must be added to GitHub repository secrets.
+
+### US-5: Adopter understands image optimization behavior outside Vercel
+
+**As** a template adopter deploying to Docker/self-hosted, **I want** image optimization to work out of the box so that `<Image />` components do not throw errors or degrade performance unexpectedly.
+
+Acceptance criteria:
+1. When `DEPLOY_TARGET=docker` or `self-hosted`, `next.config.ts` activates the custom `sharp`-based image loader at `ui/lib/image-loader.ts`.
+2. `<Image />` components render correctly and optimize images through the Next.js server's own optimization pipeline.
+3. The documentation explains the difference between Vercel's CDN-based optimization and the server-side `sharp` optimization, and notes the performance tradeoff (CPU on server vs. Vercel CDN).
+4. The documentation notes that adopters can replace `ui/lib/image-loader.ts` with a CDN-specific loader (Cloudflare Images, imgix) without changing any application code.
+5. The `sharp` package is listed as an optional peer dependency with installation instructions for the Docker image.
+
+### US-6: Adopter understands middleware compatibility
+
+**As** a template adopter deploying outside Vercel, **I want** to know whether the middleware layer works in a Node.js runtime so that authentication session management does not break silently.
+
+Acceptance criteria:
+1. `docs/deployment/non-vercel-notes.md` documents which Next.js middleware features are used and whether they are Vercel-specific.
+2. The Supabase session refresh middleware (`ui/middleware.ts`) is verified to run in Node.js runtime (not requiring Edge Runtime).
+3. If any Vercel-specific runtime APIs are found in middleware, they are extracted behind a `DEPLOY_TARGET` conditional with a documented fallback.
+4. The E2E test suite passes when run against a Docker-built image, confirming middleware behaves correctly.
+
+### US-7: Adopter understands how to configure environment variables for AWS
+
+**As** a template adopter deploying to AWS ECS or Fargate, **I want** documentation on how to inject environment variables through ECS task definitions and Secrets Manager so I do not have to translate Vercel patterns manually.
+
+Acceptance criteria:
+1. `docs/developer-guide/environment-guide.mdx` includes an "AWS ECS / Fargate" section.
+2. The section shows a representative ECS task definition snippet with `environment` (public vars) and `secrets` (sensitive vars from Secrets Manager) blocks for all required variables.
+3. The section notes that `DEPLOY_TARGET=self-hosted` should be set in the ECS task definition environment so the standalone build configuration is applied.
+4. The section references the AWS Secrets Manager ARN pattern for each secret variable.
+5. The section notes that `NEXT_PUBLIC_` variables must be set at build time (baked into the image), not at runtime — and explains how to handle this with build arguments in the Dockerfile.
+
+---
+
+## Success metrics
+
+- Docker deployment adoption: at least 30% of new adopters (based on template usage telemetry, if available) successfully run the Docker path within their first week without opening a support issue.
+- Zero regressions on Vercel: the `ci.yml` pipeline continues to pass on all pull requests with no changes required from Vercel adopters.
+- Docker image size under 500 MB for the standalone Next.js build.
+- Time-to-first-deploy for a Docker adopter: under 30 minutes following the documentation, measured by internal dogfooding before release.
+- Documentation completeness: all environment variables listed in `vercel.json` have corresponding entries in the Docker and AWS sections of the environment guide.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `NEXT_PUBLIC_` variables baked at build time break Docker image reuse across environments | Document clearly that `NEXT_PUBLIC_` vars are embedded at build time; provide a build-arg pattern in the Dockerfile and note the implication for adopters who want a single image across staging and production |
+| `sharp` native binary is architecture-dependent (arm64 vs amd64) | Use multi-platform Docker builds (`--platform linux/amd64,linux/arm64`) in the GitHub Actions workflow; document the `--platform` flag |
+| Middleware inadvertently uses Vercel Edge Runtime APIs | Audit middleware before MVP ships; add a CI check (`grep -r "waitUntil\|@vercel/edge"`) to catch regressions |
+| Standalone build output omits files needed by a workspace package | Test the full build in CI with `DEPLOY_TARGET=docker` before release; list known omission patterns in the docs |
+| Adopters set `DEPLOY_TARGET=docker` but forget to rebuild the image | Document that `DEPLOY_TARGET` affects the build output, not just runtime behavior; the Dockerfile's `ARG DEPLOY_TARGET` makes this explicit |
+| `vercel.json` secrets pattern misleads adopters into thinking secrets are injected at runtime | Add a comment in `vercel.json` clarifying that secrets are Vercel-specific and pointing to the provider-agnostic env guide |
+| Docker Compose file used in production without hardening | Add a comment in `docker-compose.yml` warning that the production profile is a starting point and recommends a reverse proxy (nginx/Caddy) in front of the container |
+
+---
+
+## Traceability
+
+### Audit events
+
+(N/A for this feature — no user-facing mutations. Deployment is an infrastructure concern with no audit trail in the application database.)
+
+### Sentry
+
+Configuration considerations per provider:
+
+- **Vercel**: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` are set in the Vercel dashboard as environment variables. Source maps are uploaded during `vercel build` automatically via `withSentryConfig`. No changes needed.
+- **Docker / self-hosted**: The same Sentry environment variables must be injected at build time (not runtime) because `withSentryConfig` uploads source maps during `next build`. In the Dockerfile, these are accepted as `ARG` build arguments and passed to `next build`. If source map upload is not desired (e.g., no Sentry subscription), `SENTRY_AUTH_TOKEN` can be omitted — `withSentryConfig` is configured with `silent: true` and does not fail the build.
+- **AWS ECS**: Source map upload happens in the CI build step before the image is pushed. Secrets Manager is not required for Sentry build-time args — they should be CI secrets (GitHub Actions secrets), not runtime secrets in the task definition.
+- **Runtime DSN**: `NEXT_PUBLIC_SENTRY_DSN` is a build-time public variable baked into the client bundle. It must be set as a Docker `--build-arg` when building for any non-Vercel target.
+
+### Seed data
+
+(N/A — this feature adds no database schema changes and requires no seed data.)
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| Run `docker compose up` with valid `.env` file | Adopter (local shell) | Application starts on port 3000; login page loads; Supabase connection succeeds |
+| Authenticate via the login page on Docker build | E2E test user | Auth flow completes; user reaches `/dashboard`; session persists across page navigation |
+| Upload an image in the Docker-built app | E2E test user | Image stored via Supabase Storage; `<Image />` renders via the custom `sharp` loader without errors |
+| Navigate all protected routes on Docker build | E2E test user | No middleware errors; session refresh works; protected pages render correctly |
+| Run `pnpm build` with `DEPLOY_TARGET=vercel` (unset) | CI pipeline | Build completes without `output: "standalone"` in the output; no regressions |
+| Run `pnpm build` with `DEPLOY_TARGET=docker` | CI pipeline | Build completes with `output: "standalone"`; `.next/standalone` directory exists |
+
+### External adapters
+
+| Target | Abstraction | Configuration entry point | Notes |
+|--------|-------------|--------------------------|-------|
+| Vercel | `vercel.json` + default `next.config.ts` | `vercel.json` secrets, Vercel dashboard | Default target; no `DEPLOY_TARGET` required |
+| Docker / self-hosted | `Dockerfile` + `docker-compose.yml` + `DEPLOY_TARGET=docker` | `.env` file or `--env-file` flag | Standalone build; `sharp` image loader |
+| AWS ECS / Fargate | ECS task definition + `DEPLOY_TARGET=self-hosted` | AWS Secrets Manager + task definition `environment` block | Image built and pushed via CI; runtime vars from Secrets Manager |
+| Cloudflare Pages | `@cloudflare/next-on-pages` (follow-up) | `wrangler.toml` + `wrangler secret put` | MVP ships documentation stub only; full adapter is follow-up |
+
+Image optimization adapters:
+
+| Provider | Loader | Activation |
+|----------|--------|------------|
+| Vercel | Built-in Vercel CDN (`"default"`) | Default when `DEPLOY_TARGET` is unset or `vercel` |
+| Docker / self-hosted | `ui/lib/image-loader.ts` (`sharp`-based, server-side) | Activated when `DEPLOY_TARGET=docker` or `self-hosted` |
+| Cloudflare Images | Custom loader (adopter-provided) | Replace `ui/lib/image-loader.ts`; no app code changes needed |
+| imgix / CloudFront | Custom loader (adopter-provided) | Replace `ui/lib/image-loader.ts`; no app code changes needed |
+
+### Production readiness
+
+- [ ] `Dockerfile` builds successfully in CI with `DEPLOY_TARGET=docker` and produces a `.next/standalone` output
+- [ ] Docker image size verified under 500 MB in CI artifact step
+- [ ] Container runs as non-root user (verified with `docker inspect` in CI)
+- [ ] `docker-compose.yml` starts the application successfully with a valid `.env` file
+- [ ] `next.config.ts` conditional logic unit-tested: verify `output: "standalone"` is set for `docker`/`self-hosted` and absent for `vercel`
+- [ ] Custom `sharp` image loader (`ui/lib/image-loader.ts`) tested with representative image URL in Docker build
+- [ ] `sharp` native binary builds correctly for `linux/amd64` in the Docker multi-stage build
+- [ ] Middleware (`ui/middleware.ts`) verified to contain no Vercel-specific runtime imports
+- [ ] E2E suite passes against Docker-built image in CI
+- [ ] `.github/workflows/deploy-docker.yml` manually triggered and verified to push image to GHCR
+- [ ] `docs/developer-guide/environment-guide.mdx` updated with Docker, AWS ECS, and Cloudflare sections
+- [ ] `.env.docker.example` committed with all required variables and descriptive comments
+- [ ] `docs/deployment/docker.md` committed with step-by-step instructions for local dev and self-hosted production
+- [ ] `docs/deployment/non-vercel-notes.md` committed documenting middleware compatibility findings
+- [ ] `DEPLOY_TARGET` variable added to `turbo.json` `globalEnv` so Turborepo invalidates cache on change
+- [ ] Vercel CI pipeline verified to still pass with no changes to `.github/workflows/ci.yml`
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Use an explicit `DEPLOY_TARGET` env var vs. auto-detecting the runtime | Explicit `DEPLOY_TARGET` | Auto-detection is fragile (Vercel sets `VERCEL=1`, but Docker has no equivalent signal); explicit opt-in is clear and deliberate |
+| Default target when `DEPLOY_TARGET` is unset | `vercel` (Vercel behavior) | Vercel is the current default; unset = no change in behavior for existing adopters; no regressions |
+| `output: "standalone"` always-on vs. gated on `DEPLOY_TARGET` | Gated on `DEPLOY_TARGET=docker` or `self-hosted` | Vercel does not need standalone output and benefits from its own build pipeline; always-on would add an unused `.next/standalone` artifact to all Vercel builds |
+| Image optimization for Docker: `unoptimized: true` vs. custom `sharp` loader | Custom `sharp`-based server-side loader | `unoptimized: true` disables optimization entirely, degrading performance; the `sharp` loader keeps optimization without Vercel dependency |
+| Dockerfile location: monorepo root vs. `ui/` workspace | Monorepo root | The build context must include all workspace packages (`packages/core`, `packages/db`, etc.); a root Dockerfile with `pnpm -r` workspace install is the correct pattern for a monorepo |
+| Docker Compose Supabase containers: include vs. exclude | Exclude | The template uses Supabase Cloud; including Supabase containers in docker-compose adds significant complexity (volumes, migrations, seed) that is out of scope for MVP; local dev uses `supabase start` from the Supabase CLI |
+| GitHub Actions Docker workflow trigger: on push vs. `workflow_dispatch` | `workflow_dispatch` (manual) by default | Most adopters will not want automated Docker deploys without first configuring registry credentials and deploy targets; manual trigger prevents accidental runs on first fork |
+| Container registry: Docker Hub vs. GHCR vs. adopter-defined | Default to GHCR | GHCR uses `GITHUB_TOKEN` — no extra credentials needed; adopters can change the registry in one line; Docker Hub requires a secret and rate-limits unauthenticated pulls |
+| `NEXT_PUBLIC_` variables baked at build vs. runtime injection | Document clearly; provide `ARG` pattern in Dockerfile | This is a Next.js constraint, not a template choice; the key deliverable is clear documentation and a Dockerfile `ARG` pattern so adopters understand the implication |
+| Cloudflare adapter: include in MVP vs. follow-up | Follow-up | `@cloudflare/next-on-pages` has significant compatibility constraints with App Router features used in this template (Server Actions, Route Handlers); shipping a broken adapter is worse than shipping a documented stub |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/deployment-provider-decoupling/rfc.md
+++ b/docs/features/deployment-provider-decoupling/rfc.md
@@ -1,0 +1,1197 @@
+---
+title: "Deployment provider decoupling RFC"
+description: "Configuration-based approach to make the Enterprise Platform Template deployable to Docker/self-hosted, AWS, and Cloudflare without changing application source code."
+owner: "Engineering"
+lastUpdated: "2026-05-11"
+---
+
+# Deployment provider decoupling RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for making the Enterprise Platform Template deployable to multiple hosting providers through configuration and environment variable changes only — never through application source code changes.
+
+## Scope
+
+- Included: `DEPLOY_TARGET` environment variable convention, `next.config.ts` conditional configuration, production `Dockerfile` for the monorepo, `docker-compose.yml` for local dev and self-hosted production, `.dockerignore`, custom `sharp`-based image loader for Docker/self-hosted, GitHub Actions workflow for Docker build + push to GHCR, environment variable documentation per provider, middleware compatibility audit and notes.
+- Excluded: AWS CDK / Pulumi / Terraform infrastructure-as-code, Cloudflare Pages/Workers full adapter (`@cloudflare/next-on-pages` — follow-up), Kubernetes Helm charts, multi-region routing or edge caching strategies, Supabase self-hosting inside Docker Compose, automated provider detection at runtime, cost comparison guides.
+
+---
+
+## Summary
+
+The template is currently Vercel-first by configuration. `vercel.json` is the build entry point, `next.config.ts` uses Vercel's default image CDN, and environment documentation covers only the Vercel dashboard workflow. Adopters who want Docker/self-hosted deployment must write a Dockerfile from scratch, figure out `output: "standalone"`, replicate image optimization, and build their own CI pipeline.
+
+The fix is configuration-level, not code-level: introduce a `DEPLOY_TARGET` environment variable, add `output: "standalone"` conditionally in `next.config.ts`, ship a production-grade `Dockerfile` and `docker-compose.yml`, add a `sharp`-based image loader activated for non-Vercel targets, and provide a GitHub Actions workflow for GHCR. All of this is layered on top of the existing Vercel path with zero regressions.
+
+## Technical objectives
+
+- Adopters can deploy to Docker/self-hosted by running `docker compose up` with a populated `.env` file — no custom build infrastructure required.
+- Vercel remains the default and reference target with no regressions — no new required env vars for Vercel adopters, `vercel.json` unchanged.
+- All target-specific configuration lives in `vercel.json`, `Dockerfile`, `docker-compose.yml`, and `next.config.ts` conditionals — never in feature source files.
+- Image optimization works out of the box for Docker/self-hosted via server-side `sharp` processing, without Vercel's CDN.
+- Docker image size stays under 500 MB using Next.js standalone output.
+- The container runs as a non-root user.
+
+---
+
+## Deployment target abstraction
+
+### `DEPLOY_TARGET` env var
+
+`DEPLOY_TARGET` is a build-time environment variable that controls target-specific configuration in `next.config.ts`. It is always set explicitly — there is no auto-detection.
+
+| Value | Meaning | Who sets it |
+|-------|---------|-------------|
+| `vercel` | Vercel deployment (default) | Vercel auto-injects; or set explicitly in `vercel.json` |
+| `docker` | Docker-based local dev or self-hosted production | Adopter sets in `.env` / `docker-compose.yml` |
+| `self-hosted` | VPS / systemd / AWS ECS / Fargate | Adopter sets in environment file or task definition |
+| `cloudflare` | Cloudflare Pages (stub — follow-up) | Adopter sets in `wrangler.toml` |
+
+**Default behavior**: when `DEPLOY_TARGET` is unset, the config behaves identically to `DEPLOY_TARGET=vercel`. Existing Vercel adopters do not need to set anything.
+
+**Build-time vs. runtime**: `DEPLOY_TARGET` must be available at `next build` time (baked into the build output). It is NOT a runtime environment variable. In Docker, it is passed as a build argument (`ARG DEPLOY_TARGET`). In Vercel, it can be set in the dashboard under "Build environment variables" if explicit control is desired.
+
+**`turbo.json` `globalEnv` addition**: `DEPLOY_TARGET` must be added to `turbo.json` `globalEnv` so Turborepo invalidates the build cache when the target changes.
+
+```json
+// turbo.json — add DEPLOY_TARGET to globalEnv
+{
+  "globalEnv": [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_APP_URL",
+    "NEXT_PUBLIC_APP_ENV",
+    "NEXT_PUBLIC_APP_NAME",
+    "NEXT_PUBLIC_SENTRY_DSN",
+    "DEPLOY_TARGET"
+  ]
+}
+```
+
+### `next.config.ts` conditional configuration
+
+The existing `ui/next.config.ts` is modified to read `DEPLOY_TARGET` and apply target-specific settings. The Sentry wrapper (`withSentryConfig`) remains unchanged and wraps the final config object.
+
+```typescript
+// ui/next.config.ts
+import { withSentryConfig } from "@sentry/nextjs";
+import type { NextConfig } from "next";
+
+const deployTarget = process.env["DEPLOY_TARGET"] ?? "vercel";
+
+const isDockerOrSelfHosted =
+  deployTarget === "docker" || deployTarget === "self-hosted";
+
+const isCloudflare = deployTarget === "cloudflare";
+
+const baseConfig: NextConfig = {
+  transpilePackages: [
+    "@enterprise/ui",
+    "@enterprise/core",
+    "@enterprise/contracts",
+    "@enterprise/db",
+  ],
+
+  // Standalone output: required for Docker multi-stage builds.
+  // Vercel ignores this field and uses its own pipeline.
+  ...(isDockerOrSelfHosted && { output: "standalone" }),
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+      {
+        // Local Supabase dev
+        protocol: "http",
+        hostname: "127.0.0.1",
+        port: "54321",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+
+    // Docker/self-hosted: use custom sharp-based server-side loader.
+    // Vercel: default CDN loader (loaderFile omitted, unoptimized: false).
+    // Cloudflare: disable optimization entirely (follow-up to add custom loader).
+    ...(isDockerOrSelfHosted && {
+      loader: "custom" as const,
+      loaderFile: "./lib/image-loader.ts",
+    }),
+    ...(isCloudflare && { unoptimized: true }),
+  },
+};
+
+export default withSentryConfig(baseConfig, {
+  org: process.env["SENTRY_ORG"],
+  project: process.env["SENTRY_PROJECT"],
+  authToken: process.env["SENTRY_AUTH_TOKEN"],
+  tunnelRoute: "/monitoring",
+  widenClientFileUpload: true,
+  sourcemaps: { deleteSourcemapsAfterUpload: true },
+  silent: true,
+  disableLogger: true,
+  reactComponentAnnotation: { enabled: true },
+});
+```
+
+**Config matrix**:
+
+| Setting | `vercel` (default) | `docker` / `self-hosted` | `cloudflare` (stub) |
+|---------|-------------------|--------------------------|---------------------|
+| `output` | (unset — Vercel default) | `"standalone"` | (unset — follow-up) |
+| `images.loader` | `"default"` (Vercel CDN) | `"custom"` + `loaderFile` | (omitted) |
+| `images.unoptimized` | `false` | `false` (custom loader active) | `true` |
+
+---
+
+## Docker support
+
+### Dockerfile
+
+Location: `Dockerfile` at the **monorepo root**.
+
+The build context must include all workspace packages (`packages/core`, `packages/db`, `packages/ui`, `packages/contracts`) because the Next.js app imports them. A root-level Dockerfile with pnpm workspace install is the correct pattern for this monorepo.
+
+The Dockerfile uses three stages:
+1. **`deps`** — install all workspace dependencies with `pnpm install --frozen-lockfile`.
+2. **`builder`** — copy source, set `DEPLOY_TARGET=docker`, run `pnpm build` (Turborepo build).
+3. **`runner`** — copy only the standalone output, run as non-root user. No `node_modules` duplication.
+
+```dockerfile
+# syntax=docker/dockerfile:1
+# ─────────────────────────────────────────────────────────────────────────────
+# Enterprise Platform — Production Dockerfile
+# Target: @enterprise/web (Next.js App Router, standalone output)
+# ─────────────────────────────────────────────────────────────────────────────
+# Build:
+#   docker build \
+#     --build-arg DEPLOY_TARGET=docker \
+#     --build-arg NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co \
+#     --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ... \
+#     --build-arg NEXT_PUBLIC_APP_URL=https://yourdomain.com \
+#     --build-arg NEXT_PUBLIC_APP_NAME="My App" \
+#     --build-arg NEXT_PUBLIC_APP_ENV=production \
+#     --build-arg NEXT_PUBLIC_SENTRY_DSN=https://xxx@o0.ingest.sentry.io/0 \
+#     --build-arg SENTRY_AUTH_TOKEN=sntrys_... \
+#     --build-arg SENTRY_ORG=your-org \
+#     --build-arg SENTRY_PROJECT=your-project \
+#     -t ghcr.io/your-org/enterprise-platform:latest .
+# ─────────────────────────────────────────────────────────────────────────────
+
+ARG NODE_VERSION=20
+ARG PNPM_VERSION=9.15.0
+
+# ─── Stage 1: deps ────────────────────────────────────────────────────────────
+FROM node:${NODE_VERSION}-alpine AS deps
+
+# Install pnpm globally
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /app
+
+# Copy workspace manifests and lockfile first for layer caching.
+# Changes to source files will not bust the dependency install layer.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/contracts/package.json ./packages/contracts/
+COPY packages/core/package.json ./packages/core/
+COPY packages/db/package.json ./packages/db/
+COPY packages/ui/package.json ./packages/ui/
+COPY ui/package.json ./ui/
+
+# Install all workspace dependencies (including devDependencies needed for build).
+# Use --frozen-lockfile to ensure reproducible installs.
+RUN pnpm install --frozen-lockfile
+
+# ─── Stage 2: builder ─────────────────────────────────────────────────────────
+FROM node:${NODE_VERSION}-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /app
+
+# Copy installed node_modules from deps stage.
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/packages/contracts/node_modules ./packages/contracts/node_modules
+COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/db/node_modules ./packages/db/node_modules
+COPY --from=deps /app/packages/ui/node_modules ./packages/ui/node_modules
+COPY --from=deps /app/ui/node_modules ./ui/node_modules
+
+# Copy all source files.
+COPY . .
+
+# ─── Build-time environment variables ────────────────────────────────────────
+# NEXT_PUBLIC_* variables are baked into the client bundle at build time.
+# They CANNOT be overridden at container runtime without rebuilding.
+# Pass them as --build-arg when building the image.
+# See: docs/developer-guide/environment-guide.mdx — Docker section.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Deployment target — MUST be docker or self-hosted to produce standalone output.
+ARG DEPLOY_TARGET=docker
+ENV DEPLOY_TARGET=${DEPLOY_TARGET}
+
+# Supabase public vars (baked into client bundle).
+ARG NEXT_PUBLIC_SUPABASE_URL
+ENV NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
+
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+
+# App configuration (baked into client bundle).
+ARG NEXT_PUBLIC_APP_URL
+ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
+
+ARG NEXT_PUBLIC_APP_NAME
+ENV NEXT_PUBLIC_APP_NAME=${NEXT_PUBLIC_APP_NAME}
+
+ARG NEXT_PUBLIC_APP_ENV=production
+ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
+
+# Sentry DSN (baked into client bundle — safe to expose, it is a public key).
+ARG NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+
+# Sentry source map upload (build-time only — NOT needed at runtime).
+# Omit SENTRY_AUTH_TOKEN to skip source map upload (withSentryConfig is silent: true).
+ARG SENTRY_AUTH_TOKEN
+ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+
+ARG SENTRY_ORG
+ENV SENTRY_ORG=${SENTRY_ORG}
+
+ARG SENTRY_PROJECT
+ENV SENTRY_PROJECT=${SENTRY_PROJECT}
+
+# Disable Next.js telemetry during CI builds.
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Build the entire monorepo. Turborepo builds packages in dependency order.
+RUN pnpm build
+
+# ─── Stage 3: runner ──────────────────────────────────────────────────────────
+FROM node:${NODE_VERSION}-alpine AS runner
+
+# Install sharp's native dependencies (Alpine needs libc compatibility via libc6-compat).
+# sharp is used by the custom image loader (ui/lib/image-loader.ts).
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create a non-root user and group for security.
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy Next.js standalone output.
+# The standalone directory is self-contained: it includes only the files needed
+# to run the server. node_modules are NOT duplicated (tree-shaken by Next.js).
+COPY --from=builder --chown=nextjs:nodejs /app/ui/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/ui/.next/static ./ui/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/ui/public ./ui/public
+
+# Install sharp for the custom image loader.
+# sharp must be installed in the runner stage (native binary, architecture-specific).
+# It is installed as a production dependency, not copied from the builder.
+RUN npm install --global --ignore-scripts false sharp@^0.33.0 && \
+    chown -R nextjs:nodejs /usr/local/lib/node_modules/sharp
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# The standalone output includes a Node.js server at server.js.
+# Next.js standalone places the app server at the monorepo-aware path.
+CMD ["node", "ui/server.js"]
+```
+
+### `docker-compose.yml`
+
+Location: `docker-compose.yml` at the monorepo root.
+
+This Compose file covers two use cases:
+- **Local dev** (profile `dev`): builds from source, mounts `.env.local`, exposes port 3000.
+- **Self-hosted production** (default profile): pulls the pre-built image from GHCR, reads from `.env.docker`, applies restart policy.
+
+> **Warning**: The self-hosted production profile is a starting point. For production traffic, place a reverse proxy (nginx, Caddy) in front of the container to handle TLS termination, compression, and static asset serving. Do NOT expose the Next.js server directly to the internet.
+
+```yaml
+# docker-compose.yml
+# ─────────────────────────────────────────────────────────────────────────────
+# Enterprise Platform — Docker Compose
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# USAGE:
+#
+#   Self-hosted production (pull pre-built image from GHCR):
+#     cp .env.example .env.docker
+#     # Fill .env.docker with production values
+#     docker compose up -d
+#
+#   Local dev (build from source):
+#     cp .env.example .env.local
+#     # Fill .env.local with local Supabase values
+#     docker compose --profile dev up
+#
+# NOTE: No Supabase containers are included. This template uses Supabase Cloud.
+# For local Supabase, run `supabase start` separately via the Supabase CLI.
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  # ── Production / self-hosted (default profile) ─────────────────────────────
+  web:
+    image: ghcr.io/${GITHUB_REPOSITORY:-your-org/enterprise-platform}:${IMAGE_TAG:-latest}
+    ports:
+      - "${APP_PORT:-3000}:3000"
+    env_file:
+      - .env.docker
+    environment:
+      # Override NODE_ENV explicitly — the image sets this at build time,
+      # but allow runtime override for debugging.
+      NODE_ENV: production
+    restart: unless-stopped
+    # Runtime-injectable environment variables (NOT NEXT_PUBLIC_ — those are baked at build time).
+    # Add any server-side-only variables here that should NOT be in the image.
+    # Example: SUPABASE_SERVICE_ROLE_KEY can be injected at runtime.
+
+  # ── Local dev (build from source) ─────────────────────────────────────────
+  web-dev:
+    profiles: [dev]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # NEXT_PUBLIC_* vars must be passed as build args — they are baked
+        # into the client bundle by next build. They cannot be set at runtime.
+        DEPLOY_TARGET: docker
+        NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+        NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+        NEXT_PUBLIC_APP_NAME: ${NEXT_PUBLIC_APP_NAME:-My Enterprise App}
+        NEXT_PUBLIC_APP_ENV: ${NEXT_PUBLIC_APP_ENV:-development}
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.local
+    restart: "no"
+```
+
+### `.dockerignore`
+
+Location: `.dockerignore` at the monorepo root.
+
+```dockerignore
+# ─────────────────────────────────────────────────────────────────────────────
+# Enterprise Platform — .dockerignore
+# Excludes files that should NOT be sent to the Docker build context.
+# Smaller context = faster builds and no accidental secret leakage.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Git
+.git
+.gitignore
+
+# Environment files — NEVER include secrets in the build context.
+# NEXT_PUBLIC_* vars are passed as --build-arg, not copied from disk.
+.env
+.env.*
+!.env.example
+
+# Node modules — reinstalled inside the builder stage via pnpm install.
+node_modules
+**/node_modules
+
+# Next.js build artifacts — rebuilt inside the builder stage.
+**/.next
+**/dist
+
+# Test artifacts
+coverage
+playwright-report
+test-results
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Turbo cache
+.turbo
+
+# Supabase local dev files (not needed in production image)
+supabase/.branches
+supabase/.temp
+
+# Documentation (not needed in the runtime image)
+docs
+
+# Skills and agent tooling
+skills
+.agents
+.claude
+.opencode
+.engram
+.atl
+.codex
+.gemini
+
+# Scripts (not needed in the runtime image)
+scripts
+
+# Playwright config and E2E tests
+playwright.config.ts
+ui/e2e
+
+# Vitest config and unit tests
+vitest.config.ts
+**/*.test.ts
+**/*.spec.ts
+```
+
+---
+
+## Image optimization per provider
+
+Next.js `<Image />` optimization routes through different layers depending on the hosting target. The strategy is:
+
+1. **Vercel (default)**: Vercel's CDN handles optimization automatically. No loader configuration needed. The image is served from Vercel's global edge network with automatic format negotiation (WebP/AVIF).
+2. **Docker / self-hosted**: A custom `sharp`-based loader runs optimization through the Next.js server process itself. No external CDN dependency.
+3. **Cloudflare (follow-up)**: `unoptimized: true` in MVP (no image processing at all). Full Cloudflare Images loader is a follow-up.
+
+### Vercel (default)
+
+No configuration changes. When `DEPLOY_TARGET` is unset or `vercel`, `next.config.ts` does not set `loader` or `loaderFile`. Vercel's image optimization CDN is active by default.
+
+```typescript
+// next.config.ts — Vercel path (no changes from current config)
+images: {
+  remotePatterns: [/* ... */],
+  // loader: "default" is implicit — Vercel CDN handles optimization
+}
+```
+
+### Docker / self-hosted (`sharp`)
+
+When `DEPLOY_TARGET=docker` or `self-hosted`, a custom loader file at `ui/lib/image-loader.ts` is activated. This loader constructs the `/_next/image` URL, which is handled by the Next.js built-in image optimization route using `sharp` for server-side processing.
+
+The `sharp` package is installed in the Docker runner stage and is available as a peer dependency for adopters running locally without Docker.
+
+```typescript
+// ui/lib/image-loader.ts
+// Custom image loader for Docker/self-hosted deployments.
+// Delegates to Next.js built-in /_next/image route, which uses sharp
+// for server-side image processing. No Vercel CDN dependency.
+//
+// Performance note: Image optimization runs on the server CPU,
+// not a CDN. For high-traffic production deployments, consider:
+//   - Adding a CDN (Cloudflare, CloudFront) in front of the Next.js server
+//   - Using a dedicated image CDN (Cloudflare Images, imgix)
+//   - Replacing this file with a CDN-specific loader without changing app code
+
+interface ImageLoaderProps {
+  src: string;
+  width: number;
+  quality?: number;
+}
+
+export default function imageLoader({ src, width, quality }: ImageLoaderProps): string {
+  const params = new URLSearchParams({
+    url: src,
+    w: String(width),
+    q: String(quality ?? 75),
+  });
+  return `/_next/image?${params.toString()}`;
+}
+```
+
+**sharp installation for local dev (without Docker)**:
+
+```bash
+# Install sharp as a dev dependency for local non-Docker development
+# when DEPLOY_TARGET=docker is set in .env.local
+pnpm add --filter @enterprise/web --save-optional sharp
+```
+
+**sharp in Docker**: The `Dockerfile` installs `sharp` globally in the runner stage. The native binary is compiled for `linux/amd64` in CI. Multi-platform builds (`linux/amd64,linux/arm64`) are supported via the GitHub Actions workflow's `platforms` matrix.
+
+### Cloudflare (follow-up)
+
+MVP ships `unoptimized: true` as a stub when `DEPLOY_TARGET=cloudflare`. This disables image optimization entirely — `<Image />` components render the original `src` URL without resizing or format conversion. A full Cloudflare Images loader is planned as a follow-up once `@cloudflare/next-on-pages` compatibility with this template's Server Actions is verified.
+
+```typescript
+// next.config.ts — Cloudflare stub (MVP)
+...(isCloudflare && { unoptimized: true }),
+```
+
+---
+
+## CI/CD workflows
+
+### Existing: Vercel CI (no changes)
+
+The existing `.github/workflows/ci.yml` runs quality checks (typecheck, lint, test, build) on every pull request and push to `main`. Vercel deployment is triggered separately by the Vercel GitHub integration — not by this workflow. No changes are needed here.
+
+The only addition to `ci.yml` is a lint step to catch accidental Vercel-specific imports in middleware:
+
+```yaml
+# Addition to the existing quality job in .github/workflows/ci.yml
+- name: Audit middleware for Vercel-specific APIs
+  run: |
+    if grep -rE "waitUntil|@vercel/edge|EdgeConfig" ui/middleware.ts; then
+      echo "ERROR: middleware.ts contains Vercel-specific runtime APIs."
+      echo "These must be guarded with DEPLOY_TARGET conditionals or extracted."
+      exit 1
+    fi
+    echo "Middleware audit passed."
+```
+
+### New: Docker build + push to GHCR
+
+Location: `.github/workflows/deploy-docker.yml`
+
+This workflow builds the Docker image, tags it with the Git SHA and `latest`, and pushes to GitHub Container Registry (GHCR). It is triggered manually by default (`workflow_dispatch`) so it does not interfere with Vercel adopters who have not configured Docker secrets.
+
+**To activate automatic triggers**, uncomment the `push` trigger block and configure the required secrets in GitHub repository settings.
+
+```yaml
+# .github/workflows/deploy-docker.yml
+# ─────────────────────────────────────────────────────────────────────────────
+# Enterprise Platform — Docker Build and Push to GHCR
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# REQUIRED GITHUB SECRETS (set in repository Settings → Secrets → Actions):
+#
+#   NEXT_PUBLIC_SUPABASE_URL       — Supabase project URL (e.g. https://xxx.supabase.co)
+#   NEXT_PUBLIC_SUPABASE_ANON_KEY  — Supabase anonymous key (public, baked at build time)
+#   NEXT_PUBLIC_APP_URL            — Full app URL (e.g. https://yourdomain.com)
+#   NEXT_PUBLIC_APP_NAME           — App display name (e.g. "My Enterprise App")
+#   NEXT_PUBLIC_APP_ENV            — Environment name (e.g. production)
+#   NEXT_PUBLIC_SENTRY_DSN         — Sentry DSN (public, baked at build time) — optional
+#   SENTRY_AUTH_TOKEN              — Sentry auth token for source map upload — optional
+#   SENTRY_ORG                     — Sentry organization slug — optional
+#   SENTRY_PROJECT                 — Sentry project slug — optional
+#
+# GITHUB_TOKEN is auto-provided by GitHub Actions — no configuration needed for GHCR push.
+#
+# OPTIONAL DEPLOY SECRETS (uncomment the deploy step you want to use):
+#
+#   DEPLOY_WEBHOOK_URL             — Webhook URL to trigger a deploy on your server
+#   DEPLOY_SSH_HOST                — SSH host of your server
+#   DEPLOY_SSH_USER                — SSH user (e.g. deploy)
+#   DEPLOY_SSH_KEY                 — SSH private key (PEM format)
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Docker Build and Push
+
+on:
+  # Manual trigger — safe default. Uncomment `push` below to enable automatic builds.
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Trigger deploy after push (requires deploy secrets)"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "webhook", "ssh"]
+
+  # Uncomment to enable automatic builds on push to main:
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - "ui/**"
+  #     - "packages/**"
+  #     - "Dockerfile"
+  #     - "pnpm-lock.yaml"
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write   # Required to push to GHCR
+
+jobs:
+  build-and-push:
+    name: Build Docker Image and Push to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Set up QEMU for multi-platform builds (linux/amd64 + linux/arm64).
+      # Required for sharp's native binary compilation across architectures.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d6a71c5c4b7a9bd00ab7e9 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5730b7e2fa08f01c7a58f8f4f43fb25d3c43ed1 # v3
+        with:
+          # Use the docker-container driver for multi-platform support and cache export.
+          driver-opts: image=moby/buildkit:latest
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          # GITHUB_TOKEN is auto-provided — no secret configuration needed for GHCR.
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbea8a63a2c28c8a69d8a45e85db # v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # Tag with the full Git SHA (e.g. sha-a1b2c3d)
+            type=sha,prefix=sha-,format=short
+            # Tag as `latest` on pushes to main (or manual dispatch from main)
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            # Tag with the branch name for non-main branches
+            type=ref,event=branch
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          # Build for both amd64 (standard servers, CI) and arm64 (Apple Silicon, AWS Graviton).
+          # sharp's native binary is compiled per-architecture in the runner stage.
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Use GitHub Actions cache to speed up subsequent builds.
+          # Cache is stored in the GHCR registry alongside the image.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache,mode=max
+          build-args: |
+            DEPLOY_TARGET=docker
+            NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+            NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_APP_NAME=${{ secrets.NEXT_PUBLIC_APP_NAME }}
+            NEXT_PUBLIC_APP_ENV=${{ secrets.NEXT_PUBLIC_APP_ENV }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
+
+      # ── Deploy step: choose ONE of the options below ────────────────────────
+      # Uncomment the deploy step that matches your deployment method.
+      # Each requires the corresponding secrets configured in GitHub repository settings.
+
+      # Option A: Webhook deploy
+      # Sends a POST request to your server's deploy webhook.
+      # Your server pulls the new image and restarts the container.
+      # ─────────────────────────────────────────────────────────────────────────
+      # - name: Deploy via webhook
+      #   if: ${{ github.event.inputs.deploy == 'webhook' || github.event_name == 'push' }}
+      #   run: |
+      #     curl --fail --silent --show-error \
+      #       -X POST \
+      #       -H "Content-Type: application/json" \
+      #       -H "Authorization: Bearer ${{ secrets.DEPLOY_WEBHOOK_SECRET }}" \
+      #       -d '{"image": "ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}"}' \
+      #       "${{ secrets.DEPLOY_WEBHOOK_URL }}"
+
+      # Option B: SSH deploy
+      # SSH into your server, pull the new image, and restart the container.
+      # ─────────────────────────────────────────────────────────────────────────
+      # - name: Deploy via SSH
+      #   if: ${{ github.event.inputs.deploy == 'ssh' || github.event_name == 'push' }}
+      #   uses: appleboy/ssh-action@7bf3f3bdacef2eee8e7d7631b2b1d5ad7e66d1b8 # v1
+      #   with:
+      #     host: ${{ secrets.DEPLOY_SSH_HOST }}
+      #     username: ${{ secrets.DEPLOY_SSH_USER }}
+      #     key: ${{ secrets.DEPLOY_SSH_KEY }}
+      #     script: |
+      #       echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      #       docker pull ghcr.io/${{ github.repository }}:latest
+      #       docker compose -f /opt/enterprise-platform/docker-compose.yml up -d
+      #       docker image prune -f
+
+      # Option C: AWS ECS service update
+      # Updates the ECS service to use the newly pushed image.
+      # NEXT_PUBLIC_* vars are baked in the image; runtime vars come from Secrets Manager.
+      # ─────────────────────────────────────────────────────────────────────────
+      # - name: Deploy to AWS ECS
+      #   if: ${{ github.event.inputs.deploy == 'webhook' || github.event_name == 'push' }}
+      #   run: |
+      #     aws ecs update-service \
+      #       --cluster ${{ secrets.AWS_ECS_CLUSTER }} \
+      #       --service ${{ secrets.AWS_ECS_SERVICE }} \
+      #       --force-new-deployment \
+      #       --region ${{ secrets.AWS_REGION }}
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  # ── Optional: verify image size ─────────────────────────────────────────────
+  verify-image-size:
+    name: Verify Docker Image Size
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image and check size
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:latest
+          SIZE_MB=$(docker image inspect ghcr.io/${{ github.repository }}:latest \
+            --format='{{.Size}}' | awk '{printf "%.0f", $1/1024/1024}')
+          echo "Image size: ${SIZE_MB} MB"
+          if [ "$SIZE_MB" -gt 500 ]; then
+            echo "ERROR: Docker image exceeds 500 MB limit (${SIZE_MB} MB)."
+            echo "Review the Dockerfile stages and ensure standalone output is active."
+            exit 1
+          fi
+          echo "Image size check passed: ${SIZE_MB} MB < 500 MB"
+```
+
+---
+
+## Environment variable documentation per provider
+
+### Variable reference
+
+All variables from `vercel.json` and `.env.example` translated across providers:
+
+| Variable | Type | Required | Notes |
+|----------|------|----------|-------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Public (build-time) | Yes | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public (build-time) | Yes | Supabase anonymous key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Secret (runtime) | Yes | Never expose to browser |
+| `NEXT_PUBLIC_APP_URL` | Public (build-time) | Yes | Full application URL |
+| `NEXT_PUBLIC_APP_NAME` | Public (build-time) | Yes | App display name |
+| `NEXT_PUBLIC_APP_ENV` | Public (build-time) | Yes | `development` / `production` |
+| `DATABASE_URL` | Secret (build-time for migrations) | No | Drizzle Kit only; not used at runtime |
+| `RESEND_API_KEY` | Secret (runtime) | No | Email sending |
+| `EMAIL_FROM` | Config (runtime) | No | Sender address |
+| `NEXT_PUBLIC_SENTRY_DSN` | Public (build-time) | No | Sentry error tracking |
+| `SENTRY_AUTH_TOKEN` | Secret (build-time) | No | Source map upload only |
+| `SENTRY_ORG` | Config (build-time) | No | Source map upload only |
+| `SENTRY_PROJECT` | Config (build-time) | No | Source map upload only |
+| `DEPLOY_TARGET` | Config (build-time) | No | Default: `vercel` |
+
+**`NEXT_PUBLIC_` variables are build-time constants** — they are inlined into the JavaScript bundle by `next build`. They CANNOT be changed at container runtime without rebuilding the image. This is a Next.js constraint, not a template choice. See the Dockerfile `ARG` / `ENV` pattern for how to pass them at build time.
+
+### Vercel
+
+Environment variables are set in the Vercel dashboard under **Settings → Environment Variables** and optionally referenced in `vercel.json` via secret aliases (e.g., `@supabase-url`).
+
+`NEXT_PUBLIC_` variables set in the Vercel dashboard are automatically available at both build time and runtime on Vercel (Vercel re-injects them into the build environment). No `DEPLOY_TARGET` is needed — Vercel is the default.
+
+```json
+// vercel.json — current configuration (no changes required)
+{
+  "$schema": "https://openapi.vercel.com/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "pnpm build",
+  "devCommand": "pnpm dev",
+  "installCommand": "pnpm install",
+  "regions": ["iad1"],
+  "env": {
+    "NEXT_PUBLIC_SUPABASE_URL": "@supabase-url",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@supabase-anon-key",
+    "SUPABASE_SERVICE_ROLE_KEY": "@supabase-service-role-key",
+    "NEXT_PUBLIC_APP_URL": "@app-url",
+    "NEXT_PUBLIC_APP_NAME": "@app-name",
+    "NEXT_PUBLIC_APP_ENV": "@app-env"
+  }
+}
+```
+
+### Docker / self-hosted
+
+`.env.docker.example` (new file at monorepo root):
+
+```bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Enterprise Platform — Docker / Self-Hosted Environment
+# ─────────────────────────────────────────────────────────────────────────────
+# Copy to .env.docker and fill in your values.
+# NEVER commit .env.docker to version control.
+#
+# IMPORTANT: NEXT_PUBLIC_* variables are baked into the Docker image at build
+# time. They CANNOT be changed at runtime without rebuilding the image.
+# Pass them as Docker build arguments (--build-arg) when building.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Deployment target ─────────────────────────────────────────────────────────
+# Must match the value used when building the Docker image.
+# Values: docker | self-hosted
+DEPLOY_TARGET=docker
+
+# ── Supabase ──────────────────────────────────────────────────────────────────
+# Public — baked into the client bundle at build time (passed as --build-arg).
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+
+# Public — baked into the client bundle at build time (passed as --build-arg).
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+
+# SECRET — server-side only. Injected at container runtime (NOT a build arg).
+# NEVER prefix with NEXT_PUBLIC_.
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+
+# ── App configuration ─────────────────────────────────────────────────────────
+# Baked into the client bundle at build time (passed as --build-arg).
+NEXT_PUBLIC_APP_URL=https://yourdomain.com
+NEXT_PUBLIC_APP_NAME=My Enterprise App
+NEXT_PUBLIC_APP_ENV=production
+
+# ── Email ─────────────────────────────────────────────────────────────────────
+# Server-side only. Injected at container runtime.
+RESEND_API_KEY=re_...
+EMAIL_FROM=noreply@yourdomain.com
+
+# ── Sentry (optional) ─────────────────────────────────────────────────────────
+# DSN is public — baked into the client bundle at build time.
+NEXT_PUBLIC_SENTRY_DSN=https://xxx@o0.ingest.sentry.io/0
+
+# Auth token and org/project are build-time only (source map upload).
+# Set as GitHub Actions secrets, NOT here.
+# SENTRY_AUTH_TOKEN=sntrys_...
+# SENTRY_ORG=your-org
+# SENTRY_PROJECT=your-project
+```
+
+How Docker Compose reads these variables at runtime:
+
+```yaml
+# docker-compose.yml — env_file usage
+services:
+  web:
+    env_file:
+      - .env.docker
+```
+
+Variables that are NOT `NEXT_PUBLIC_` (e.g., `SUPABASE_SERVICE_ROLE_KEY`) can be injected at runtime via `env_file` without rebuilding the image — the server process reads them when the container starts.
+
+### AWS ECS / Fargate
+
+`DEPLOY_TARGET=self-hosted` is set in the ECS task definition environment block. `NEXT_PUBLIC_*` variables must be baked into the image at build time via GitHub Actions build arguments. Runtime secrets (e.g., `SUPABASE_SERVICE_ROLE_KEY`) are stored in AWS Secrets Manager and referenced in the task definition `secrets` block.
+
+```json
+// ECS Task Definition — representative snippet
+{
+  "family": "enterprise-platform",
+  "containerDefinitions": [
+    {
+      "name": "web",
+      "image": "ghcr.io/your-org/enterprise-platform:latest",
+      "portMappings": [{ "containerPort": 3000, "protocol": "tcp" }],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" },
+        { "name": "DEPLOY_TARGET", "value": "self-hosted" },
+        { "name": "NEXT_PUBLIC_APP_ENV", "value": "production" }
+        // NOTE: NEXT_PUBLIC_* are baked into the image at build time.
+        // Setting them here has NO effect — Next.js reads them at build, not runtime.
+        // They must be passed as Docker --build-arg in the GitHub Actions workflow.
+      ],
+      "secrets": [
+        {
+          "name": "SUPABASE_SERVICE_ROLE_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:enterprise-platform/supabase-service-role-key"
+        },
+        {
+          "name": "RESEND_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:123456789012:secret:enterprise-platform/resend-api-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/enterprise-platform",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Cloudflare Pages (stub — follow-up)
+
+MVP documents the variable injection pattern but ships no full adapter. `NEXT_PUBLIC_*` variables are set in `wrangler.toml` under `[vars]`. Sensitive variables use `wrangler secret put`.
+
+```toml
+# wrangler.toml — stub for documentation
+name = "enterprise-platform"
+compatibility_date = "2024-01-01"
+
+[vars]
+NEXT_PUBLIC_APP_ENV = "production"
+# NOTE: Full Cloudflare Pages adapter is a follow-up.
+# The current template uses features (Server Actions, Route Handlers)
+# that require @cloudflare/next-on-pages compatibility verification.
+```
+
+```bash
+# Sensitive variables — set via CLI (not stored in wrangler.toml)
+wrangler secret put SUPABASE_SERVICE_ROLE_KEY
+wrangler secret put RESEND_API_KEY
+```
+
+---
+
+## Middleware compatibility
+
+### Current state
+
+`ui/middleware.ts` handles:
+1. Supabase session refresh via `updateSession` from `@enterprise/core/supabase/middleware`.
+2. Authentication guard — redirects unauthenticated users to `/sign-in`.
+3. Role-based redirect — routes users to their role home after login.
+
+### Vercel-specific API audit
+
+The middleware was audited for Vercel-specific runtime APIs. Findings:
+
+| API | Present | Vercel-specific? | Status |
+|-----|---------|-----------------|--------|
+| `waitUntil` | No | Yes | Safe |
+| `@vercel/edge` | No | Yes | Safe |
+| `EdgeConfig` | No | Yes | Safe |
+| `next-action` header check | Yes | No | Safe — standard Next.js header |
+| `NextRequest` / `NextResponse` | Yes | No | Safe — Next.js core API |
+| `supabase.auth.getUser()` | Yes | No | Safe — runs in Node.js runtime |
+
+**Result**: The middleware contains no Vercel-specific runtime APIs. It runs correctly in the Node.js runtime used by Docker/self-hosted deployments.
+
+### Edge Runtime vs. Node.js runtime
+
+The `config.matcher` in `ui/middleware.ts` does not specify a `runtime` field. Next.js defaults middleware to the Edge Runtime for performance when deployed on Vercel. When deployed on Docker/self-hosted (Node.js runtime), the middleware runs in the Node.js runtime, which is fully compatible.
+
+The Supabase session refresh (`updateSession`) from `@enterprise/core/supabase/middleware` uses `@supabase/ssr` — a library that is compatible with both Edge and Node.js runtimes.
+
+**No changes to `ui/middleware.ts` are required** for Docker/self-hosted compatibility.
+
+### CI guard
+
+A lint step in `.github/workflows/ci.yml` checks for Vercel-specific imports in middleware to prevent future regressions:
+
+```bash
+# Fails the build if Vercel-specific APIs are introduced
+grep -rE "waitUntil|@vercel/edge|EdgeConfig" ui/middleware.ts
+```
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/core/src/__tests__/deploy-config.test.ts` (new)
+Location: `ui/__tests__/next-config.test.ts` (new)
+
+| Test | What it verifies |
+|------|-----------------|
+| `DEPLOY_TARGET=vercel` → no `output` field | `next.config.ts` logic does not set `output: "standalone"` for Vercel |
+| `DEPLOY_TARGET=docker` → `output: "standalone"` | Config sets standalone output for Docker target |
+| `DEPLOY_TARGET=self-hosted` → `output: "standalone"` | Config sets standalone output for self-hosted target |
+| `DEPLOY_TARGET=cloudflare` → `unoptimized: true` | Config sets `images.unoptimized` for Cloudflare stub |
+| `DEPLOY_TARGET` unset → Vercel behavior | Unset behaves identically to `vercel` |
+| `DEPLOY_TARGET=docker` → `loader: "custom"` set | Custom loader is activated for Docker target |
+| `DEPLOY_TARGET=vercel` → no `loaderFile` | Vercel target does not set a custom `loaderFile` |
+| Image loader returns correct `/_next/image` URL | `ui/lib/image-loader.ts` produces correct URL with `url`, `w`, `q` params |
+| Image loader uses default quality 75 | Quality defaults to 75 when not provided |
+
+### E2E tests against Docker-built image
+
+Location: `ui/e2e/docker/docker-build.spec.ts` (new)
+
+These tests run against the Docker-built image in CI. The workflow spins up the container and runs Playwright against `http://localhost:3000`.
+
+| Test | Tag | Flow |
+|------|-----|------|
+| Application starts and serves login page | `@critical` | `GET /` → redirect to `/sign-in` → 200 |
+| Authentication flow works in Docker build | `@critical` | Login with E2E credentials → reach `/dashboard` |
+| Supabase connection succeeds | `@critical` | Login succeeds → session persists across navigation |
+| Middleware redirects unauthenticated user | `@critical` | `GET /dashboard` without session → redirect to `/sign-in` |
+| Protected routes render correctly | `@critical` | All nav links in `/dashboard` load without error |
+| `<Image />` renders via custom sharp loader | | Upload image via Supabase Storage → `<Image />` renders without 500 error |
+| Session refresh persists across page loads | | Navigate multiple pages → session stays valid |
+
+CI workflow addition to run E2E against Docker:
+
+```yaml
+# Addition to .github/workflows/deploy-docker.yml or a separate ci-docker.yml
+  e2e-docker:
+    name: E2E Tests Against Docker Image
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start application container
+        run: |
+          docker run -d \
+            --name enterprise-platform-e2e \
+            -p 3000:3000 \
+            --env SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
+            --env RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
+            ghcr.io/${{ github.repository }}:latest
+          # Wait for the server to be ready
+          timeout 60 bash -c 'until curl -sf http://localhost:3000; do sleep 2; done'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests against Docker image
+        run: pnpm e2e --project=chromium ui/e2e/docker/
+        env:
+          BASE_URL: http://localhost:3000
+          E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+
+      - name: Stop container
+        if: always()
+        run: docker stop enterprise-platform-e2e && docker rm enterprise-platform-e2e
+```
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Provider detection | Explicit `DEPLOY_TARGET` env var | Auto-detection at runtime | Vercel sets `VERCEL=1` but Docker has no equivalent; explicit is unambiguous and deliberate |
+| Default when `DEPLOY_TARGET` is unset | `vercel` behavior | Error or neutral default | Zero regression for existing Vercel adopters; safe fallback |
+| `output: "standalone"` | Gated on `docker` / `self-hosted` | Always-on | Always-on adds an unused `.next/standalone` artifact to Vercel builds; conditional is correct |
+| Image optimization for Docker | Custom `sharp` server-side loader | `unoptimized: true` | `unoptimized: true` degrades performance; `sharp` keeps optimization at server cost vs. CDN cost |
+| Dockerfile location | Monorepo root | `ui/Dockerfile` | Build context must include all workspace packages; root-level Dockerfile with pnpm workspace install is the correct pattern |
+| Supabase in Docker Compose | Excluded | Include Supabase containers | Template uses Supabase Cloud; local dev uses `supabase start` from the CLI; adding Supabase containers adds migrations, volumes, and seed complexity that is out of scope |
+| Container registry | GHCR (default) | Docker Hub / adopter-defined | GHCR uses `GITHUB_TOKEN` — no extra credentials; Docker Hub rate-limits and requires a secret |
+| Docker workflow trigger | `workflow_dispatch` (manual) | Automatic on push to main | Most adopters will not configure Docker secrets on first fork; manual trigger prevents accidental runs |
+| `NEXT_PUBLIC_*` at build vs. runtime | Build-time (Next.js constraint) | Runtime injection | This is a Next.js architectural constraint; the deliverable is clear documentation and a Dockerfile `ARG` pattern |
+| Cloudflare adapter in MVP | Follow-up stub only | Full adapter | `@cloudflare/next-on-pages` has significant compatibility gaps with App Router Server Actions; shipping a broken adapter is worse than shipping a documented stub |
+| Multi-platform Docker build | `linux/amd64,linux/arm64` | `linux/amd64` only | `sharp` native binaries are architecture-specific; building both prevents issues on AWS Graviton and Apple Silicon |
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `NEXT_PUBLIC_*` variables baked at build break image reuse across environments | High — adopters expect one image for staging and production | Document clearly in Dockerfile and environment guide; provide build-arg pattern; note implication explicitly |
+| `sharp` native binary architecture mismatch | High — image optimization fails silently or crashes | Multi-platform Docker builds in CI (`--platform linux/amd64,linux/arm64`); document `--platform` flag |
+| Middleware introduces Vercel-specific APIs in the future | High — silent breakage for Docker/self-hosted users | CI grep check added to `ci.yml`; middleware audit documented in `non-vercel-notes.md` |
+| Standalone build omits files needed by a workspace package | Medium — runtime `MODULE_NOT_FOUND` errors | Full build with `DEPLOY_TARGET=docker` in CI before release; known omission patterns documented |
+| Adopters set `DEPLOY_TARGET=docker` but do not rebuild the image | Medium — build configuration does not apply | Dockerfile `ARG DEPLOY_TARGET` makes this explicit; document in environment guide |
+| Docker Compose used in production without reverse proxy | Medium — no TLS; direct port 3000 exposure | Warning comment in `docker-compose.yml`; note in `docs/deployment/docker.md` |
+| `vercel.json` secrets pattern misleads adopters into thinking secrets are runtime-injected for Docker | Low — configuration confusion | Comment in `vercel.json` pointing to environment guide; provider-specific sections in docs |
+| Docker image exceeds 500 MB limit | Low — adoption barrier | `verify-image-size` job in GitHub Actions workflow fails the build if exceeded |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | `DEPLOY_TARGET` added to `turbo.json` `globalEnv`; `next.config.ts` conditional logic (`output`, `images.loader`) | None |
+| 2 | `ui/lib/image-loader.ts` (custom `sharp`-based loader); `sharp` optional peer dependency documented | Phase 1 |
+| 3 | `Dockerfile` at monorepo root (multi-stage: `deps`, `builder`, `runner`); `.dockerignore` | Phase 1 |
+| 4 | `docker-compose.yml` (default + `dev` profile); `.env.docker.example` | Phase 3 |
+| 5 | `.github/workflows/deploy-docker.yml` (build, tag, push to GHCR; multi-platform; image size check) | Phases 3–4 |
+| 6 | Middleware audit; CI grep guard added to `ci.yml`; `docs/deployment/non-vercel-notes.md` | Phase 1 |
+| 7 | `docs/developer-guide/environment-guide.mdx` updated (Docker, AWS ECS, Cloudflare sections); `docs/deployment/docker.md` step-by-step guide | Phases 3–4 |
+| 8 | Unit tests for `next.config.ts` conditional logic and `image-loader.ts` | Phases 1–2 |
+| 9 | E2E tests against Docker-built image in CI (`ui/e2e/docker/docker-build.spec.ts`) | Phases 3–5 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Explicit `DEPLOY_TARGET` vs. auto-detection | Explicit `DEPLOY_TARGET` | Auto-detection is fragile; `VERCEL=1` is set by Vercel but Docker has no equivalent signal; explicit opt-in is clear |
+| Default target when `DEPLOY_TARGET` is unset | `vercel` (Vercel behavior) | Unset = no change for existing adopters; zero regressions |
+| `output: "standalone"` gated or always-on | Gated on `docker` / `self-hosted` | Vercel benefits from its own pipeline; always-on adds unused `.next/standalone` to Vercel builds |
+| Image optimization outside Vercel: `unoptimized: true` or custom loader | Custom `sharp`-based server-side loader | `unoptimized: true` disables optimization entirely; `sharp` keeps it at server CPU cost vs. Vercel CDN |
+| Dockerfile at monorepo root or `ui/` workspace | Monorepo root | Build context must include all workspace packages; root Dockerfile with pnpm workspace install is correct |
+| Supabase containers in Docker Compose | Excluded | Template uses Supabase Cloud; Supabase containers add migration and seed complexity out of scope for MVP |
+| Docker workflow trigger | `workflow_dispatch` (manual) | Prevents accidental runs on fork without configured secrets |
+| Container registry | GHCR (default) | `GITHUB_TOKEN` — no extra credentials; Docker Hub requires a secret and rate-limits |
+| Cloudflare adapter in MVP | Follow-up stub only | `@cloudflare/next-on-pages` compatibility with App Router Server Actions is unverified; broken adapter is worse than documented stub |
+| `NEXT_PUBLIC_*` build-time vs. runtime | Document clearly; `ARG` pattern in Dockerfile | Next.js architectural constraint; key deliverable is clear documentation |
+
+---
+
+## File inventory
+
+### New files
+
+| File | Description |
+|------|-------------|
+| `Dockerfile` | Multi-stage production build targeting `@enterprise/web` standalone output |
+| `.dockerignore` | Docker build context exclusions |
+| `docker-compose.yml` | Self-hosted production and local dev Compose configuration |
+| `.env.docker.example` | Docker/self-hosted environment variable template with comments |
+| `ui/lib/image-loader.ts` | Custom `sharp`-based image loader for non-Vercel targets |
+| `.github/workflows/deploy-docker.yml` | GitHub Actions workflow for Docker build, GHCR push, and optional deploy |
+| `docs/deployment/docker.md` | Step-by-step guide: copy env → fill values → `docker compose up` |
+| `docs/deployment/non-vercel-notes.md` | Middleware compatibility audit; notes on Edge Runtime vs. Node.js runtime |
+| `ui/e2e/docker/docker-build.spec.ts` | E2E tests run against Docker-built image |
+| `packages/core/src/__tests__/deploy-config.test.ts` | Unit tests for config conditional logic |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `ui/next.config.ts` | Add `DEPLOY_TARGET` conditional logic for `output`, `images.loader`, `images.unoptimized` |
+| `turbo.json` | Add `DEPLOY_TARGET` to `globalEnv` for build cache invalidation |
+| `.github/workflows/ci.yml` | Add middleware audit grep step to catch Vercel-specific API regressions |
+| `docs/developer-guide/environment-guide.mdx` | Add Docker, AWS ECS, and Cloudflare provider sections |
+
+---
+
+*Last updated: 2026-05-11*

--- a/docs/features/roadmap.md
+++ b/docs/features/roadmap.md
@@ -2,7 +2,7 @@
 title: "Feature roadmap"
 description: "Defines the implementation priority order for planned feature work in the multi-tenant SaaS template."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-05-12"
 ---
 
 # Feature roadmap
@@ -22,18 +22,25 @@ Define the canonical implementation priority for planned features in this templa
 
 | Order | Priority | Feature | Status | Why now |
 |------:|----------|---------|--------|---------|
-| 1 | P0 | Tenant team management | Planned | Completes the core multi-tenant member lifecycle. |
-| 2 | P0 | Workspace admin | Planned | Makes tenant operations usable in day-to-day product workflows. |
-| 3 | P0 | Billing and plans | Planned | Enables SaaS monetization and plan-based packaging. |
-| 4 | P1 | Notifications | Planned | Supports invites, billing events, and critical product communication. |
-| 5 | P1 | Public API and API keys | Planned | Unlocks integrations and external automation. |
-| 6 | P1 | Webhooks | Planned | Completes outbound integration workflows for technical adopters. |
-| 7 | P1 | Usage limits and quotas | Planned | Enforces plan value and protects shared resources. |
-| 8 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |
-| 9 | P2 | File storage module | Planned | Covers a common SaaS need for tenant-scoped file handling. |
-| 10 | P2 | i18n and regional settings | Planned | Expands reuse across regions and teams. |
-| 11 | P3 | Feature flags | Planned | Adds rollout and packaging control after the core platform exists. |
-| 12 | P3 | Secure impersonation | Planned | Adds advanced support tooling after admin and audit flows mature. |
+| 1 | P0 | Example resource management | Done | Reference CRUD module demonstrating the service layer pattern. |
+| 2 | P0 | Theme system | Done | JSON-configurable design tokens, build-time CSS generation, light/dark mode. |
+| 3 | P0 | Form validation | Done | Shared FormField/FormMessage, useActionState + ActionResult, inline error UX. |
+| 4 | P0 | Tenant team management | Done | Completes the core multi-tenant member lifecycle. |
+| 5 | P0 | Workspace admin | Done | Makes tenant operations usable in day-to-day product workflows. |
+| 6 | P0 | Billing and plans | Planned | Enables SaaS monetization and plan-based packaging. |
+| 7 | P1 | Notifications | Planned | Supports invites, billing events, and critical product communication. |
+| 8 | P1 | Public API and API keys | Planned | Unlocks integrations and external automation. |
+| 9 | P1 | Webhooks | Planned | Completes outbound integration workflows for technical adopters. |
+| 10 | P1 | Usage limits and quotas | Planned | Enforces plan value and protects shared resources. |
+| 11 | P1 | Brand abstraction layer | Planned | Enables multi-brand support from a single codebase with provider-agnostic branding. |
+| 12 | P1 | Brand isolation package | Planned | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
+| 13 | P1 | Backend provider decoupling | Planned | Introduces port/adapter interfaces to decouple @enterprise/core from Supabase. |
+| 14 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |
+| 15 | P2 | File storage module | Planned | Covers a common SaaS need for tenant-scoped file handling. |
+| 16 | P2 | i18n and regional settings | Planned | Expands reuse across regions and teams. |
+| 17 | P2 | Deployment provider decoupling | Planned | Adds Docker support and deployment-target abstraction for non-Vercel hosting. |
+| 18 | P3 | Feature flags | Planned | Adds rollout and packaging control after the core platform exists. |
+| 19 | P3 | Secure impersonation | Planned | Adds advanced support tooling after admin and audit flows mature. |
 
 ---
 
@@ -61,10 +68,18 @@ Define the canonical implementation priority for planned features in this templa
 ## Related documents
 
 - [Documentation structure](../README.md)
+- [Example resource management PRD](./example-resource-management/prd.md)
+- [Theme system PRD](./theme-system/prd.md)
+- [Form validation PRD](./form-validation/prd.md)
 - [Tenant team management PRD](./tenant-team-management/prd.md)
+- [Workspace admin PRD](./workspace-admin/prd.md)
 - [Billing and plans PRD](./billing-and-plans/prd.md)
 - [Public API and API keys PRD](./public-api-and-api-keys/prd.md)
+- [Brand abstraction layer PRD](./brand-abstraction-layer/prd.md)
+- [Brand isolation package PRD](./brand-isolation-package/prd.md)
+- [Backend provider decoupling PRD](./backend-provider-decoupling/prd.md)
+- [Deployment provider decoupling PRD](./deployment-provider-decoupling/prd.md)
 
 ---
 
-*Last updated: 2026-05-07*
+*Last updated: 2026-05-12*

--- a/packages/ui/src/components/__tests__/form-banner.test.ts
+++ b/packages/ui/src/components/__tests__/form-banner.test.ts
@@ -1,8 +1,16 @@
 /**
  * FormBanner — unit tests
  *
- * Tests the exported FormBanner component's render logic.
- * We invoke the component function directly since it has simple conditional logic.
+ * Tests the exported FormBanner component's conditional render logic.
+ * We invoke the component function directly and inspect the returned React
+ * element's props — no DOM or rendering context required.
+ *
+ * Scenarios covered:
+ * - Returns null when state is null
+ * - Renders error banner with role="alert" for form-level errors only
+ * - Does NOT render banner when hasFieldErrors(state) is true
+ * - Renders success banner (green classes) when state.success && successMessage
+ * - Returns null when state.success but no successMessage provided
  */
 
 import type { ActionResult } from "@enterprise/contracts";
@@ -10,16 +18,12 @@ import { describe, expect, it } from "vitest";
 import { FormBanner } from "../form-banner";
 
 describe("FormBanner", () => {
-  it("is a named export and a function", () => {
-    expect(typeof FormBanner).toBe("function");
-  });
-
   it("returns null when state is null", () => {
     const result = FormBanner({ state: null });
     expect(result).toBeNull();
   });
 
-  it("renders error banner for form-level error (no field-level errors)", () => {
+  it("renders error banner with role='alert' for form-level error (no field-level errors)", () => {
     const state: ActionResult = {
       success: false,
       error: {
@@ -29,10 +33,22 @@ describe("FormBanner", () => {
     };
     const result = FormBanner({ state });
     expect(result).not.toBeNull();
-    expect(result).toBeDefined();
+    expect(result).toMatchObject({ props: { role: "alert" } });
   });
 
-  it("returns null when there are field-level errors (banner is not shown)", () => {
+  it("error banner contains the error message from state", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "AUTH_ERROR",
+        message: "Something went wrong.",
+      },
+    };
+    const result = FormBanner({ state });
+    expect(result).toMatchObject({ props: { children: "Something went wrong." } });
+  });
+
+  it("returns null when there are field-level errors (hasFieldErrors is true)", () => {
     const state: ActionResult = {
       success: false,
       error: {
@@ -45,14 +61,24 @@ describe("FormBanner", () => {
     expect(result).toBeNull();
   });
 
-  it("renders success banner when state is successful and successMessage provided", () => {
+  it("renders success banner (green classes) when state.success && successMessage provided", () => {
     const state: ActionResult = { success: true, data: undefined };
     const result = FormBanner({ state, successMessage: "Saved successfully." });
     expect(result).not.toBeNull();
-    expect(result).toBeDefined();
+    const className: string = (result as { props: { className: string } }).props.className;
+    expect(className).toContain("bg-green-500");
+    expect(className).toContain("text-green-500");
   });
 
-  it("returns null when state is successful but no successMessage provided", () => {
+  it("success banner has no role='alert'", () => {
+    const state: ActionResult = { success: true, data: undefined };
+    const result = FormBanner({ state, successMessage: "Done." });
+    // Success banner is informational, not an alert
+    const role = (result as { props: { role?: string } }).props.role;
+    expect(role).toBeUndefined();
+  });
+
+  it("returns null when state.success but no successMessage provided", () => {
     const state: ActionResult = { success: true, data: undefined };
     const result = FormBanner({ state });
     expect(result).toBeNull();

--- a/packages/ui/src/components/__tests__/form-field.test.ts
+++ b/packages/ui/src/components/__tests__/form-field.test.ts
@@ -1,19 +1,125 @@
+// @vitest-environment happy-dom
 /**
  * FormField — unit tests
  *
- * FormField uses `useId` and `cloneElement` which require a React rendering
- * context. In node environment without a DOM, we verify the module exports
- * and the component's interface contract.
+ * FormField uses `useId`, `cloneElement`, and renders Label + optional
+ * FormMessage. We render it with ReactDOM.createRoot + act() using the
+ * happy-dom environment.
+ *
+ * Scenarios:
+ * - No error state: no FormMessage, no aria-invalid, no aria-describedby
+ * - Field error present: FormMessage renders, aria-invalid set, aria-describedby links error id
+ * - required=true: label shows " *" indicator
  */
-import { describe, expect, it } from "vitest";
-import { FormField } from "../form-field";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { act, createElement, type ReactElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTree(tree: ReactElement): { container: HTMLDivElement; root: ReactDOM.Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+/** Build a FormField element with an `<input>` child — avoids TS children-in-props noise */
+function field(
+  Comp: typeof import("../form-field").FormField,
+  props: { name: string; label: string; state: ActionResult | null; required?: boolean },
+): ReactElement {
+  // Cast to `never` to satisfy createElement overload — children is the third arg
+  return createElement(Comp, props as never, createElement("input", { type: "text" }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("FormField", () => {
-  it("is a named export and a function", () => {
-    expect(typeof FormField).toBe("function");
+  let FormField: typeof import("../form-field").FormField;
+  const cleanup: Array<() => void> = [];
+
+  beforeEach(async () => {
+    const mod = await import("../form-field");
+    FormField = mod.FormField;
   });
 
-  it("has the correct display name / function name", () => {
-    expect(FormField.name).toBe("FormField");
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+  });
+
+  it("no error state: no FormMessage rendered, no aria-invalid attribute", () => {
+    const { container, root } = renderTree(
+      field(FormField, { name: "email", label: "Email", state: null }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    // No role="alert" element (FormMessage not rendered)
+    const alert = container.querySelector("[role='alert']");
+    expect(alert).toBeNull();
+
+    // Input does not have aria-invalid
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("aria-invalid")).toBeNull();
+  });
+
+  it("field error present: FormMessage renders, aria-invalid set, aria-describedby links to error id", () => {
+    const state: ActionResult = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Please fix the errors below.",
+        details: { email: ["Must be a valid email address"] },
+      },
+    };
+
+    const { container, root } = renderTree(
+      field(FormField, { name: "email", label: "Email", state }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    // FormMessage is rendered (role="alert")
+    const alert = container.querySelector("[role='alert']");
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toBe("Must be a valid email address");
+
+    // Input has aria-invalid="true"
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("aria-invalid")).toBe("true");
+
+    // aria-describedby on input references the error element's id
+    const describedBy = input?.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(alert?.id).toBe(describedBy);
+  });
+
+  it("required=true: label shows ' *' indicator", () => {
+    const { container, root } = renderTree(
+      field(FormField, { name: "email", label: "Email", state: null, required: true }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    const label = container.querySelector("label");
+    expect(label?.textContent).toContain("*");
+  });
+
+  it("required=false (default): label does not show ' *' indicator", () => {
+    const { container, root } = renderTree(
+      field(FormField, { name: "email", label: "Email", state: null }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    const label = container.querySelector("label");
+    expect(label?.textContent).not.toContain("*");
   });
 });

--- a/packages/ui/src/components/__tests__/form-message.test.ts
+++ b/packages/ui/src/components/__tests__/form-message.test.ts
@@ -1,22 +1,17 @@
 /**
  * FormMessage — unit tests
  *
- * Tests the exported FormMessage component's render logic.
- * Since the ui project runs in a node environment without a DOM,
- * we test the module exports and confirm the component is exported correctly.
- * The core logic (returns null when children is falsy) is a conditional return —
- * validated here by confirming the component is a function with the right shape.
+ * The component has simple conditional render logic.
+ * We invoke it directly as a function (valid in React 19 / RSC-style testing)
+ * and inspect the returned React element's props.
+ *
+ * No DOM required — node environment is sufficient.
  */
 import { describe, expect, it } from "vitest";
 import { FormMessage } from "../form-message";
 
 describe("FormMessage", () => {
-  it("is a named export and a function", () => {
-    expect(typeof FormMessage).toBe("function");
-  });
-
   it("returns null when children is falsy (empty string)", () => {
-    // Invoke component function directly — no DOM needed for null-return check
     const result = FormMessage({ children: "" });
     expect(result).toBeNull();
   });
@@ -26,9 +21,28 @@ describe("FormMessage", () => {
     expect(result).toBeNull();
   });
 
-  it("returns a React element when children is a non-empty string", () => {
-    const result = FormMessage({ children: "Required" });
+  it("returns null when children is false", () => {
+    const result = FormMessage({ children: false });
+    expect(result).toBeNull();
+  });
+
+  it("returns a React element with role='alert' when children is a non-empty string", () => {
+    const result = FormMessage({ children: "This field is required." });
     expect(result).not.toBeNull();
-    expect(result).toBeDefined();
+    // React element is a plain object with { type, props, ... }
+    expect(result).toMatchObject({ props: { role: "alert" } });
+  });
+
+  it("returned element has text-xs and text-destructive classes", () => {
+    const result = FormMessage({ children: "Error text" });
+    expect(result).not.toBeNull();
+    const className: string = (result as { props: { className: string } }).props.className;
+    expect(className).toContain("text-xs");
+    expect(className).toContain("text-destructive");
+  });
+
+  it("passes id prop to the rendered element", () => {
+    const result = FormMessage({ children: "Error", id: "email-error" });
+    expect(result).toMatchObject({ props: { id: "email-error" } });
   });
 });

--- a/packages/ui/src/components/__tests__/submit-button.test.ts
+++ b/packages/ui/src/components/__tests__/submit-button.test.ts
@@ -1,19 +1,111 @@
+// @vitest-environment happy-dom
 /**
  * SubmitButton — unit tests
  *
- * SubmitButton uses `useFormStatus` which requires a React rendering context.
- * In node environment without a DOM, we verify the module exports and
- * the component's interface contract.
+ * SubmitButton uses `useFormStatus()` from react-dom.
+ * We mock react-dom to control the pending state without needing a real form
+ * submission context.
+ *
+ * Rendering uses ReactDOM.createRoot + act() — same pattern as provider.test.ts.
+ *
+ * Scenarios:
+ * - Idle state: shows children text, button is NOT disabled
+ * - Pending state: shows pendingText, button IS disabled
  */
-import { describe, expect, it } from "vitest";
-import { SubmitButton } from "../submit-button";
+
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock react-dom to control useFormStatus
+// ---------------------------------------------------------------------------
+
+const mockPending = { current: false };
+
+vi.mock("react-dom", async (importOriginal) => {
+  const original = await importOriginal<typeof import("react-dom")>();
+  return {
+    ...original,
+    useFormStatus: () => ({ pending: mockPending.current, data: null, method: null, action: null }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTree(tree: React.ReactElement): { container: HTMLDivElement; root: ReactDOM.Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("SubmitButton", () => {
-  it("is a named export and a function", () => {
-    expect(typeof SubmitButton).toBe("function");
+  // Import after mock is in place
+  let SubmitButton: typeof import("../submit-button").SubmitButton;
+  const cleanup: Array<() => void> = [];
+
+  beforeEach(async () => {
+    const mod = await import("../submit-button");
+    SubmitButton = mod.SubmitButton;
+    mockPending.current = false;
   });
 
-  it("has the correct display name / function name", () => {
-    expect(SubmitButton.name).toBe("SubmitButton");
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("idle state: renders children text and button is not disabled", () => {
+    mockPending.current = false;
+    const { container, root } = renderTree(createElement(SubmitButton, null, "Save changes"));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe("Save changes");
+    expect(button?.disabled).toBe(false);
+  });
+
+  it("pending state: renders pendingText and button is disabled", () => {
+    mockPending.current = true;
+    const { container, root } = renderTree(
+      createElement(SubmitButton, { pendingText: "Saving…" }, "Save changes"),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe("Saving…");
+    expect(button?.disabled).toBe(true);
+  });
+
+  it("pending state: uses default pendingText 'Saving…' when prop is omitted", () => {
+    mockPending.current = true;
+    const { container, root } = renderTree(createElement(SubmitButton, null, "Submit"));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Saving…");
+    expect(button?.disabled).toBe(true);
+  });
+
+  it("button has type='submit'", () => {
+    mockPending.current = false;
+    const { container, root } = renderTree(createElement(SubmitButton, null, "Go"));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const button = container.querySelector("button");
+    expect(button?.type).toBe("submit");
   });
 });


### PR DESCRIPTION
## Summary

- Add 4 new PRD+RFC pairs for multi-brand platform evolution (brand-abstraction-layer, brand-isolation-package, backend-provider-decoupling, deployment-provider-decoupling)
- Rewrite billing-and-plans PRD and RFC to implementation-ready depth
- Update roadmap.md with features 13-16
- Add 4 missing unit tests for form-validation shared UI components (FormMessage, FormBanner, SubmitButton, FormField) — completing the form-validation SDD test gap
- Add form-validation auto-invoke rows to root AGENTS.md

## Type of Change

- [x] Documentation
- [x] Tests
- [x] Chore (no production code changes)

## Test Results

- `pnpm --filter @enterprise/ui test` — 88/88 passing (was 81)

## Checklist

- [x] All code and comments in English
- [x] No production code modified
- [x] Tests pass locally