### PR TITLE
feat(db): add billing Drizzle schema and migration [2/7]

### DIFF
--- a/packages/contracts/src/__tests__/billing.test.ts
+++ b/packages/contracts/src/__tests__/billing.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "vitest";
+import {
+  BILLING_CYCLE,
+  SUBSCRIPTION_STATUS,
+  billingCycleSchema,
+  billingEventSchema,
+  billingHistoryQuerySchema,
+  cancelSubscriptionSchema,
+  changePlanSchema,
+  planSchema,
+  subscriptionSchema,
+  subscriptionStatusSchema,
+} from "../dto/billing";
+
+// ============================================================================
+// subscriptionStatusSchema
+// ============================================================================
+
+describe("subscriptionStatusSchema", () => {
+  it("accepts 'trialing'", () => {
+    const result = subscriptionStatusSchema.safeParse("trialing");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'active'", () => {
+    const result = subscriptionStatusSchema.safeParse("active");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'past_due'", () => {
+    const result = subscriptionStatusSchema.safeParse("past_due");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'canceled'", () => {
+    const result = subscriptionStatusSchema.safeParse("canceled");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'unpaid'", () => {
+    const result = subscriptionStatusSchema.safeParse("unpaid");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid status value", () => {
+    const result = subscriptionStatusSchema.safeParse("expired");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    const result = subscriptionStatusSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes all values via SUBSCRIPTION_STATUS const", () => {
+    expect(SUBSCRIPTION_STATUS.TRIALING).toBe("trialing");
+    expect(SUBSCRIPTION_STATUS.ACTIVE).toBe("active");
+    expect(SUBSCRIPTION_STATUS.PAST_DUE).toBe("past_due");
+    expect(SUBSCRIPTION_STATUS.CANCELED).toBe("canceled");
+    expect(SUBSCRIPTION_STATUS.UNPAID).toBe("unpaid");
+  });
+});
+
+// ============================================================================
+// billingCycleSchema
+// ============================================================================
+
+describe("billingCycleSchema", () => {
+  it("accepts 'monthly'", () => {
+    const result = billingCycleSchema.safeParse("monthly");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'yearly'", () => {
+    const result = billingCycleSchema.safeParse("yearly");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 'weekly'", () => {
+    const result = billingCycleSchema.safeParse("weekly");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    const result = billingCycleSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes all values via BILLING_CYCLE const", () => {
+    expect(BILLING_CYCLE.MONTHLY).toBe("monthly");
+    expect(BILLING_CYCLE.YEARLY).toBe("yearly");
+  });
+});
+
+// ============================================================================
+// planSchema
+// ============================================================================
+
+describe("planSchema", () => {
+  const validPlan = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    name: "Pro",
+    slug: "pro",
+    description: "The Pro plan",
+    priceMonthly: 2900,
+    priceYearly: 29000,
+    currency: "usd",
+    features: '{"ai":true}',
+    limits: '{"members":10}',
+    isActive: true,
+    displayOrder: 1,
+    trialDays: 14,
+  };
+
+  it("accepts a valid plan object", () => {
+    const result = planSchema.safeParse(validPlan);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null description", () => {
+    const result = planSchema.safeParse({ ...validPlan, description: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field 'name'", () => {
+    const { name: _name, ...withoutName } = validPlan;
+    const result = planSchema.safeParse(withoutName);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field 'slug'", () => {
+    const { slug: _slug, ...withoutSlug } = validPlan;
+    const result = planSchema.safeParse(withoutSlug);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field 'priceMonthly'", () => {
+    const { priceMonthly: _pm, ...withoutPrice } = validPlan;
+    const result = planSchema.safeParse(withoutPrice);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for id", () => {
+    const result = planSchema.safeParse({ ...validPlan, id: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// subscriptionSchema
+// ============================================================================
+
+describe("subscriptionSchema", () => {
+  const validSubscription = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    tenantId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    planId: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+    status: "active" as const,
+    billingCycle: "monthly" as const,
+    currentPeriodStart: "2024-01-01T00:00:00.000Z",
+    currentPeriodEnd: "2024-02-01T00:00:00.000Z",
+    cancelAtPeriodEnd: false,
+    canceledAt: null,
+    trialEndsAt: null,
+    graceEndsAt: null,
+    externalSubscriptionId: null,
+    externalCustomerId: null,
+  };
+
+  it("accepts a valid subscription object", () => {
+    const result = subscriptionSchema.safeParse(validSubscription);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable canceledAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, canceledAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable trialEndsAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, trialEndsAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable graceEndsAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, graceEndsAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalSubscriptionId", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      externalSubscriptionId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalCustomerId", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      externalCustomerId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows optional nested plan", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      plan: {
+        id: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+        name: "Pro",
+        slug: "pro",
+        description: null,
+        priceMonthly: 2900,
+        priceYearly: 29000,
+        currency: "usd",
+        features: "{}",
+        limits: "{}",
+        isActive: true,
+        displayOrder: 1,
+        trialDays: 14,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts subscription without nested plan", () => {
+    const result = subscriptionSchema.safeParse(validSubscription);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plan).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid status value", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, status: "expired" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// billingEventSchema
+// ============================================================================
+
+describe("billingEventSchema", () => {
+  const validEvent = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    tenantId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    subscriptionId: null,
+    eventType: "payment.succeeded",
+    provider: "stripe",
+    externalEventId: "evt_001",
+    processedAt: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid billing event", () => {
+    const result = billingEventSchema.safeParse(validEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable subscriptionId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, subscriptionId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalEventId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, externalEventId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable processedAt", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, processedAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field 'eventType'", () => {
+    const { eventType: _et, ...withoutEventType } = validEvent;
+    const result = billingEventSchema.safeParse(withoutEventType);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for tenantId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, tenantId: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// changePlanSchema
+// ============================================================================
+
+describe("changePlanSchema", () => {
+  it("accepts a valid UUID planId", () => {
+    const result = changePlanSchema.safeParse({
+      planId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-UUID planId", () => {
+    const result = changePlanSchema.safeParse({ planId: "pro-plan" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string planId", () => {
+    const result = changePlanSchema.safeParse({ planId: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing planId", () => {
+    const result = changePlanSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// cancelSubscriptionSchema
+// ============================================================================
+
+describe("cancelSubscriptionSchema", () => {
+  it("defaults cancelAtPeriodEnd to true when not provided", () => {
+    const result = cancelSubscriptionSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(true);
+    }
+  });
+
+  it("accepts explicit true", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(true);
+    }
+  });
+
+  it("accepts explicit false", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(false);
+    }
+  });
+
+  it("rejects a string value for cancelAtPeriodEnd", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: "true" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// billingHistoryQuerySchema
+// ============================================================================
+
+describe("billingHistoryQuerySchema", () => {
+  it("applies default limit of 50 when not provided", () => {
+    const result = billingHistoryQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("applies default offset of 0 when not provided", () => {
+    const result = billingHistoryQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it("accepts limit = 1 (minimum boundary)", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts limit = 100 (maximum boundary)", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects limit > 100", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit < 1", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid offset", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 50, offset: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative offset", () => {
+    const result = billingHistoryQuerySchema.safeParse({ offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts limit and offset together", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 25, offset: 50 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(25);
+      expect(result.data.offset).toBe(50);
+    }
+  });
+});

--- a/packages/contracts/src/__tests__/billing.test.ts
+++ b/packages/contracts/src/__tests__/billing.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   BILLING_CYCLE,
-  SUBSCRIPTION_STATUS,
   billingCycleSchema,
   billingEventSchema,
   billingHistoryQuerySchema,
   cancelSubscriptionSchema,
   changePlanSchema,
   planSchema,
+  SUBSCRIPTION_STATUS,
   subscriptionSchema,
   subscriptionStatusSchema,
 } from "../dto/billing";

--- a/packages/contracts/src/dto/billing.ts
+++ b/packages/contracts/src/dto/billing.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+// ============================================================================
+// Subscription Status
+// ============================================================================
+
+export const SUBSCRIPTION_STATUS = {
+  TRIALING: "trialing",
+  ACTIVE: "active",
+  PAST_DUE: "past_due",
+  CANCELED: "canceled",
+  UNPAID: "unpaid",
+} as const;
+
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUS)[keyof typeof SUBSCRIPTION_STATUS];
+
+export const subscriptionStatusSchema = z.enum([
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+]);
+
+// ============================================================================
+// Billing Cycle
+// ============================================================================
+
+export const BILLING_CYCLE = {
+  MONTHLY: "monthly",
+  YEARLY: "yearly",
+} as const;
+
+export type BillingCycle = (typeof BILLING_CYCLE)[keyof typeof BILLING_CYCLE];
+
+export const billingCycleSchema = z.enum(["monthly", "yearly"]);
+
+// ============================================================================
+// Plan (output)
+// ============================================================================
+
+export const planSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  priceMonthly: z.number().int(),
+  priceYearly: z.number().int(),
+  currency: z.string(),
+  features: z.string(),
+  limits: z.string(),
+  isActive: z.boolean(),
+  displayOrder: z.number().int(),
+  trialDays: z.number().int(),
+});
+
+export type PlanDto = z.infer<typeof planSchema>;
+
+// ============================================================================
+// Subscription (output)
+// ============================================================================
+
+export const subscriptionSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  planId: z.string().uuid(),
+  status: subscriptionStatusSchema,
+  billingCycle: billingCycleSchema,
+  currentPeriodStart: z.string().datetime(),
+  currentPeriodEnd: z.string().datetime(),
+  cancelAtPeriodEnd: z.boolean(),
+  canceledAt: z.string().datetime().nullable(),
+  trialEndsAt: z.string().datetime().nullable(),
+  graceEndsAt: z.string().datetime().nullable(),
+  externalSubscriptionId: z.string().nullable(),
+  externalCustomerId: z.string().nullable(),
+  plan: planSchema.optional(),
+});
+
+export type SubscriptionDto = z.infer<typeof subscriptionSchema>;
+
+// ============================================================================
+// Billing Event (output)
+// ============================================================================
+
+export const billingEventSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  subscriptionId: z.string().uuid().nullable(),
+  eventType: z.string(),
+  provider: z.string(),
+  externalEventId: z.string().nullable(),
+  processedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type BillingEventDto = z.infer<typeof billingEventSchema>;
+
+// ============================================================================
+// Change Plan (input)
+// ============================================================================
+
+export const changePlanSchema = z.object({
+  planId: z.string().uuid(),
+});
+
+export type ChangePlanDto = z.infer<typeof changePlanSchema>;
+
+// ============================================================================
+// Cancel Subscription (input)
+// ============================================================================
+
+export const cancelSubscriptionSchema = z.object({
+  cancelAtPeriodEnd: z.boolean().default(true),
+});
+
+export type CancelSubscriptionDto = z.infer<typeof cancelSubscriptionSchema>;
+
+// ============================================================================
+// Billing History Query (input)
+// ============================================================================
+
+export const billingHistoryQuerySchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+
+export type BillingHistoryQueryDto = z.infer<typeof billingHistoryQuerySchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@
 
 // Re-export Zod for convenience
 export { z } from "zod";
+export * from "./dto/billing";
 // DTOs
 export * from "./dto/platform";
 export * from "./dto/resources";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@
 export type { PgTable } from "drizzle-orm/pg-core";
 // Re-export drizzle utilities
 export { drizzle } from "drizzle-orm/postgres-js";
+export * from "./schema/billing.js";
 // Re-export new types explicitly for consumers
 export type { NewTenantInvitation, TenantInvitation } from "./schema/platform.js";
 export * from "./schema/platform.js";

--- a/packages/db/src/schema/billing.ts
+++ b/packages/db/src/schema/billing.ts
@@ -1,0 +1,212 @@
+// Billing schema - Plans, tenant subscriptions, and billing events with RLS
+// All billing writes are service_role only (webhook handler + service layer)
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  pgEnum,
+  pgPolicy,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { authenticatedRole, serviceRole } from "drizzle-orm/supabase";
+import { tenants } from "./platform.js";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/** Subscription lifecycle status */
+export const subscriptionStatusEnum = pgEnum("subscription_status", [
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+]);
+
+/** Billing frequency */
+export const billingCycleEnum = pgEnum("billing_cycle", ["monthly", "yearly"]);
+
+// ============================================================================
+// RLS Helpers
+// ============================================================================
+
+/** Matches the tenant_id column against the JWT app_metadata tenant_id claim */
+const tenantClaimMatchesColumn = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+
+/** Restricts access to owner and admin roles via app_metadata */
+const ownerOrAdminRoleClaim = sql`(auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))`;
+
+// ============================================================================
+// Plans Table
+// ============================================================================
+
+/** Plans - the billing catalog (public read, service_role write) */
+export const plans = pgTable(
+  "plans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: text("name").notNull(),
+    slug: text("slug").notNull().unique(),
+    description: text("description"),
+    priceMonthly: integer("price_monthly").notNull(), // cents
+    priceYearly: integer("price_yearly").notNull(), // cents
+    currency: text("currency").notNull().default("usd"),
+    features: text("features").notNull(), // JSON string
+    limits: text("limits").notNull(), // JSON string
+    isActive: boolean("is_active").notNull().default(true),
+    displayOrder: integer("display_order").notNull().default(0),
+    trialDays: integer("trial_days").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("plans_slug_idx").on(table.slug),
+    index("plans_active_order_idx").on(table.isActive, table.displayOrder),
+    // Plans are a public catalog — any authenticated user can read
+    pgPolicy("plans_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`true`,
+    }),
+    pgPolicy("plans_insert", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("plans_update", {
+      as: "permissive",
+      for: "update",
+      to: serviceRole,
+      using: sql`true`,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("plans_delete", {
+      as: "permissive",
+      for: "delete",
+      to: serviceRole,
+      using: sql`true`,
+    }),
+  ],
+).enableRLS();
+
+// ============================================================================
+// Tenant Subscriptions Table
+// ============================================================================
+
+/** Tenant subscriptions - one active subscription per tenant */
+export const tenantSubscriptions = pgTable(
+  "tenant_subscriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" })
+      .unique(),
+    planId: uuid("plan_id")
+      .notNull()
+      .references(() => plans.id),
+    status: subscriptionStatusEnum("status").notNull(),
+    billingCycle: billingCycleEnum("billing_cycle").notNull(),
+    currentPeriodStart: timestamp("current_period_start", { withTimezone: true }).notNull(),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }).notNull(),
+    cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
+    canceledAt: timestamp("canceled_at", { withTimezone: true }),
+    trialEndsAt: timestamp("trial_ends_at", { withTimezone: true }),
+    graceEndsAt: timestamp("grace_ends_at", { withTimezone: true }),
+    externalSubscriptionId: text("external_subscription_id").unique(),
+    externalCustomerId: text("external_customer_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("subscriptions_tenant_idx").on(table.tenantId),
+    index("subscriptions_external_id_idx").on(table.externalSubscriptionId),
+    index("subscriptions_status_idx").on(table.status),
+    // Only owner and admin can read their tenant's subscription
+    pgPolicy("subscriptions_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`(${tenantClaimMatchesColumn} AND ${ownerOrAdminRoleClaim})`,
+    }),
+    // All writes via service_role only (webhook handler + service layer)
+    pgPolicy("subscriptions_insert_sr", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("subscriptions_update_sr", {
+      as: "permissive",
+      for: "update",
+      to: serviceRole,
+      using: sql`true`,
+      withCheck: sql`true`,
+    }),
+    // No DELETE policy — status transitions only, never hard delete
+  ],
+).enableRLS();
+
+// ============================================================================
+// Billing Events Table
+// ============================================================================
+
+/** Billing events - immutable audit trail of all payment provider events */
+export const billingEvents = pgTable(
+  "billing_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    subscriptionId: uuid("subscription_id").references(() => tenantSubscriptions.id),
+    eventType: text("event_type").notNull(),
+    provider: text("provider").notNull(),
+    externalEventId: text("external_event_id").unique(),
+    payload: text("payload"), // JSON string
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("billing_events_tenant_idx").on(table.tenantId),
+    index("billing_events_external_event_idx").on(table.externalEventId),
+    index("billing_events_subscription_idx").on(table.subscriptionId),
+    // Only owner and admin can read their tenant's billing events
+    pgPolicy("billing_events_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`(${tenantClaimMatchesColumn} AND ${ownerOrAdminRoleClaim})`,
+    }),
+    // All writes via service_role only — immutable after insert
+    pgPolicy("billing_events_insert_sr", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    // No UPDATE — immutable after insert
+    // No DELETE — audit records must be retained
+  ],
+).enableRLS();
+
+// ============================================================================
+// Type Exports (for use in services)
+// ============================================================================
+
+export type Plan = typeof plans.$inferSelect;
+export type NewPlan = typeof plans.$inferInsert;
+
+export type TenantSubscription = typeof tenantSubscriptions.$inferSelect;
+export type NewTenantSubscription = typeof tenantSubscriptions.$inferInsert;
+
+export type BillingEvent = typeof billingEvents.$inferSelect;
+export type NewBillingEvent = typeof billingEvents.$inferInsert;

--- a/supabase/migrations/20260521000001_billing_schema.sql
+++ b/supabase/migrations/20260521000001_billing_schema.sql
@@ -1,0 +1,183 @@
+-- Billing schema: plans, tenant_subscriptions, billing_events
+-- Adds subscription lifecycle management with RLS-enforced tenant isolation.
+-- All writes are service_role only (webhook handler + service layer).
+
+-- ============================================================================
+-- Enums
+-- ============================================================================
+
+CREATE TYPE "public"."subscription_status" AS ENUM(
+  'trialing',
+  'active',
+  'past_due',
+  'canceled',
+  'unpaid'
+);
+
+CREATE TYPE "public"."billing_cycle" AS ENUM('monthly', 'yearly');
+
+-- ============================================================================
+-- plans
+-- ============================================================================
+
+CREATE TABLE "plans" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "slug" text NOT NULL,
+  "description" text,
+  "price_monthly" integer NOT NULL,
+  "price_yearly" integer NOT NULL,
+  "currency" text DEFAULT 'usd' NOT NULL,
+  "features" text NOT NULL,
+  "limits" text NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "display_order" integer DEFAULT 0 NOT NULL,
+  "trial_days" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "plans_slug_unique" UNIQUE("slug")
+);
+
+ALTER TABLE "plans" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "plans_slug_idx" ON "plans" USING btree ("slug");
+CREATE INDEX "plans_active_order_idx" ON "plans" USING btree ("is_active", "display_order");
+
+-- Plans are a public catalog — any authenticated user can read
+CREATE POLICY "plans_select" ON "plans"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (true);
+
+-- All writes via service_role only
+CREATE POLICY "plans_insert" ON "plans"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+CREATE POLICY "plans_update" ON "plans"
+  AS PERMISSIVE FOR UPDATE
+  TO "service_role"
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "plans_delete" ON "plans"
+  AS PERMISSIVE FOR DELETE
+  TO "service_role"
+  USING (true);
+
+-- ============================================================================
+-- tenant_subscriptions
+-- ============================================================================
+
+CREATE TABLE "tenant_subscriptions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "plan_id" uuid NOT NULL,
+  "status" "subscription_status" NOT NULL,
+  "billing_cycle" "billing_cycle" NOT NULL,
+  "current_period_start" timestamp with time zone NOT NULL,
+  "current_period_end" timestamp with time zone NOT NULL,
+  "cancel_at_period_end" boolean DEFAULT false NOT NULL,
+  "canceled_at" timestamp with time zone,
+  "trial_ends_at" timestamp with time zone,
+  "grace_ends_at" timestamp with time zone,
+  "external_subscription_id" text,
+  "external_customer_id" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "tenant_subscriptions_tenant_id_unique" UNIQUE("tenant_id"),
+  CONSTRAINT "tenant_subscriptions_external_subscription_id_unique" UNIQUE("external_subscription_id")
+);
+
+ALTER TABLE "tenant_subscriptions"
+  ADD CONSTRAINT "tenant_subscriptions_tenant_id_tenants_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "tenant_subscriptions"
+  ADD CONSTRAINT "tenant_subscriptions_plan_id_plans_id_fk"
+  FOREIGN KEY ("plan_id") REFERENCES "public"."plans"("id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "tenant_subscriptions" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "subscriptions_tenant_idx" ON "tenant_subscriptions" USING btree ("tenant_id");
+CREATE INDEX "subscriptions_external_id_idx" ON "tenant_subscriptions" USING btree ("external_subscription_id");
+CREATE INDEX "subscriptions_status_idx" ON "tenant_subscriptions" USING btree ("status");
+
+-- Only owner and admin can read their tenant's subscription
+CREATE POLICY "subscriptions_select" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (
+    ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)
+    AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))
+  );
+
+-- All writes via service_role only (webhook handler + service layer)
+CREATE POLICY "subscriptions_insert_sr" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+CREATE POLICY "subscriptions_update_sr" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR UPDATE
+  TO "service_role"
+  USING (true)
+  WITH CHECK (true);
+
+-- No DELETE policy — status transitions only, never hard delete
+
+-- ============================================================================
+-- billing_events
+-- ============================================================================
+
+CREATE TABLE "billing_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "subscription_id" uuid,
+  "event_type" text NOT NULL,
+  "provider" text NOT NULL,
+  "external_event_id" text,
+  "payload" text,
+  "processed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "billing_events_external_event_id_unique" UNIQUE("external_event_id")
+);
+
+ALTER TABLE "billing_events"
+  ADD CONSTRAINT "billing_events_tenant_id_tenants_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "billing_events"
+  ADD CONSTRAINT "billing_events_subscription_id_tenant_subscriptions_id_fk"
+  FOREIGN KEY ("subscription_id") REFERENCES "public"."tenant_subscriptions"("id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "billing_events" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "billing_events_tenant_idx" ON "billing_events" USING btree ("tenant_id");
+CREATE INDEX "billing_events_external_event_idx" ON "billing_events" USING btree ("external_event_id");
+CREATE INDEX "billing_events_subscription_idx" ON "billing_events" USING btree ("subscription_id");
+
+-- Only owner and admin can read their tenant's billing events
+CREATE POLICY "billing_events_select" ON "billing_events"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (
+    ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)
+    AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))
+  );
+
+-- All writes via service_role only — immutable after insert
+CREATE POLICY "billing_events_insert_sr" ON "billing_events"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+-- No UPDATE — immutable after insert
+-- No DELETE — audit records must be retained
+
+-- ============================================================================
+-- Reload PostgREST schema cache
+-- ============================================================================
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/meta/0001_snapshot.json
+++ b/supabase/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1605 @@
+{
+  "id": "979c4b2c-50d8-490e-9e38-5d3a39bb2d8b",
+  "prevId": "bd7e8b72-8351-4d34-be92-fb5b66d77b75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_events_tenant_idx": {
+          "name": "billing_events_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_external_event_idx": {
+          "name": "billing_events_external_event_idx",
+          "columns": [
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_subscription_idx": {
+          "name": "billing_events_subscription_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_events_tenant_id_tenants_id_fk": {
+          "name": "billing_events_tenant_id_tenants_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_events_subscription_id_tenant_subscriptions_id_fk": {
+          "name": "billing_events_subscription_id_tenant_subscriptions_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenant_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_external_event_id_unique": {
+          "name": "billing_events_external_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_event_id"
+          ]
+        }
+      },
+      "policies": {
+        "billing_events_select": {
+          "name": "billing_events_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "billing_events_insert_sr": {
+          "name": "billing_events_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_yearly": {
+          "name": "price_yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "features": {
+          "name": "features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limits": {
+          "name": "limits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trial_days": {
+          "name": "trial_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_active_order_idx": {
+          "name": "plans_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_slug_unique": {
+          "name": "plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "plans_select": {
+          "name": "plans_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "plans_insert": {
+          "name": "plans_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "plans_update": {
+          "name": "plans_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        },
+        "plans_delete": {
+          "name": "plans_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_subscriptions": {
+      "name": "tenant_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subscription_id": {
+          "name": "external_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_customer_id": {
+          "name": "external_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_external_id_idx": {
+          "name": "subscriptions_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_subscriptions_tenant_id_tenants_id_fk": {
+          "name": "tenant_subscriptions_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_subscriptions_plan_id_plans_id_fk": {
+          "name": "tenant_subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_subscriptions_tenant_id_unique": {
+          "name": "tenant_subscriptions_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id"
+          ]
+        },
+        "tenant_subscriptions_external_subscription_id_unique": {
+          "name": "tenant_subscriptions_external_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_subscription_id"
+          ]
+        }
+      },
+      "policies": {
+        "subscriptions_select": {
+          "name": "subscriptions_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "subscriptions_insert_sr": {
+          "name": "subscriptions_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "subscriptions_update_sr": {
+          "name": "subscriptions_update_sr",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_tenant_idx": {
+          "name": "audit_log_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_idx": {
+          "name": "audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_idx": {
+          "name": "audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_log_select": {
+          "name": "audit_log_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "audit_log_insert": {
+          "name": "audit_log_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND auth.uid() = user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_tenant_idx": {
+          "name": "profiles_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_email_idx": {
+          "name": "profiles_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "profiles_select": {
+          "name": "profiles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "profiles_insert": {
+          "name": "profiles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid() = id AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "profiles_update": {
+          "name": "profiles_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "profiles_delete": {
+          "name": "profiles_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_invitations": {
+      "name": "tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_tenant_idx": {
+          "name": "invitations_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_token_hash_idx": {
+          "name": "invitations_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_invitations_tenant_id_tenants_id_fk": {
+          "name": "tenant_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "invitations_select": {
+          "name": "invitations_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_insert": {
+          "name": "invitations_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_update": {
+          "name": "invitations_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_delete": {
+          "name": "invitations_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-US'"
+        },
+        "allow_admin_invites": {
+          "name": "allow_admin_invites",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_slug_idx": {
+          "name": "tenants_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenants_status_idx": {
+          "name": "tenants_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "tenants_select": {
+          "name": "tenants_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = id)"
+        },
+        "tenants_insert": {
+          "name": "tenants_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "tenants_update": {
+          "name": "tenants_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_roles_user_tenant_idx": {
+          "name": "user_roles_user_tenant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_roles_select": {
+          "name": "user_roles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "user_roles_insert": {
+          "name": "user_roles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_tenant_idx": {
+          "name": "resources_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_status_idx": {
+          "name": "resources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_type_idx": {
+          "name": "resources_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_created_by_idx": {
+          "name": "resources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "resources_select": {
+          "name": "resources_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "resources_insert": {
+          "name": "resources_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_update": {
+          "name": "resources_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_delete": {
+          "name": "resources_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "yearly"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "read",
+        "update",
+        "delete",
+        "login",
+        "logout",
+        "custom"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.tenant_status": {
+      "name": "tenant_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "suspended"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "guest"
+      ]
+    },
+    "public.resource_status": {
+      "name": "resource_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "draft",
+        "archived",
+        "suspended"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "service",
+        "asset",
+        "document",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776909061381,
       "tag": "0000_late_scorpion",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779396142849,
+      "tag": "0001_happy_the_renegades",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add billing Drizzle schema: `plans`, `tenant_subscriptions`, `billing_events` tables
- Add `subscription_status` and `billing_cycle` pgEnums
- 8 indexes, 9 RLS policies (plans public read, subscriptions/events tenant-scoped)
- Hand-written targeted migration (drizzle-kit snapshot bootstrapped for future generates)

## Type of Change

- [x] New feature (schema only — no runtime behavior)

## Test Results

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (413 tests)

## Part of

Billing & Plans feature — PR 2 of 7 (feature-branch-chain)