### PR TITLE
feat(ui): add billing Server Actions and webhook handler [5/7]

### DIFF
--- a/ui/app/api/webhooks/billing/route.ts
+++ b/ui/app/api/webhooks/billing/route.ts
@@ -1,0 +1,63 @@
+import { createPaymentAdapter } from "@enterprise/core/services/adapters/payment-adapter-factory";
+import { processWebhookEvent } from "@enterprise/core/services/billing-service";
+import { getAdminClient } from "@enterprise/core/supabase/admin";
+
+// Webhook Route Handler — NOT a Server Action
+// Sits outside (protected)/ — no auth middleware applies
+// Raw body is required for Stripe signature verification
+
+function extractExternalSubscriptionId(event: Record<string, unknown>): string {
+  const data = event["data"] as Record<string, unknown> | undefined;
+  const obj = data?.["object"] as Record<string, unknown> | undefined;
+  return (obj?.["subscription"] as string | undefined) ?? "";
+}
+
+export async function POST(request: Request) {
+  try {
+    const rawBody = await request.text();
+    const signature = request.headers.get("stripe-signature") ?? "";
+
+    const adapter = createPaymentAdapter();
+    const isValid = await adapter.verifyWebhookSignature(rawBody, signature);
+
+    if (!isValid) {
+      return new Response(JSON.stringify({ error: "Invalid signature" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Parse the raw event payload
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON payload" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const adminClient = getAdminClient();
+    const result = await processWebhookEvent(adminClient, {
+      eventType: (event["type"] as string | undefined) ?? "unknown",
+      externalEventId: (event["id"] as string | undefined) ?? "",
+      externalSubscriptionId: extractExternalSubscriptionId(event),
+      provider: "stripe",
+      payload: event,
+    });
+
+    if (!result.success) {
+      // Log failures but still return 200 — prevents provider retry loops for non-transient errors
+      console.error("[webhook/billing] Processing failed:", result.error, result.code);
+    }
+
+    return new Response("ok", { status: 200 });
+  } catch (error) {
+    console.error("[webhook/billing] Unexpected error:", error);
+    return new Response(JSON.stringify({ error: "Internal error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/ui/features/billing/actions.ts
+++ b/ui/features/billing/actions.ts
@@ -1,0 +1,300 @@
+"use server";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { cancelSubscriptionSchema, changePlanSchema } from "@enterprise/contracts";
+import { createPaymentAdapter } from "@enterprise/core/services/adapters/payment-adapter-factory";
+import {
+  cancelSubscription,
+  changePlan,
+  getSubscription,
+  resumeSubscription,
+} from "@enterprise/core/services/billing-service";
+import { getAdminClient } from "@enterprise/core/supabase/admin";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { getAppUrl } from "@enterprise/core/utils/env";
+import { revalidatePath } from "next/cache";
+import { ROUTES } from "@/lib/routes";
+import { captureActionError } from "@/lib/sentry";
+
+// ─── Auth Context ─────────────────────────────────────────────────────────────
+
+async function getAuthContext(supabase: Awaited<ReturnType<typeof getServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+  const role = (user.app_metadata?.["role"] as string | undefined) ?? null;
+
+  return { userId: user.id, tenantId, role };
+}
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+export async function changePlanAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = Object.fromEntries(formData.entries());
+  const parsed = changePlanSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can change plans" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await changePlan(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      parsed.data,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "CHANGE_PLAN_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "changePlanAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function cancelSubscriptionAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = Object.fromEntries(formData.entries());
+  // cancelAtPeriodEnd comes as a string from FormData; coerce it
+  const coerced = {
+    cancelAtPeriodEnd:
+      raw["cancelAtPeriodEnd"] === "false" ? false : raw["cancelAtPeriodEnd"] !== "false",
+  };
+  const parsed = cancelSubscriptionSchema.safeParse(coerced);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can cancel subscriptions" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await cancelSubscription(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      parsed.data,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "CANCEL_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "cancelSubscriptionAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function resumeSubscriptionAction(
+  _prevState: ActionResult | null,
+  _formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can resume subscriptions" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await resumeSubscription(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "RESUME_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "resumeSubscriptionAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function getPortalUrlAction(): Promise<ActionResult<{ url: string }>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can access the billing portal" },
+    };
+  }
+
+  try {
+    // Get subscription to extract the external customer ID
+    const subResult = await getSubscription(supabase, auth.tenantId);
+
+    if (!subResult.success || !subResult.data) {
+      return {
+        success: false,
+        error: {
+          code: subResult.success
+            ? "SUBSCRIPTION_NOT_FOUND"
+            : (subResult.code ?? "SUBSCRIPTION_FETCH_FAILED"),
+          message: subResult.success ? "No active subscription found" : subResult.error,
+        },
+      };
+    }
+
+    const customerId = subResult.data.externalCustomerId ?? `local_${auth.tenantId}`;
+    const returnUrl = `${getAppUrl()}${ROUTES.billing}`;
+
+    const adapter = createPaymentAdapter();
+    const portalResult = await adapter.getPortalUrl({ customerId, returnUrl });
+
+    return { success: true, data: { url: portalResult.url } };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "getPortalUrlAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}

--- a/ui/features/billing/queries.ts
+++ b/ui/features/billing/queries.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import type { BillingHistoryQueryDto } from "@enterprise/contracts";
+import type {
+  BillingEventRecord,
+  PlanRecord,
+  SubscriptionWithPlan,
+} from "@enterprise/core/services/billing-service";
+import {
+  getBillingHistory,
+  getSubscription,
+  listPlans,
+} from "@enterprise/core/services/billing-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+
+export async function getSubscriptionQuery(tenantId: string): Promise<SubscriptionWithPlan | null> {
+  const supabase = await getServerClient();
+  const result = await getSubscription(supabase, tenantId);
+  if (!result.success) return null;
+  return result.data;
+}
+
+export async function listPlansQuery(): Promise<PlanRecord[]> {
+  const supabase = await getServerClient();
+  const result = await listPlans(supabase);
+  if (!result.success) return [];
+  return result.data;
+}
+
+export async function getBillingHistoryQuery(
+  tenantId: string,
+  query: BillingHistoryQueryDto,
+): Promise<BillingEventRecord[]> {
+  const supabase = await getServerClient();
+  const result = await getBillingHistory(supabase, tenantId, query);
+  if (!result.success) return [];
+  return result.data;
+}

--- a/ui/features/billing/types.ts
+++ b/ui/features/billing/types.ts
@@ -1,0 +1,21 @@
+import type { BillingEventDto, PlanDto, SubscriptionDto } from "@enterprise/contracts";
+
+// ─── Page Props ────────────────────────────────────────────────────────────────
+
+export interface BillingPageProps {
+  subscription: SubscriptionDto | null;
+  plans: PlanDto[];
+  history: BillingEventDto[];
+}
+
+// ─── Component Props ───────────────────────────────────────────────────────────
+
+export interface PlanCardProps {
+  plan: PlanDto;
+  currentPlanId: string | null;
+  isOwner: boolean;
+}
+
+export interface HistoryRowProps {
+  event: BillingEventDto;
+}

--- a/ui/lib/routes.ts
+++ b/ui/lib/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
   dashboard: "/dashboard",
+  billing: "/billing",
   settings: "/settings",
   team: "/team",
   resources: {

--- a/ui/lib/sentry.ts
+++ b/ui/lib/sentry.ts
@@ -3,7 +3,14 @@ import * as Sentry from "@sentry/nextjs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type SentryArea = "auth" | "dashboard" | "resources" | "settings" | "team" | "webhook";
+export type SentryArea =
+  | "auth"
+  | "billing"
+  | "dashboard"
+  | "resources"
+  | "settings"
+  | "team"
+  | "webhook";
 
 export interface ActionErrorContext {
   actionName: string;


### PR DESCRIPTION
## Summary

- Register `"billing"` Sentry area and `/billing` route
- Add 4 Server Actions: `changePlanAction`, `cancelSubscriptionAction`, `resumeSubscriptionAction`, `getPortalUrlAction`
- Add server-side queries: `getPlans`, `getSubscription`, `getBillingHistory`
- Add webhook Route Handler at `/api/webhooks/billing` with signature verification and idempotent processing
- All imports use subpath pattern (never barrel)

## Type of Change

- [x] New feature

## Test Results

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅

## Part of

Billing & Plans feature — PR 5 of 7 (feature-branch-chain)