### PR TITLE
feat(ui): add billing Server Actions and webhook handler [5/7]

### DIFF
--- a/packages/contracts/src/__tests__/billing.test.ts
+++ b/packages/contracts/src/__tests__/billing.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "vitest";
+import {
+  BILLING_CYCLE,
+  SUBSCRIPTION_STATUS,
+  billingCycleSchema,
+  billingEventSchema,
+  billingHistoryQuerySchema,
+  cancelSubscriptionSchema,
+  changePlanSchema,
+  planSchema,
+  subscriptionSchema,
+  subscriptionStatusSchema,
+} from "../dto/billing";
+
+// ============================================================================
+// subscriptionStatusSchema
+// ============================================================================
+
+describe("subscriptionStatusSchema", () => {
+  it("accepts 'trialing'", () => {
+    const result = subscriptionStatusSchema.safeParse("trialing");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'active'", () => {
+    const result = subscriptionStatusSchema.safeParse("active");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'past_due'", () => {
+    const result = subscriptionStatusSchema.safeParse("past_due");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'canceled'", () => {
+    const result = subscriptionStatusSchema.safeParse("canceled");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'unpaid'", () => {
+    const result = subscriptionStatusSchema.safeParse("unpaid");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid status value", () => {
+    const result = subscriptionStatusSchema.safeParse("expired");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    const result = subscriptionStatusSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes all values via SUBSCRIPTION_STATUS const", () => {
+    expect(SUBSCRIPTION_STATUS.TRIALING).toBe("trialing");
+    expect(SUBSCRIPTION_STATUS.ACTIVE).toBe("active");
+    expect(SUBSCRIPTION_STATUS.PAST_DUE).toBe("past_due");
+    expect(SUBSCRIPTION_STATUS.CANCELED).toBe("canceled");
+    expect(SUBSCRIPTION_STATUS.UNPAID).toBe("unpaid");
+  });
+});
+
+// ============================================================================
+// billingCycleSchema
+// ============================================================================
+
+describe("billingCycleSchema", () => {
+  it("accepts 'monthly'", () => {
+    const result = billingCycleSchema.safeParse("monthly");
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 'yearly'", () => {
+    const result = billingCycleSchema.safeParse("yearly");
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects 'weekly'", () => {
+    const result = billingCycleSchema.safeParse("weekly");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    const result = billingCycleSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes all values via BILLING_CYCLE const", () => {
+    expect(BILLING_CYCLE.MONTHLY).toBe("monthly");
+    expect(BILLING_CYCLE.YEARLY).toBe("yearly");
+  });
+});
+
+// ============================================================================
+// planSchema
+// ============================================================================
+
+describe("planSchema", () => {
+  const validPlan = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    name: "Pro",
+    slug: "pro",
+    description: "The Pro plan",
+    priceMonthly: 2900,
+    priceYearly: 29000,
+    currency: "usd",
+    features: '{"ai":true}',
+    limits: '{"members":10}',
+    isActive: true,
+    displayOrder: 1,
+    trialDays: 14,
+  };
+
+  it("accepts a valid plan object", () => {
+    const result = planSchema.safeParse(validPlan);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null description", () => {
+    const result = planSchema.safeParse({ ...validPlan, description: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field 'name'", () => {
+    const { name: _name, ...withoutName } = validPlan;
+    const result = planSchema.safeParse(withoutName);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field 'slug'", () => {
+    const { slug: _slug, ...withoutSlug } = validPlan;
+    const result = planSchema.safeParse(withoutSlug);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field 'priceMonthly'", () => {
+    const { priceMonthly: _pm, ...withoutPrice } = validPlan;
+    const result = planSchema.safeParse(withoutPrice);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for id", () => {
+    const result = planSchema.safeParse({ ...validPlan, id: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// subscriptionSchema
+// ============================================================================
+
+describe("subscriptionSchema", () => {
+  const validSubscription = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    tenantId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    planId: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+    status: "active" as const,
+    billingCycle: "monthly" as const,
+    currentPeriodStart: "2024-01-01T00:00:00.000Z",
+    currentPeriodEnd: "2024-02-01T00:00:00.000Z",
+    cancelAtPeriodEnd: false,
+    canceledAt: null,
+    trialEndsAt: null,
+    graceEndsAt: null,
+    externalSubscriptionId: null,
+    externalCustomerId: null,
+  };
+
+  it("accepts a valid subscription object", () => {
+    const result = subscriptionSchema.safeParse(validSubscription);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable canceledAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, canceledAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable trialEndsAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, trialEndsAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable graceEndsAt", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, graceEndsAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalSubscriptionId", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      externalSubscriptionId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalCustomerId", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      externalCustomerId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows optional nested plan", () => {
+    const result = subscriptionSchema.safeParse({
+      ...validSubscription,
+      plan: {
+        id: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+        name: "Pro",
+        slug: "pro",
+        description: null,
+        priceMonthly: 2900,
+        priceYearly: 29000,
+        currency: "usd",
+        features: "{}",
+        limits: "{}",
+        isActive: true,
+        displayOrder: 1,
+        trialDays: 14,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts subscription without nested plan", () => {
+    const result = subscriptionSchema.safeParse(validSubscription);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.plan).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid status value", () => {
+    const result = subscriptionSchema.safeParse({ ...validSubscription, status: "expired" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// billingEventSchema
+// ============================================================================
+
+describe("billingEventSchema", () => {
+  const validEvent = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    tenantId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    subscriptionId: null,
+    eventType: "payment.succeeded",
+    provider: "stripe",
+    externalEventId: "evt_001",
+    processedAt: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid billing event", () => {
+    const result = billingEventSchema.safeParse(validEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable subscriptionId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, subscriptionId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable externalEventId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, externalEventId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows nullable processedAt", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, processedAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field 'eventType'", () => {
+    const { eventType: _et, ...withoutEventType } = validEvent;
+    const result = billingEventSchema.safeParse(withoutEventType);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for tenantId", () => {
+    const result = billingEventSchema.safeParse({ ...validEvent, tenantId: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// changePlanSchema
+// ============================================================================
+
+describe("changePlanSchema", () => {
+  it("accepts a valid UUID planId", () => {
+    const result = changePlanSchema.safeParse({
+      planId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-UUID planId", () => {
+    const result = changePlanSchema.safeParse({ planId: "pro-plan" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string planId", () => {
+    const result = changePlanSchema.safeParse({ planId: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing planId", () => {
+    const result = changePlanSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// cancelSubscriptionSchema
+// ============================================================================
+
+describe("cancelSubscriptionSchema", () => {
+  it("defaults cancelAtPeriodEnd to true when not provided", () => {
+    const result = cancelSubscriptionSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(true);
+    }
+  });
+
+  it("accepts explicit true", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(true);
+    }
+  });
+
+  it("accepts explicit false", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(false);
+    }
+  });
+
+  it("rejects a string value for cancelAtPeriodEnd", () => {
+    const result = cancelSubscriptionSchema.safeParse({ cancelAtPeriodEnd: "true" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// billingHistoryQuerySchema
+// ============================================================================
+
+describe("billingHistoryQuerySchema", () => {
+  it("applies default limit of 50 when not provided", () => {
+    const result = billingHistoryQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("applies default offset of 0 when not provided", () => {
+    const result = billingHistoryQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it("accepts limit = 1 (minimum boundary)", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts limit = 100 (maximum boundary)", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects limit > 100", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit < 1", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid offset", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 50, offset: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative offset", () => {
+    const result = billingHistoryQuerySchema.safeParse({ offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts limit and offset together", () => {
+    const result = billingHistoryQuerySchema.safeParse({ limit: 25, offset: 50 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(25);
+      expect(result.data.offset).toBe(50);
+    }
+  });
+});

--- a/packages/contracts/src/__tests__/billing.test.ts
+++ b/packages/contracts/src/__tests__/billing.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   BILLING_CYCLE,
-  SUBSCRIPTION_STATUS,
   billingCycleSchema,
   billingEventSchema,
   billingHistoryQuerySchema,
   cancelSubscriptionSchema,
   changePlanSchema,
   planSchema,
+  SUBSCRIPTION_STATUS,
   subscriptionSchema,
   subscriptionStatusSchema,
 } from "../dto/billing";

--- a/packages/contracts/src/dto/billing.ts
+++ b/packages/contracts/src/dto/billing.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+// ============================================================================
+// Subscription Status
+// ============================================================================
+
+export const SUBSCRIPTION_STATUS = {
+  TRIALING: "trialing",
+  ACTIVE: "active",
+  PAST_DUE: "past_due",
+  CANCELED: "canceled",
+  UNPAID: "unpaid",
+} as const;
+
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUS)[keyof typeof SUBSCRIPTION_STATUS];
+
+export const subscriptionStatusSchema = z.enum([
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+]);
+
+// ============================================================================
+// Billing Cycle
+// ============================================================================
+
+export const BILLING_CYCLE = {
+  MONTHLY: "monthly",
+  YEARLY: "yearly",
+} as const;
+
+export type BillingCycle = (typeof BILLING_CYCLE)[keyof typeof BILLING_CYCLE];
+
+export const billingCycleSchema = z.enum(["monthly", "yearly"]);
+
+// ============================================================================
+// Plan (output)
+// ============================================================================
+
+export const planSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  priceMonthly: z.number().int(),
+  priceYearly: z.number().int(),
+  currency: z.string(),
+  features: z.string(),
+  limits: z.string(),
+  isActive: z.boolean(),
+  displayOrder: z.number().int(),
+  trialDays: z.number().int(),
+});
+
+export type PlanDto = z.infer<typeof planSchema>;
+
+// ============================================================================
+// Subscription (output)
+// ============================================================================
+
+export const subscriptionSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  planId: z.string().uuid(),
+  status: subscriptionStatusSchema,
+  billingCycle: billingCycleSchema,
+  currentPeriodStart: z.string().datetime(),
+  currentPeriodEnd: z.string().datetime(),
+  cancelAtPeriodEnd: z.boolean(),
+  canceledAt: z.string().datetime().nullable(),
+  trialEndsAt: z.string().datetime().nullable(),
+  graceEndsAt: z.string().datetime().nullable(),
+  externalSubscriptionId: z.string().nullable(),
+  externalCustomerId: z.string().nullable(),
+  plan: planSchema.optional(),
+});
+
+export type SubscriptionDto = z.infer<typeof subscriptionSchema>;
+
+// ============================================================================
+// Billing Event (output)
+// ============================================================================
+
+export const billingEventSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  subscriptionId: z.string().uuid().nullable(),
+  eventType: z.string(),
+  provider: z.string(),
+  externalEventId: z.string().nullable(),
+  processedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type BillingEventDto = z.infer<typeof billingEventSchema>;
+
+// ============================================================================
+// Change Plan (input)
+// ============================================================================
+
+export const changePlanSchema = z.object({
+  planId: z.string().uuid(),
+});
+
+export type ChangePlanDto = z.infer<typeof changePlanSchema>;
+
+// ============================================================================
+// Cancel Subscription (input)
+// ============================================================================
+
+export const cancelSubscriptionSchema = z.object({
+  cancelAtPeriodEnd: z.boolean().default(true),
+});
+
+export type CancelSubscriptionDto = z.infer<typeof cancelSubscriptionSchema>;
+
+// ============================================================================
+// Billing History Query (input)
+// ============================================================================
+
+export const billingHistoryQuerySchema = z.object({
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+});
+
+export type BillingHistoryQueryDto = z.infer<typeof billingHistoryQuerySchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@
 
 // Re-export Zod for convenience
 export { z } from "zod";
+export * from "./dto/billing";
 // DTOs
 export * from "./dto/platform";
 export * from "./dto/resources";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,10 @@
     "./supabase/storage-paths": "./src/supabase/storage-paths.ts",
     "./utils/env": "./src/utils/env.ts",
     "./services": "./src/services/index.ts",
-    "./services/auth-service": "./src/services/auth-service.ts"
+    "./services/auth-service": "./src/services/auth-service.ts",
+    "./services/billing-service": "./src/services/billing-service.ts",
+    "./services/ports/payment-provider-port": "./src/services/ports/payment-provider-port.ts",
+    "./services/adapters/payment-adapter-factory": "./src/services/adapters/payment-adapter-factory.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -27,6 +30,7 @@
     "@enterprise/db": "workspace:*",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.50.0",
+    "stripe": "^17.7.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/core/src/services/__tests__/billing-service.test.ts
+++ b/packages/core/src/services/__tests__/billing-service.test.ts
@@ -1,0 +1,605 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import type { PaymentProviderPort } from "../ports/payment-provider-port";
+import {
+  cancelSubscription,
+  changePlan,
+  getSubscription,
+  listPlans,
+  processWebhookEvent,
+  resumeSubscription,
+} from "../billing-service";
+
+// ─── Mock Helpers ──────────────────────────────────────────────────────────────
+
+const TENANT_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const USER_ID = "bbbbbbbb-0000-4000-8000-000000000001";
+const PLAN_FREE_ID = "cccccccc-0000-4000-8000-000000000001";
+const PLAN_PRO_ID = "cccccccc-0000-4000-8000-000000000002";
+const SUBSCRIPTION_ID = "dddddddd-0000-4000-8000-000000000001";
+const EXTERNAL_SUB_ID = "local_sub_001";
+
+const FREE_PLAN = {
+  id: PLAN_FREE_ID,
+  name: "Free",
+  slug: "free",
+  description: null,
+  price_monthly: 0,
+  price_yearly: 0,
+  currency: "usd",
+  features: "{}",
+  limits: "{}",
+  is_active: true,
+  display_order: 1,
+  trial_days: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const PRO_PLAN = {
+  id: PLAN_PRO_ID,
+  name: "Pro",
+  slug: "pro",
+  description: "Pro plan",
+  price_monthly: 2900,
+  price_yearly: 29000,
+  currency: "usd",
+  features: "{}",
+  limits: "{}",
+  is_active: true,
+  display_order: 2,
+  trial_days: 14,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const INACTIVE_PLAN = {
+  ...FREE_PLAN,
+  id: "cccccccc-0000-4000-8000-000000000003",
+  name: "Legacy",
+  slug: "legacy",
+  is_active: false,
+  display_order: 99,
+};
+
+const ACTIVE_SUBSCRIPTION = {
+  id: SUBSCRIPTION_ID,
+  tenant_id: TENANT_ID,
+  plan_id: PLAN_FREE_ID,
+  status: "active",
+  billing_cycle: "monthly",
+  current_period_start: new Date().toISOString(),
+  current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+  cancel_at_period_end: false,
+  canceled_at: null,
+  trial_ends_at: null,
+  grace_ends_at: null,
+  external_subscription_id: EXTERNAL_SUB_ID,
+  external_customer_id: "local_cust_001",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  plans: FREE_PLAN,
+};
+
+function createMockAdapter(): PaymentProviderPort & {
+  changePlan: ReturnType<typeof vi.fn>;
+  cancelSubscription: ReturnType<typeof vi.fn>;
+  resumeSubscription: ReturnType<typeof vi.fn>;
+  createCustomer: ReturnType<typeof vi.fn>;
+  createSubscription: ReturnType<typeof vi.fn>;
+} {
+  return {
+    createCustomer: vi.fn().mockResolvedValue({ customerId: "local_cust" }),
+    createSubscription: vi.fn().mockResolvedValue({
+      subscriptionId: EXTERNAL_SUB_ID,
+      status: "active",
+      currentPeriodStart: new Date().toISOString(),
+      currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    }),
+    changePlan: vi.fn().mockResolvedValue({ success: true }),
+    cancelSubscription: vi.fn().mockResolvedValue({ success: true }),
+    resumeSubscription: vi.fn().mockResolvedValue({ success: true }),
+    getPortalUrl: vi.fn().mockResolvedValue({ url: "http://localhost:3000/billing?portal=local" }),
+    verifyWebhookSignature: vi.fn().mockResolvedValue(true),
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("listPlans", () => {
+  it("returns only active plans sorted by display_order", async () => {
+    // Plans returned from DB pre-filtered (is_active = true), ordered by display_order
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue({ data: [FREE_PLAN, PRO_PLAN], error: null }),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await listPlans(mockClient);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      const first = result.data[0];
+      const second = result.data[1];
+      expect(first?.slug).toBe("free");
+      expect(second?.slug).toBe("pro");
+    }
+  });
+
+  it("excludes inactive plans — returns empty array when none active", async () => {
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await listPlans(mockClient);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(0);
+    }
+  });
+});
+
+describe("getSubscription", () => {
+  it("returns subscription with joined plan on success", async () => {
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await getSubscription(mockClient, TENANT_ID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toBeNull();
+      if (result.data !== null) {
+        expect(result.data.tenantId).toBe(TENANT_ID);
+        expect(result.data.status).toBe("active");
+        expect(result.data.plan).toBeDefined();
+        expect(result.data.plan.slug).toBe("free");
+      }
+    }
+  });
+
+  it("returns null when no subscription row exists", async () => {
+    const mockClient = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await getSubscription(mockClient, TENANT_ID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+});
+
+describe("changePlan", () => {
+  it("success — calls adapter, updates subscription row, writes audit log", async () => {
+    const adapter = createMockAdapter();
+    const auditInsertMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    // Updated subscription row returned after UPDATE
+    const updatedSubscription = { ...ACTIVE_SUBSCRIPTION, plan_id: PLAN_PRO_ID };
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === "plans") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: PRO_PLAN, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const mockAdminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: updatedSubscription, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+        return { insert: auditInsertMock };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await changePlan(
+      mockClient,
+      mockAdminClient,
+      TENANT_ID,
+      USER_ID,
+      { planId: PLAN_PRO_ID },
+      adapter,
+    );
+
+    expect(result.success).toBe(true);
+    expect(adapter.changePlan).toHaveBeenCalledOnce();
+    expect(auditInsertMock).toHaveBeenCalled();
+  });
+
+  it("rejects inactive plan with PLAN_NOT_AVAILABLE", async () => {
+    const adapter = createMockAdapter();
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === "plans") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: INACTIVE_PLAN, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await changePlan(
+      mockClient,
+      {} as SupabaseClient,
+      TENANT_ID,
+      USER_ID,
+      { planId: INACTIVE_PLAN.id },
+      adapter,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("PLAN_NOT_AVAILABLE");
+    }
+    expect(adapter.changePlan).not.toHaveBeenCalled();
+  });
+
+  it("rejects same plan with PLAN_ALREADY_ACTIVE", async () => {
+    const adapter = createMockAdapter();
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === "plans") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                // Same plan as current subscription (FREE)
+                maybeSingle: vi.fn().mockResolvedValue({ data: FREE_PLAN, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await changePlan(
+      mockClient,
+      {} as SupabaseClient,
+      TENANT_ID,
+      USER_ID,
+      { planId: PLAN_FREE_ID },
+      adapter,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("PLAN_ALREADY_ACTIVE");
+    }
+    expect(adapter.changePlan).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelSubscription", () => {
+  it("at period end — sets cancel_at_period_end = true, status stays active", async () => {
+    const adapter = createMockAdapter();
+    const auditInsertMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    const canceledSub = {
+      ...ACTIVE_SUBSCRIPTION,
+      cancel_at_period_end: true,
+    };
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const mockAdminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: canceledSub, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+        return { insert: auditInsertMock };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await cancelSubscription(
+      mockClient,
+      mockAdminClient,
+      TENANT_ID,
+      USER_ID,
+      { cancelAtPeriodEnd: true },
+      adapter,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(true);
+      expect(result.data.status).toBe("active");
+    }
+    expect(adapter.cancelSubscription).toHaveBeenCalledOnce();
+  });
+
+  it("immediate — sets status = canceled", async () => {
+    const adapter = createMockAdapter();
+    const auditInsertMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    const immediateCanceledSub = {
+      ...ACTIVE_SUBSCRIPTION,
+      status: "canceled",
+      canceled_at: new Date().toISOString(),
+    };
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const mockAdminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi
+                    .fn()
+                    .mockResolvedValue({ data: immediateCanceledSub, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+        return { insert: auditInsertMock };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await cancelSubscription(
+      mockClient,
+      mockAdminClient,
+      TENANT_ID,
+      USER_ID,
+      { cancelAtPeriodEnd: false },
+      adapter,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("canceled");
+    }
+  });
+});
+
+describe("resumeSubscription", () => {
+  it("success — clears cancel_at_period_end", async () => {
+    const adapter = createMockAdapter();
+    const auditInsertMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    const cancelPendingSub = { ...ACTIVE_SUBSCRIPTION, cancel_at_period_end: true };
+    const resumedSub = { ...ACTIVE_SUBSCRIPTION, cancel_at_period_end: false };
+
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: cancelPendingSub, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const mockAdminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            update: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                select: vi.fn(() => ({
+                  single: vi.fn().mockResolvedValue({ data: resumedSub, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+        return { insert: auditInsertMock };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await resumeSubscription(mockClient, mockAdminClient, TENANT_ID, USER_ID, adapter);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.cancelAtPeriodEnd).toBe(false);
+    }
+    expect(adapter.resumeSubscription).toHaveBeenCalledOnce();
+    expect(auditInsertMock).toHaveBeenCalled();
+  });
+
+  it("no-op when cancel_at_period_end = false — returns SUBSCRIPTION_NOT_PENDING_CANCEL", async () => {
+    const adapter = createMockAdapter();
+
+    // Subscription is already active with no pending cancel
+    const mockClient = {
+      from: vi.fn((table: string) => {
+        if (table === "tenant_subscriptions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                // cancel_at_period_end = false → no-op
+                maybeSingle: vi
+                  .fn()
+                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await resumeSubscription(
+      mockClient,
+      {} as SupabaseClient,
+      TENANT_ID,
+      USER_ID,
+      adapter,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("SUBSCRIPTION_NOT_PENDING_CANCEL");
+    }
+    expect(adapter.resumeSubscription).not.toHaveBeenCalled();
+  });
+});
+
+describe("processWebhookEvent", () => {
+  it("duplicate event — no-op returns WEBHOOK_ALREADY_PROCESSED", async () => {
+    // Existing billing event with the same external_event_id
+    const existingEvent = {
+      id: "eeeeeeee-0000-4000-8000-000000000001",
+      external_event_id: "evt_001",
+    };
+
+    const mockAdminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "billing_events") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn().mockResolvedValue({ data: existingEvent, error: null }),
+              })),
+            })),
+          };
+        }
+        return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+      }),
+    } as unknown as SupabaseClient;
+
+    const result = await processWebhookEvent(mockAdminClient, {
+      eventType: "payment.succeeded",
+      externalEventId: "evt_001",
+      externalSubscriptionId: EXTERNAL_SUB_ID,
+      provider: "stripe",
+      tenantId: TENANT_ID,
+      payload: {},
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("WEBHOOK_ALREADY_PROCESSED");
+    }
+  });
+});

--- a/packages/core/src/services/__tests__/billing-service.test.ts
+++ b/packages/core/src/services/__tests__/billing-service.test.ts
@@ -1,6 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { describe, expect, it, vi } from "vitest";
-import type { PaymentProviderPort } from "../ports/payment-provider-port";
 import {
   cancelSubscription,
   changePlan,
@@ -9,6 +8,7 @@ import {
   processWebhookEvent,
   resumeSubscription,
 } from "../billing-service";
+import type { PaymentProviderPort } from "../ports/payment-provider-port";
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
@@ -211,9 +211,7 @@ describe("changePlan", () => {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };
@@ -271,9 +269,7 @@ describe("changePlan", () => {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };
@@ -316,9 +312,7 @@ describe("changePlan", () => {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };
@@ -370,9 +364,7 @@ describe("cancelSubscription", () => {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };
@@ -431,9 +423,7 @@ describe("cancelSubscription", () => {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };
@@ -449,9 +439,7 @@ describe("cancelSubscription", () => {
             update: vi.fn(() => ({
               eq: vi.fn(() => ({
                 select: vi.fn(() => ({
-                  single: vi
-                    .fn()
-                    .mockResolvedValue({ data: immediateCanceledSub, error: null }),
+                  single: vi.fn().mockResolvedValue({ data: immediateCanceledSub, error: null }),
                 })),
               })),
             })),
@@ -517,7 +505,13 @@ describe("resumeSubscription", () => {
       }),
     } as unknown as SupabaseClient;
 
-    const result = await resumeSubscription(mockClient, mockAdminClient, TENANT_ID, USER_ID, adapter);
+    const result = await resumeSubscription(
+      mockClient,
+      mockAdminClient,
+      TENANT_ID,
+      USER_ID,
+      adapter,
+    );
 
     expect(result.success).toBe(true);
     if (result.success) {
@@ -538,9 +532,7 @@ describe("resumeSubscription", () => {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
                 // cancel_at_period_end = false → no-op
-                maybeSingle: vi
-                  .fn()
-                  .mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
+                maybeSingle: vi.fn().mockResolvedValue({ data: ACTIVE_SUBSCRIPTION, error: null }),
               })),
             })),
           };

--- a/packages/core/src/services/adapters/local-payment-adapter.ts
+++ b/packages/core/src/services/adapters/local-payment-adapter.ts
@@ -1,0 +1,88 @@
+// Local payment adapter — in-memory implementation for development and testing
+// Returns deterministic local_ prefixed IDs, logs all operations to console
+// Zero external dependencies — safe for local dev without Stripe credentials
+
+import type {
+  CancelSubscriptionParams,
+  ChangePlanParams,
+  CreateCustomerParams,
+  CreateSubscriptionParams,
+  PaymentProviderPort,
+  PortalUrlParams,
+  ResumeSubscriptionParams,
+} from "../ports/payment-provider-port";
+
+export class LocalPaymentAdapter implements PaymentProviderPort {
+  async createCustomer(params: CreateCustomerParams): Promise<{ customerId: string }> {
+    const customerId = `local_${params.tenantId}`;
+    console.log("[LocalPaymentAdapter] createCustomer:", {
+      tenantId: params.tenantId,
+      tenantName: params.tenantName,
+      email: params.email,
+      customerId,
+    });
+    return { customerId };
+  }
+
+  async createSubscription(params: CreateSubscriptionParams): Promise<{
+    subscriptionId: string;
+    status: string;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+  }> {
+    const now = new Date();
+    const periodEnd = new Date(now);
+    periodEnd.setMonth(periodEnd.getMonth() + (params.billingCycle === "yearly" ? 12 : 1));
+
+    const subscriptionId = `local_sub_${params.customerId}_${params.planSlug}`;
+    const result = {
+      subscriptionId,
+      status: "active",
+      currentPeriodStart: now.toISOString(),
+      currentPeriodEnd: periodEnd.toISOString(),
+    };
+
+    console.log("[LocalPaymentAdapter] createSubscription:", {
+      customerId: params.customerId,
+      planSlug: params.planSlug,
+      billingCycle: params.billingCycle,
+      ...result,
+    });
+
+    return result;
+  }
+
+  async changePlan(params: ChangePlanParams): Promise<{ success: boolean }> {
+    console.log("[LocalPaymentAdapter] changePlan:", {
+      subscriptionId: params.subscriptionId,
+      newPlanSlug: params.newPlanSlug,
+    });
+    return { success: true };
+  }
+
+  async cancelSubscription(params: CancelSubscriptionParams): Promise<{ success: boolean }> {
+    console.log("[LocalPaymentAdapter] cancelSubscription:", {
+      subscriptionId: params.subscriptionId,
+      cancelAtPeriodEnd: params.cancelAtPeriodEnd,
+    });
+    return { success: true };
+  }
+
+  async resumeSubscription(params: ResumeSubscriptionParams): Promise<{ success: boolean }> {
+    console.log("[LocalPaymentAdapter] resumeSubscription:", {
+      subscriptionId: params.subscriptionId,
+    });
+    return { success: true };
+  }
+
+  async getPortalUrl(_params: PortalUrlParams): Promise<{ url: string }> {
+    const url = "http://localhost:3000/billing?portal=local";
+    console.log("[LocalPaymentAdapter] getPortalUrl:", { url });
+    return { url };
+  }
+
+  async verifyWebhookSignature(_payload: string, _signature: string): Promise<boolean> {
+    console.log("[LocalPaymentAdapter] verifyWebhookSignature: always returns true in local mode");
+    return true;
+  }
+}

--- a/packages/core/src/services/adapters/payment-adapter-factory.ts
+++ b/packages/core/src/services/adapters/payment-adapter-factory.ts
@@ -1,0 +1,26 @@
+// Payment adapter factory — selects the correct adapter based on env var presence
+// STRIPE_SECRET_KEY present → StripePaymentAdapter; absent → LocalPaymentAdapter
+// Adapter is singleton-cached per process (serverless-safe — each cold start gets fresh selection)
+
+import type { PaymentProviderPort } from "../ports/payment-provider-port";
+import { LocalPaymentAdapter } from "./local-payment-adapter";
+import { StripePaymentAdapter } from "./stripe-payment-adapter";
+
+let cachedAdapter: PaymentProviderPort | null = null;
+
+/**
+ * Returns the appropriate payment adapter based on env var presence.
+ * Cached per process — multiple calls return the same instance.
+ */
+export function createPaymentAdapter(): PaymentProviderPort {
+  if (cachedAdapter) return cachedAdapter;
+
+  const stripeKey = process.env["STRIPE_SECRET_KEY"];
+  const webhookSecret = process.env["STRIPE_WEBHOOK_SECRET"] ?? "";
+
+  cachedAdapter = stripeKey
+    ? new StripePaymentAdapter(stripeKey, webhookSecret)
+    : new LocalPaymentAdapter();
+
+  return cachedAdapter;
+}

--- a/packages/core/src/services/adapters/stripe-payment-adapter.ts
+++ b/packages/core/src/services/adapters/stripe-payment-adapter.ts
@@ -1,0 +1,204 @@
+// Stripe payment adapter — production implementation using Stripe SDK
+// Constructor receives stripeSecretKey and webhookSecret for signature verification
+// Maps plan slugs to Stripe product/price IDs via metadata convention
+
+import type {
+  CancelSubscriptionParams,
+  ChangePlanParams,
+  CreateCustomerParams,
+  CreateSubscriptionParams,
+  PaymentProviderPort,
+  PortalUrlParams,
+  ResumeSubscriptionParams,
+} from "../ports/payment-provider-port";
+
+// Dynamic import type — avoids hard dependency if stripe is not installed
+type StripeInstance = import("stripe").default;
+
+export class StripePaymentAdapter implements PaymentProviderPort {
+  private readonly stripeSecretKey: string;
+  private readonly webhookSecret: string;
+  private stripeInstance: StripeInstance | null = null;
+
+  constructor(stripeSecretKey: string, webhookSecret = "") {
+    this.stripeSecretKey = stripeSecretKey;
+    this.webhookSecret = webhookSecret;
+  }
+
+  private async getStripe(): Promise<StripeInstance> {
+    if (this.stripeInstance) return this.stripeInstance;
+
+    const { default: Stripe } = await import("stripe");
+    this.stripeInstance = new Stripe(this.stripeSecretKey, {
+      apiVersion: "2025-02-24.acacia",
+    });
+
+    return this.stripeInstance;
+  }
+
+  async createCustomer(params: CreateCustomerParams): Promise<{ customerId: string }> {
+    try {
+      const stripe = await this.getStripe();
+      const customer = await stripe.customers.create({
+        name: params.tenantName,
+        email: params.email,
+        metadata: {
+          tenant_id: params.tenantId,
+        },
+      });
+      return { customerId: customer.id };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe createCustomer failed";
+      throw new Error(`[StripePaymentAdapter] createCustomer error: ${message}`);
+    }
+  }
+
+  async createSubscription(params: CreateSubscriptionParams): Promise<{
+    subscriptionId: string;
+    status: string;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+  }> {
+    try {
+      const stripe = await this.getStripe();
+
+      // Look up Stripe price by plan slug and billing cycle via metadata
+      const prices = await stripe.prices.search({
+        query: `metadata["plan_slug"]:"${params.planSlug}" AND metadata["billing_cycle"]:"${params.billingCycle}" AND active:"true"`,
+      });
+
+      if (!prices.data[0]) {
+        throw new Error(
+          `No active Stripe price found for plan "${params.planSlug}" (${params.billingCycle})`,
+        );
+      }
+
+      const priceId = prices.data[0].id;
+
+      const subscription = await stripe.subscriptions.create({
+        customer: params.customerId,
+        items: [{ price: priceId }],
+        metadata: {
+          plan_slug: params.planSlug,
+          billing_cycle: params.billingCycle,
+        },
+      });
+
+      return {
+        subscriptionId: subscription.id,
+        status: subscription.status,
+        currentPeriodStart: new Date(subscription.current_period_start * 1000).toISOString(),
+        currentPeriodEnd: new Date(subscription.current_period_end * 1000).toISOString(),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe createSubscription failed";
+      throw new Error(`[StripePaymentAdapter] createSubscription error: ${message}`);
+    }
+  }
+
+  async changePlan(params: ChangePlanParams): Promise<{ success: boolean }> {
+    try {
+      const stripe = await this.getStripe();
+
+      // Load current subscription to get the existing item
+      const subscription = await stripe.subscriptions.retrieve(params.subscriptionId);
+      const subscriptionItemId = subscription.items.data[0]?.id;
+
+      if (!subscriptionItemId) {
+        throw new Error(`No subscription item found for subscription ${params.subscriptionId}`);
+      }
+
+      // Look up new price by plan slug (cycle inherited from current subscription)
+      const currentInterval = subscription.items.data[0]?.price.recurring?.interval ?? "month";
+      const billingCycle = currentInterval === "year" ? "yearly" : "monthly";
+
+      const prices = await stripe.prices.search({
+        query: `metadata["plan_slug"]:"${params.newPlanSlug}" AND metadata["billing_cycle"]:"${billingCycle}" AND active:"true"`,
+      });
+
+      if (!prices.data[0]) {
+        throw new Error(`No active Stripe price found for plan "${params.newPlanSlug}"`);
+      }
+
+      await stripe.subscriptions.update(params.subscriptionId, {
+        items: [{ id: subscriptionItemId, price: prices.data[0].id }],
+        proration_behavior: "create_prorations",
+        metadata: {
+          plan_slug: params.newPlanSlug,
+        },
+      });
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe changePlan failed";
+      throw new Error(`[StripePaymentAdapter] changePlan error: ${message}`);
+    }
+  }
+
+  async cancelSubscription(params: CancelSubscriptionParams): Promise<{ success: boolean }> {
+    try {
+      const stripe = await this.getStripe();
+
+      if (params.cancelAtPeriodEnd) {
+        await stripe.subscriptions.update(params.subscriptionId, {
+          cancel_at_period_end: true,
+        });
+      } else {
+        await stripe.subscriptions.cancel(params.subscriptionId);
+      }
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe cancelSubscription failed";
+      throw new Error(`[StripePaymentAdapter] cancelSubscription error: ${message}`);
+    }
+  }
+
+  async resumeSubscription(params: ResumeSubscriptionParams): Promise<{ success: boolean }> {
+    try {
+      const stripe = await this.getStripe();
+
+      await stripe.subscriptions.update(params.subscriptionId, {
+        cancel_at_period_end: false,
+      });
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe resumeSubscription failed";
+      throw new Error(`[StripePaymentAdapter] resumeSubscription error: ${message}`);
+    }
+  }
+
+  async getPortalUrl(params: PortalUrlParams): Promise<{ url: string }> {
+    try {
+      const stripe = await this.getStripe();
+
+      const session = await stripe.billingPortal.sessions.create({
+        customer: params.customerId,
+        return_url: params.returnUrl,
+      });
+
+      return { url: session.url };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Stripe getPortalUrl failed";
+      throw new Error(`[StripePaymentAdapter] getPortalUrl error: ${message}`);
+    }
+  }
+
+  async verifyWebhookSignature(payload: string, signature: string): Promise<boolean> {
+    try {
+      if (!this.webhookSecret) {
+        console.warn(
+          "[StripePaymentAdapter] verifyWebhookSignature: no webhookSecret configured — skipping verification",
+        );
+        return false;
+      }
+
+      const stripe = await this.getStripe();
+      stripe.webhooks.constructEvent(payload, signature, this.webhookSecret);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/core/src/services/billing-service.ts
+++ b/packages/core/src/services/billing-service.ts
@@ -1,0 +1,925 @@
+// Billing Service
+// Handles plan catalog, tenant subscriptions, plan changes, cancellation, webhook events
+// All functions receive SupabaseClient via DI and return ServiceResult<T>
+// ALL writes use adminClient (service_role) — never the authenticated client for mutations
+
+import type {
+  BillingHistoryQueryDto,
+  CancelSubscriptionDto,
+  ChangePlanDto,
+} from "@enterprise/contracts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ServiceResult } from "./auth-service";
+import type { PaymentProviderPort } from "./ports/payment-provider-port";
+
+// ─── Service-Layer Types ──────────────────────────────────────────────────────
+// These use ISO string timestamps (matching what Supabase JS client returns)
+// instead of Drizzle's Date-based $inferSelect types.
+
+export interface PlanRecord {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  priceMonthly: number;
+  priceYearly: number;
+  currency: string;
+  features: string;
+  limits: string;
+  isActive: boolean;
+  displayOrder: number;
+  trialDays: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubscriptionRecord {
+  id: string;
+  tenantId: string;
+  planId: string;
+  status: "trialing" | "active" | "past_due" | "canceled" | "unpaid";
+  billingCycle: "monthly" | "yearly";
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  cancelAtPeriodEnd: boolean;
+  canceledAt: string | null;
+  trialEndsAt: string | null;
+  graceEndsAt: string | null;
+  externalSubscriptionId: string | null;
+  externalCustomerId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BillingEventRecord {
+  id: string;
+  tenantId: string;
+  subscriptionId: string | null;
+  eventType: string;
+  provider: string;
+  externalEventId: string | null;
+  payload: string | null;
+  processedAt: string | null;
+  createdAt: string;
+}
+
+export interface SubscriptionWithPlan {
+  id: string;
+  tenantId: string;
+  planId: string;
+  status: "trialing" | "active" | "past_due" | "canceled" | "unpaid";
+  billingCycle: "monthly" | "yearly";
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  cancelAtPeriodEnd: boolean;
+  canceledAt: string | null;
+  trialEndsAt: string | null;
+  graceEndsAt: string | null;
+  externalSubscriptionId: string | null;
+  externalCustomerId: string | null;
+  plan: {
+    id: string;
+    name: string;
+    slug: string;
+    description: string | null;
+    priceMonthly: number;
+    priceYearly: number;
+    currency: string;
+    features: string;
+    limits: string;
+    trialDays: number;
+  };
+}
+
+export interface WebhookEvent {
+  eventType: string;
+  externalEventId: string;
+  externalSubscriptionId: string;
+  provider: string;
+  tenantId?: string;
+  payload: Record<string, unknown>;
+  subscriptionData?: {
+    status?: string;
+    currentPeriodStart?: string;
+    currentPeriodEnd?: string;
+    cancelAtPeriodEnd?: boolean;
+    graceEndsAt?: string | null;
+    planSlug?: string;
+  };
+}
+
+// ─── Row Mappers ─────────────────────────────────────────────────────────────
+
+type PlanRow = Record<string, unknown>;
+type SubscriptionRow = Record<string, unknown>;
+
+function mapPlanRow(row: PlanRow): PlanRecord {
+  return {
+    id: row["id"] as string,
+    name: row["name"] as string,
+    slug: row["slug"] as string,
+    description: (row["description"] as string | null) ?? null,
+    priceMonthly: row["price_monthly"] as number,
+    priceYearly: row["price_yearly"] as number,
+    currency: row["currency"] as string,
+    features: row["features"] as string,
+    limits: row["limits"] as string,
+    isActive: row["is_active"] as boolean,
+    displayOrder: row["display_order"] as number,
+    trialDays: row["trial_days"] as number,
+    createdAt: row["created_at"] as string,
+    updatedAt: row["updated_at"] as string,
+  };
+}
+
+function mapSubscriptionRow(row: SubscriptionRow): SubscriptionRecord {
+  return {
+    id: row["id"] as string,
+    tenantId: row["tenant_id"] as string,
+    planId: row["plan_id"] as string,
+    status: row["status"] as SubscriptionRecord["status"],
+    billingCycle: row["billing_cycle"] as SubscriptionRecord["billingCycle"],
+    currentPeriodStart: row["current_period_start"] as string,
+    currentPeriodEnd: row["current_period_end"] as string,
+    cancelAtPeriodEnd: row["cancel_at_period_end"] as boolean,
+    canceledAt: (row["canceled_at"] as string | null) ?? null,
+    trialEndsAt: (row["trial_ends_at"] as string | null) ?? null,
+    graceEndsAt: (row["grace_ends_at"] as string | null) ?? null,
+    externalSubscriptionId: (row["external_subscription_id"] as string | null) ?? null,
+    externalCustomerId: (row["external_customer_id"] as string | null) ?? null,
+    createdAt: row["created_at"] as string,
+    updatedAt: row["updated_at"] as string,
+  };
+}
+
+function mapSubscriptionWithPlan(row: SubscriptionRow): SubscriptionWithPlan {
+  const planRow = row["plans"] as PlanRow | undefined;
+  if (!planRow) {
+    throw new Error("Subscription row missing joined plan data");
+  }
+
+  return {
+    id: row["id"] as string,
+    tenantId: row["tenant_id"] as string,
+    planId: row["plan_id"] as string,
+    status: row["status"] as SubscriptionWithPlan["status"],
+    billingCycle: row["billing_cycle"] as SubscriptionWithPlan["billingCycle"],
+    currentPeriodStart: row["current_period_start"] as string,
+    currentPeriodEnd: row["current_period_end"] as string,
+    cancelAtPeriodEnd: row["cancel_at_period_end"] as boolean,
+    canceledAt: (row["canceled_at"] as string | null) ?? null,
+    trialEndsAt: (row["trial_ends_at"] as string | null) ?? null,
+    graceEndsAt: (row["grace_ends_at"] as string | null) ?? null,
+    externalSubscriptionId: (row["external_subscription_id"] as string | null) ?? null,
+    externalCustomerId: (row["external_customer_id"] as string | null) ?? null,
+    plan: {
+      id: planRow["id"] as string,
+      name: planRow["name"] as string,
+      slug: planRow["slug"] as string,
+      description: (planRow["description"] as string | null) ?? null,
+      priceMonthly: planRow["price_monthly"] as number,
+      priceYearly: planRow["price_yearly"] as number,
+      currency: planRow["currency"] as string,
+      features: planRow["features"] as string,
+      limits: planRow["limits"] as string,
+      trialDays: planRow["trial_days"] as number,
+    },
+  };
+}
+
+// ─── Audit Helper ─────────────────────────────────────────────────────────────
+
+async function writeAuditLog(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  event: string,
+  resourceId?: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const action = event.includes("canceled") || event.includes("expired") ? "delete" : "update";
+
+  const { error } = await client.from("audit_log").insert({
+    tenant_id: tenantId,
+    user_id: userId,
+    action,
+    resource: "billing",
+    resource_id: resourceId ?? null,
+    metadata: JSON.stringify({ event, ...(metadata ?? {}) }),
+    ip_address: null,
+    user_agent: null,
+  });
+
+  if (error) {
+    console.error(`[audit_log] Failed to write [${event} -> ${action}]:`, error);
+  }
+}
+
+// ─── Service Functions ────────────────────────────────────────────────────────
+
+/**
+ * List all active plans sorted by display_order ASC.
+ * Uses authenticated client (RLS: plans_select allows any authenticated user).
+ */
+export async function listPlans(client: SupabaseClient): Promise<ServiceResult<PlanRecord[]>> {
+  const { data, error } = await client
+    .from("plans")
+    .select(
+      "id, name, slug, description, price_monthly, price_yearly, currency, features, limits, is_active, display_order, trial_days, created_at, updated_at",
+    )
+    .eq("is_active", true)
+    .order("display_order", { ascending: true });
+
+  if (error) {
+    return { success: false, error: error.message, code: "PLANS_LIST_FAILED" };
+  }
+
+  return { success: true, data: ((data ?? []) as PlanRow[]).map(mapPlanRow) as PlanRecord[] };
+}
+
+/**
+ * Get current subscription for a tenant with joined plan details.
+ * Returns null when no subscription row exists (valid for new tenants before init).
+ */
+export async function getSubscription(
+  client: SupabaseClient,
+  tenantId: string,
+): Promise<ServiceResult<SubscriptionWithPlan | null>> {
+  const { data, error } = await client
+    .from("tenant_subscriptions")
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at, plans(id, name, slug, description, price_monthly, price_yearly, currency, features, limits, trial_days)",
+    )
+    .eq("tenant_id", tenantId)
+    .maybeSingle();
+
+  if (error) {
+    return { success: false, error: error.message, code: "SUBSCRIPTION_FETCH_FAILED" };
+  }
+
+  if (!data) {
+    return { success: true, data: null };
+  }
+
+  try {
+    return { success: true, data: mapSubscriptionWithPlan(data as SubscriptionRow) };
+  } catch (mapError) {
+    return {
+      success: false,
+      error: mapError instanceof Error ? mapError.message : "Failed to map subscription",
+      code: "SUBSCRIPTION_FETCH_FAILED",
+    };
+  }
+}
+
+/**
+ * Change subscription plan (upgrade or downgrade).
+ * Validates: plan exists, plan is active, plan is not the same as current.
+ * Calls adapter, updates DB, writes audit log.
+ */
+export async function changePlan(
+  client: SupabaseClient,
+  adminClient: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  input: ChangePlanDto,
+  adapter: PaymentProviderPort,
+): Promise<ServiceResult<SubscriptionRecord>> {
+  // 1. Get current subscription
+  const { data: currentSub, error: subError } = await client
+    .from("tenant_subscriptions")
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .eq("tenant_id", tenantId)
+    .maybeSingle();
+
+  if (subError) {
+    return { success: false, error: subError.message, code: "SUBSCRIPTION_FETCH_FAILED" };
+  }
+
+  if (!currentSub) {
+    return { success: false, error: "No subscription found", code: "SUBSCRIPTION_NOT_FOUND" };
+  }
+
+  const sub = currentSub as SubscriptionRow;
+
+  // 2. Verify same plan guard
+  if ((sub["plan_id"] as string) === input.planId) {
+    return {
+      success: false,
+      error: "Tenant is already on this plan",
+      code: "PLAN_ALREADY_ACTIVE",
+    };
+  }
+
+  // 3. Get target plan
+  const { data: targetPlan, error: planError } = await client
+    .from("plans")
+    .select(
+      "id, name, slug, description, price_monthly, price_yearly, currency, features, limits, is_active, display_order, trial_days, created_at, updated_at",
+    )
+    .eq("id", input.planId)
+    .maybeSingle();
+
+  if (planError) {
+    return { success: false, error: planError.message, code: "PLAN_NOT_FOUND" };
+  }
+
+  if (!targetPlan) {
+    return { success: false, error: "Plan not found", code: "PLAN_NOT_FOUND" };
+  }
+
+  const plan = targetPlan as PlanRow;
+
+  // 4. Validate plan is active
+  if (!(plan["is_active"] as boolean)) {
+    return { success: false, error: "Plan is not available", code: "PLAN_NOT_AVAILABLE" };
+  }
+
+  // 5. Call adapter
+  const externalSubId = sub["external_subscription_id"] as string | null;
+  if (externalSubId) {
+    try {
+      await adapter.changePlan({
+        subscriptionId: externalSubId,
+        newPlanSlug: plan["slug"] as string,
+      });
+    } catch (adapterError) {
+      return {
+        success: false,
+        error: adapterError instanceof Error ? adapterError.message : "Adapter error",
+        code: "ADAPTER_ERROR",
+      };
+    }
+  }
+
+  // 6. Update subscription in DB via adminClient
+  const { data: updatedSub, error: updateError } = await adminClient
+    .from("tenant_subscriptions")
+    .update({
+      plan_id: input.planId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", tenantId)
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .single();
+
+  if (updateError || !updatedSub) {
+    return {
+      success: false,
+      error: updateError?.message ?? "Failed to update subscription",
+      code: "UPDATE_FAILED",
+    };
+  }
+
+  // 7. Determine upgrade vs downgrade based on price
+  const newPriceMonthly = plan["price_monthly"] as number;
+  const oldPlanId = sub["plan_id"] as string;
+
+  // Fetch old plan price for upgrade/downgrade determination
+  const { data: oldPlanData } = await client
+    .from("plans")
+    .select("price_monthly")
+    .eq("id", oldPlanId)
+    .maybeSingle();
+
+  const oldPrice = (oldPlanData as PlanRow | null)?.["price_monthly"] as number | undefined;
+  const isUpgrade = oldPrice !== undefined ? newPriceMonthly > oldPrice : true;
+  const auditEvent = isUpgrade ? "billing.plan_upgraded" : "billing.plan_downgraded";
+
+  // 8. Write audit log (fire-and-forget)
+  void writeAuditLog(adminClient, tenantId, userId, auditEvent, sub["id"] as string, {
+    fromPlanId: oldPlanId,
+    toPlanId: input.planId,
+    initiatedBy: userId,
+  });
+
+  return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
+}
+
+/**
+ * Cancel subscription — sets cancel_at_period_end or status = 'canceled' for immediate.
+ * Calls adapter, updates DB, writes audit log.
+ */
+export async function cancelSubscription(
+  client: SupabaseClient,
+  adminClient: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  input: CancelSubscriptionDto,
+  adapter: PaymentProviderPort,
+): Promise<ServiceResult<SubscriptionRecord>> {
+  // 1. Get current subscription
+  const { data: currentSub, error: subError } = await client
+    .from("tenant_subscriptions")
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .eq("tenant_id", tenantId)
+    .maybeSingle();
+
+  if (subError) {
+    return { success: false, error: subError.message, code: "SUBSCRIPTION_FETCH_FAILED" };
+  }
+
+  if (!currentSub) {
+    return { success: false, error: "No subscription found", code: "SUBSCRIPTION_NOT_FOUND" };
+  }
+
+  const sub = currentSub as SubscriptionRow;
+
+  // 2. Guard: already canceled
+  if ((sub["status"] as string) === "canceled") {
+    return {
+      success: false,
+      error: "Subscription is already canceled",
+      code: "SUBSCRIPTION_ALREADY_CANCELED",
+    };
+  }
+
+  const externalSubId = sub["external_subscription_id"] as string | null;
+
+  // 3. Call adapter
+  if (externalSubId) {
+    try {
+      await adapter.cancelSubscription({
+        subscriptionId: externalSubId,
+        cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+      });
+    } catch (adapterError) {
+      return {
+        success: false,
+        error: adapterError instanceof Error ? adapterError.message : "Adapter error",
+        code: "ADAPTER_ERROR",
+      };
+    }
+  }
+
+  // 4. Build update payload
+  const updatePayload: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (input.cancelAtPeriodEnd) {
+    updatePayload["cancel_at_period_end"] = true;
+  } else {
+    updatePayload["status"] = "canceled";
+    updatePayload["canceled_at"] = new Date().toISOString();
+  }
+
+  // 5. Update DB via adminClient
+  const { data: updatedSub, error: updateError } = await adminClient
+    .from("tenant_subscriptions")
+    .update(updatePayload)
+    .eq("tenant_id", tenantId)
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .single();
+
+  if (updateError || !updatedSub) {
+    return {
+      success: false,
+      error: updateError?.message ?? "Failed to update subscription",
+      code: "UPDATE_FAILED",
+    };
+  }
+
+  // 6. Write audit log
+  void writeAuditLog(
+    adminClient,
+    tenantId,
+    userId,
+    "billing.subscription_canceled",
+    sub["id"] as string,
+    {
+      planId: sub["plan_id"] as string,
+      cancelAtPeriodEnd: input.cancelAtPeriodEnd,
+      accessUntil: input.cancelAtPeriodEnd ? (sub["current_period_end"] as string) : null,
+      initiatedBy: userId,
+    },
+  );
+
+  return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
+}
+
+/**
+ * Resume a pending cancellation (cancel_at_period_end = true → false).
+ * No-op if subscription is already active with no pending cancel.
+ */
+export async function resumeSubscription(
+  client: SupabaseClient,
+  adminClient: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  adapter: PaymentProviderPort,
+): Promise<ServiceResult<SubscriptionRecord>> {
+  // 1. Get current subscription
+  const { data: currentSub, error: subError } = await client
+    .from("tenant_subscriptions")
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .eq("tenant_id", tenantId)
+    .maybeSingle();
+
+  if (subError) {
+    return { success: false, error: subError.message, code: "SUBSCRIPTION_FETCH_FAILED" };
+  }
+
+  if (!currentSub) {
+    return { success: false, error: "No subscription found", code: "SUBSCRIPTION_NOT_FOUND" };
+  }
+
+  const sub = currentSub as SubscriptionRow;
+
+  // 2. No-op guard: not pending cancel
+  if (!(sub["cancel_at_period_end"] as boolean)) {
+    return {
+      success: false,
+      error: "Subscription is not pending cancellation",
+      code: "SUBSCRIPTION_NOT_PENDING_CANCEL",
+    };
+  }
+
+  const externalSubId = sub["external_subscription_id"] as string | null;
+
+  // 3. Call adapter
+  if (externalSubId) {
+    try {
+      await adapter.resumeSubscription({ subscriptionId: externalSubId });
+    } catch (adapterError) {
+      return {
+        success: false,
+        error: adapterError instanceof Error ? adapterError.message : "Adapter error",
+        code: "ADAPTER_ERROR",
+      };
+    }
+  }
+
+  // 4. Update DB via adminClient
+  const { data: updatedSub, error: updateError } = await adminClient
+    .from("tenant_subscriptions")
+    .update({
+      cancel_at_period_end: false,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", tenantId)
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .single();
+
+  if (updateError || !updatedSub) {
+    return {
+      success: false,
+      error: updateError?.message ?? "Failed to update subscription",
+      code: "UPDATE_FAILED",
+    };
+  }
+
+  // 5. Write audit log
+  void writeAuditLog(
+    adminClient,
+    tenantId,
+    userId,
+    "billing.subscription_reactivated",
+    sub["id"] as string,
+    {
+      planId: sub["plan_id"] as string,
+      initiatedBy: userId,
+    },
+  );
+
+  return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
+}
+
+/**
+ * Process an incoming webhook event — idempotent.
+ * Checks external_event_id before inserting; no-op on duplicate.
+ */
+export async function processWebhookEvent(
+  adminClient: SupabaseClient,
+  event: WebhookEvent,
+): Promise<ServiceResult<null>> {
+  // 1. Idempotency check
+  const { data: existingEvent, error: checkError } = await adminClient
+    .from("billing_events")
+    .select("id")
+    .eq("external_event_id", event.externalEventId)
+    .maybeSingle();
+
+  if (checkError) {
+    return { success: false, error: checkError.message, code: "WEBHOOK_CHECK_FAILED" };
+  }
+
+  if (existingEvent) {
+    return {
+      success: false,
+      error: "Webhook event already processed",
+      code: "WEBHOOK_ALREADY_PROCESSED",
+    };
+  }
+
+  // 2. Resolve tenantId — either passed in or looked up via externalSubscriptionId
+  let tenantId = event.tenantId;
+
+  if (!tenantId && event.externalSubscriptionId) {
+    const { data: subRow } = await adminClient
+      .from("tenant_subscriptions")
+      .select("tenant_id")
+      .eq("external_subscription_id", event.externalSubscriptionId)
+      .maybeSingle();
+
+    tenantId = (subRow as SubscriptionRow | null)?.["tenant_id"] as string | undefined;
+  }
+
+  if (!tenantId) {
+    return {
+      success: false,
+      error: "Could not resolve tenant for webhook event",
+      code: "TENANT_NOT_FOUND",
+    };
+  }
+
+  // 3. Get subscription row for the tenant
+  const { data: subRow } = await adminClient
+    .from("tenant_subscriptions")
+    .select("id")
+    .eq("tenant_id", tenantId)
+    .maybeSingle();
+
+  const subscriptionId = (subRow as SubscriptionRow | null)?.["id"] as string | undefined;
+
+  // 4. Insert billing_events row
+  const { error: insertError } = await adminClient.from("billing_events").insert({
+    tenant_id: tenantId,
+    subscription_id: subscriptionId ?? null,
+    event_type: event.eventType,
+    provider: event.provider,
+    external_event_id: event.externalEventId,
+    payload: JSON.stringify(event.payload),
+    processed_at: new Date().toISOString(),
+  });
+
+  if (insertError) {
+    // Handle race condition: UNIQUE constraint violation means duplicate
+    if (insertError.code === "23505") {
+      return {
+        success: false,
+        error: "Webhook event already processed",
+        code: "WEBHOOK_ALREADY_PROCESSED",
+      };
+    }
+    return { success: false, error: insertError.message, code: "WEBHOOK_INSERT_FAILED" };
+  }
+
+  // 5. Sync subscription state if data provided
+  if (event.subscriptionData && subscriptionId) {
+    await syncSubscriptionState(adminClient, tenantId, event.subscriptionData);
+  }
+
+  return { success: true, data: null };
+}
+
+/**
+ * Get paginated billing history for a tenant.
+ * Returns events ordered by created_at DESC.
+ */
+export async function getBillingHistory(
+  client: SupabaseClient,
+  tenantId: string,
+  query: BillingHistoryQueryDto,
+): Promise<ServiceResult<BillingEventRecord[]>> {
+  const { limit, offset } = query;
+
+  const { data, error } = await client
+    .from("billing_events")
+    .select(
+      "id, tenant_id, subscription_id, event_type, provider, external_event_id, payload, processed_at, created_at",
+    )
+    .eq("tenant_id", tenantId)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return { success: false, error: error.message, code: "BILLING_HISTORY_FAILED" };
+  }
+
+  type BillingEventRow = Record<string, unknown>;
+  const events: BillingEventRecord[] = ((data ?? []) as BillingEventRow[]).map((row) => ({
+    id: row["id"] as string,
+    tenantId: row["tenant_id"] as string,
+    subscriptionId: (row["subscription_id"] as string | null) ?? null,
+    eventType: row["event_type"] as string,
+    provider: row["provider"] as string,
+    externalEventId: (row["external_event_id"] as string | null) ?? null,
+    payload: (row["payload"] as string | null) ?? null,
+    processedAt: (row["processed_at"] as string | null) ?? null,
+    createdAt: row["created_at"] as string,
+  }));
+
+  return { success: true, data: events };
+}
+
+/**
+ * Internal: sync subscription state from provider data.
+ * Used by processWebhookEvent to apply status transitions.
+ */
+async function syncSubscriptionState(
+  adminClient: SupabaseClient,
+  tenantId: string,
+  data: WebhookEvent["subscriptionData"],
+): Promise<ServiceResult<SubscriptionRecord>> {
+  if (!data) {
+    return { success: false, error: "No subscription data to sync", code: "SYNC_NO_DATA" };
+  }
+
+  const updatePayload: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (data.status !== undefined) updatePayload["status"] = data.status;
+  if (data.currentPeriodStart !== undefined)
+    updatePayload["current_period_start"] = data.currentPeriodStart;
+  if (data.currentPeriodEnd !== undefined)
+    updatePayload["current_period_end"] = data.currentPeriodEnd;
+  if (data.cancelAtPeriodEnd !== undefined)
+    updatePayload["cancel_at_period_end"] = data.cancelAtPeriodEnd;
+  if (data.graceEndsAt !== undefined) updatePayload["grace_ends_at"] = data.graceEndsAt;
+
+  const { data: updatedSub, error: updateError } = await adminClient
+    .from("tenant_subscriptions")
+    .update(updatePayload)
+    .eq("tenant_id", tenantId)
+    .select(
+      "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+    )
+    .single();
+
+  if (updateError || !updatedSub) {
+    return {
+      success: false,
+      error: updateError?.message ?? "Failed to sync subscription",
+      code: "SYNC_FAILED",
+    };
+  }
+
+  // Write audit event based on new status
+  const systemUserId = "00000000-0000-0000-0000-000000000000";
+  const statusAuditMap: Record<string, string> = {
+    active: "billing.subscription_activated",
+    past_due: "billing.subscription_past_due",
+    canceled: "billing.subscription_expired",
+  };
+
+  const auditEvent = data.status ? statusAuditMap[data.status] : undefined;
+  if (auditEvent) {
+    void writeAuditLog(adminClient, tenantId, systemUserId, auditEvent, updatedSub["id"] as string);
+  }
+
+  return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
+}
+
+/**
+ * Initialize subscription for a new tenant — called from signup flow.
+ * MUST be wrapped in try/catch — signup MUST NOT fail if billing init fails.
+ */
+export async function initializeSubscription(
+  adminClient: SupabaseClient,
+  tenantId: string,
+  adapter: PaymentProviderPort,
+  planSlug = "free",
+): Promise<ServiceResult<SubscriptionRecord>> {
+  try {
+    // 1. Find free plan
+    const { data: planData, error: planError } = await adminClient
+      .from("plans")
+      .select(
+        "id, name, slug, description, price_monthly, price_yearly, currency, features, limits, is_active, display_order, trial_days, created_at, updated_at",
+      )
+      .eq("slug", planSlug)
+      .eq("is_active", true)
+      .maybeSingle();
+
+    if (planError || !planData) {
+      console.error("[billing] initializeSubscription: plan not found:", planSlug);
+      return {
+        success: false,
+        error: planError?.message ?? `Plan not found: ${planSlug}`,
+        code: "PLAN_NOT_FOUND",
+      };
+    }
+
+    const plan = planData as PlanRow;
+
+    // 2. Create customer via adapter (best-effort)
+    let customerId: string;
+    try {
+      const customerResult = await adapter.createCustomer({
+        tenantId,
+        tenantName: tenantId, // Tenant name not available at this point — use tenantId as fallback
+        email: `tenant-${tenantId}@platform.internal`,
+      });
+      customerId = customerResult.customerId;
+    } catch (err) {
+      console.error("[billing] initializeSubscription: createCustomer failed:", err);
+      customerId = `local_${tenantId}`;
+    }
+
+    // 3. Create subscription via adapter (best-effort)
+    let externalSubscriptionId: string;
+    let currentPeriodStart: string;
+    let currentPeriodEnd: string;
+    try {
+      const subResult = await adapter.createSubscription({
+        customerId,
+        planSlug: plan["slug"] as string,
+        billingCycle: "monthly",
+      });
+      externalSubscriptionId = subResult.subscriptionId;
+      currentPeriodStart = subResult.currentPeriodStart;
+      currentPeriodEnd = subResult.currentPeriodEnd;
+    } catch (err) {
+      console.error("[billing] initializeSubscription: createSubscription failed:", err);
+      const now = new Date();
+      const periodEnd = new Date(now);
+      periodEnd.setMonth(periodEnd.getMonth() + 1);
+      externalSubscriptionId = `local_sub_${tenantId}`;
+      currentPeriodStart = now.toISOString();
+      currentPeriodEnd = periodEnd.toISOString();
+    }
+
+    // 4. Determine status (trialing if trial_days > 0)
+    const trialDays = plan["trial_days"] as number;
+    const now = new Date();
+    const status: SubscriptionRecord["status"] = trialDays > 0 ? "trialing" : "active";
+    const trialEndsAt =
+      trialDays > 0
+        ? new Date(now.getTime() + trialDays * 24 * 60 * 60 * 1000).toISOString()
+        : null;
+
+    // 5. Insert tenant_subscriptions row via adminClient
+    const { data: newSub, error: insertError } = await adminClient
+      .from("tenant_subscriptions")
+      .insert({
+        tenant_id: tenantId,
+        plan_id: plan["id"] as string,
+        status,
+        billing_cycle: "monthly",
+        current_period_start: currentPeriodStart,
+        current_period_end: currentPeriodEnd,
+        cancel_at_period_end: false,
+        trial_ends_at: trialEndsAt,
+        external_subscription_id: externalSubscriptionId,
+        external_customer_id: customerId,
+      })
+      .select(
+        "id, tenant_id, plan_id, status, billing_cycle, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_ends_at, grace_ends_at, external_subscription_id, external_customer_id, created_at, updated_at",
+      )
+      .single();
+
+    if (insertError || !newSub) {
+      console.error("[billing] initializeSubscription: insert failed:", insertError);
+      // Log audit event for failure
+      void writeAuditLog(
+        adminClient,
+        tenantId,
+        "00000000-0000-0000-0000-000000000000",
+        "billing.webhook_processing_failed",
+        undefined,
+        { error: insertError?.message ?? "Insert failed", planSlug },
+      );
+      return {
+        success: false,
+        error: insertError?.message ?? "Failed to initialize subscription",
+        code: "INIT_FAILED",
+      };
+    }
+
+    return { success: true, data: mapSubscriptionRow(newSub as SubscriptionRow) };
+  } catch (error) {
+    console.error("[billing] initializeSubscription: unexpected error:", error);
+    // Log failure to audit log (best-effort — do NOT rethrow)
+    try {
+      void writeAuditLog(
+        adminClient,
+        tenantId,
+        "00000000-0000-0000-0000-000000000000",
+        "billing.webhook_processing_failed",
+        undefined,
+        { error: error instanceof Error ? error.message : "Unknown error", planSlug },
+      );
+    } catch {
+      // Swallow audit log error — signup must proceed
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unexpected error",
+      code: "INIT_FAILED",
+    };
+  }
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -4,6 +4,7 @@
 export { ConsoleInvitationEmailAdapter } from "./adapters/console-invitation-email-adapter";
 export { ResendInvitationEmailAdapter } from "./adapters/resend-invitation-email-adapter";
 export * from "./auth-service";
+export * from "./billing-service";
 export type { InvitationEmailParams, InvitationEmailPort } from "./ports/invitation-email-port";
 export * from "./resource-service";
 export * from "./tenant-team-service";

--- a/packages/core/src/services/ports/payment-provider-port.ts
+++ b/packages/core/src/services/ports/payment-provider-port.ts
@@ -1,0 +1,49 @@
+// Payment provider port interface
+// Implement this interface to swap payment adapters per environment
+// All adapter-facing params use planSlug (not planId) — internal UUIDs stay internal
+
+export interface CreateCustomerParams {
+  tenantId: string;
+  tenantName: string;
+  email: string;
+}
+
+export interface CreateSubscriptionParams {
+  customerId: string;
+  planSlug: string;
+  billingCycle: "monthly" | "yearly";
+}
+
+export interface ChangePlanParams {
+  subscriptionId: string;
+  newPlanSlug: string;
+}
+
+export interface CancelSubscriptionParams {
+  subscriptionId: string;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface ResumeSubscriptionParams {
+  subscriptionId: string;
+}
+
+export interface PortalUrlParams {
+  customerId: string;
+  returnUrl: string;
+}
+
+export interface PaymentProviderPort {
+  createCustomer(params: CreateCustomerParams): Promise<{ customerId: string }>;
+  createSubscription(params: CreateSubscriptionParams): Promise<{
+    subscriptionId: string;
+    status: string;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+  }>;
+  changePlan(params: ChangePlanParams): Promise<{ success: boolean }>;
+  cancelSubscription(params: CancelSubscriptionParams): Promise<{ success: boolean }>;
+  resumeSubscription(params: ResumeSubscriptionParams): Promise<{ success: boolean }>;
+  getPortalUrl(params: PortalUrlParams): Promise<{ url: string }>;
+  verifyWebhookSignature(payload: string, signature: string): Promise<boolean>;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,6 +4,7 @@
 export type { PgTable } from "drizzle-orm/pg-core";
 // Re-export drizzle utilities
 export { drizzle } from "drizzle-orm/postgres-js";
+export * from "./schema/billing.js";
 // Re-export new types explicitly for consumers
 export type { NewTenantInvitation, TenantInvitation } from "./schema/platform.js";
 export * from "./schema/platform.js";

--- a/packages/db/src/schema/billing.ts
+++ b/packages/db/src/schema/billing.ts
@@ -1,0 +1,212 @@
+// Billing schema - Plans, tenant subscriptions, and billing events with RLS
+// All billing writes are service_role only (webhook handler + service layer)
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  pgEnum,
+  pgPolicy,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { authenticatedRole, serviceRole } from "drizzle-orm/supabase";
+import { tenants } from "./platform.js";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/** Subscription lifecycle status */
+export const subscriptionStatusEnum = pgEnum("subscription_status", [
+  "trialing",
+  "active",
+  "past_due",
+  "canceled",
+  "unpaid",
+]);
+
+/** Billing frequency */
+export const billingCycleEnum = pgEnum("billing_cycle", ["monthly", "yearly"]);
+
+// ============================================================================
+// RLS Helpers
+// ============================================================================
+
+/** Matches the tenant_id column against the JWT app_metadata tenant_id claim */
+const tenantClaimMatchesColumn = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+
+/** Restricts access to owner and admin roles via app_metadata */
+const ownerOrAdminRoleClaim = sql`(auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))`;
+
+// ============================================================================
+// Plans Table
+// ============================================================================
+
+/** Plans - the billing catalog (public read, service_role write) */
+export const plans = pgTable(
+  "plans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    name: text("name").notNull(),
+    slug: text("slug").notNull().unique(),
+    description: text("description"),
+    priceMonthly: integer("price_monthly").notNull(), // cents
+    priceYearly: integer("price_yearly").notNull(), // cents
+    currency: text("currency").notNull().default("usd"),
+    features: text("features").notNull(), // JSON string
+    limits: text("limits").notNull(), // JSON string
+    isActive: boolean("is_active").notNull().default(true),
+    displayOrder: integer("display_order").notNull().default(0),
+    trialDays: integer("trial_days").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("plans_slug_idx").on(table.slug),
+    index("plans_active_order_idx").on(table.isActive, table.displayOrder),
+    // Plans are a public catalog — any authenticated user can read
+    pgPolicy("plans_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`true`,
+    }),
+    pgPolicy("plans_insert", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("plans_update", {
+      as: "permissive",
+      for: "update",
+      to: serviceRole,
+      using: sql`true`,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("plans_delete", {
+      as: "permissive",
+      for: "delete",
+      to: serviceRole,
+      using: sql`true`,
+    }),
+  ],
+).enableRLS();
+
+// ============================================================================
+// Tenant Subscriptions Table
+// ============================================================================
+
+/** Tenant subscriptions - one active subscription per tenant */
+export const tenantSubscriptions = pgTable(
+  "tenant_subscriptions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" })
+      .unique(),
+    planId: uuid("plan_id")
+      .notNull()
+      .references(() => plans.id),
+    status: subscriptionStatusEnum("status").notNull(),
+    billingCycle: billingCycleEnum("billing_cycle").notNull(),
+    currentPeriodStart: timestamp("current_period_start", { withTimezone: true }).notNull(),
+    currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }).notNull(),
+    cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
+    canceledAt: timestamp("canceled_at", { withTimezone: true }),
+    trialEndsAt: timestamp("trial_ends_at", { withTimezone: true }),
+    graceEndsAt: timestamp("grace_ends_at", { withTimezone: true }),
+    externalSubscriptionId: text("external_subscription_id").unique(),
+    externalCustomerId: text("external_customer_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("subscriptions_tenant_idx").on(table.tenantId),
+    index("subscriptions_external_id_idx").on(table.externalSubscriptionId),
+    index("subscriptions_status_idx").on(table.status),
+    // Only owner and admin can read their tenant's subscription
+    pgPolicy("subscriptions_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`(${tenantClaimMatchesColumn} AND ${ownerOrAdminRoleClaim})`,
+    }),
+    // All writes via service_role only (webhook handler + service layer)
+    pgPolicy("subscriptions_insert_sr", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("subscriptions_update_sr", {
+      as: "permissive",
+      for: "update",
+      to: serviceRole,
+      using: sql`true`,
+      withCheck: sql`true`,
+    }),
+    // No DELETE policy — status transitions only, never hard delete
+  ],
+).enableRLS();
+
+// ============================================================================
+// Billing Events Table
+// ============================================================================
+
+/** Billing events - immutable audit trail of all payment provider events */
+export const billingEvents = pgTable(
+  "billing_events",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    subscriptionId: uuid("subscription_id").references(() => tenantSubscriptions.id),
+    eventType: text("event_type").notNull(),
+    provider: text("provider").notNull(),
+    externalEventId: text("external_event_id").unique(),
+    payload: text("payload"), // JSON string
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("billing_events_tenant_idx").on(table.tenantId),
+    index("billing_events_external_event_idx").on(table.externalEventId),
+    index("billing_events_subscription_idx").on(table.subscriptionId),
+    // Only owner and admin can read their tenant's billing events
+    pgPolicy("billing_events_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: sql`(${tenantClaimMatchesColumn} AND ${ownerOrAdminRoleClaim})`,
+    }),
+    // All writes via service_role only — immutable after insert
+    pgPolicy("billing_events_insert_sr", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    // No UPDATE — immutable after insert
+    // No DELETE — audit records must be retained
+  ],
+).enableRLS();
+
+// ============================================================================
+// Type Exports (for use in services)
+// ============================================================================
+
+export type Plan = typeof plans.$inferSelect;
+export type NewPlan = typeof plans.$inferInsert;
+
+export type TenantSubscription = typeof tenantSubscriptions.$inferSelect;
+export type NewTenantSubscription = typeof tenantSubscriptions.$inferInsert;
+
+export type BillingEvent = typeof billingEvents.$inferSelect;
+export type NewBillingEvent = typeof billingEvents.$inferInsert;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.50.0
         version: 2.103.3
+      stripe:
+        specifier: ^17.7.0
+        version: 17.7.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -2594,6 +2597,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
@@ -2777,6 +2788,10 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -2793,11 +2808,23 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -2884,13 +2911,24 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -2907,6 +2945,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2917,6 +2959,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -3101,6 +3151,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3166,6 +3220,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -3255,6 +3313,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -3352,6 +3414,22 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -3404,6 +3482,10 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  stripe@17.7.0:
+    resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
+    engines: {node: '>=12.*'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -5975,6 +6057,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001788: {}
 
   chai@5.3.3:
@@ -6051,6 +6143,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.6
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.344: {}
@@ -6064,9 +6162,17 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -6202,9 +6308,29 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -6227,6 +6353,8 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   happy-dom@18.0.1:
@@ -6236,6 +6364,12 @@ snapshots:
       whatwg-mimetype: 3.0.0
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
 
@@ -6400,6 +6534,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
   merge-stream@2.0.0: {}
 
   mime-db@1.54.0: {}
@@ -6452,6 +6588,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.38: {}
+
+  object-inspect@1.13.4: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -6524,6 +6662,10 @@ snapshots:
   progress@2.0.3: {}
 
   proxy-from-env@1.1.0: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -6715,6 +6857,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -6764,6 +6934,11 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@17.7.0:
+    dependencies:
+      '@types/node': 25.6.0
+      qs: 6.15.2
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:

--- a/supabase/migrations/20260521000001_billing_schema.sql
+++ b/supabase/migrations/20260521000001_billing_schema.sql
@@ -1,0 +1,183 @@
+-- Billing schema: plans, tenant_subscriptions, billing_events
+-- Adds subscription lifecycle management with RLS-enforced tenant isolation.
+-- All writes are service_role only (webhook handler + service layer).
+
+-- ============================================================================
+-- Enums
+-- ============================================================================
+
+CREATE TYPE "public"."subscription_status" AS ENUM(
+  'trialing',
+  'active',
+  'past_due',
+  'canceled',
+  'unpaid'
+);
+
+CREATE TYPE "public"."billing_cycle" AS ENUM('monthly', 'yearly');
+
+-- ============================================================================
+-- plans
+-- ============================================================================
+
+CREATE TABLE "plans" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "name" text NOT NULL,
+  "slug" text NOT NULL,
+  "description" text,
+  "price_monthly" integer NOT NULL,
+  "price_yearly" integer NOT NULL,
+  "currency" text DEFAULT 'usd' NOT NULL,
+  "features" text NOT NULL,
+  "limits" text NOT NULL,
+  "is_active" boolean DEFAULT true NOT NULL,
+  "display_order" integer DEFAULT 0 NOT NULL,
+  "trial_days" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "plans_slug_unique" UNIQUE("slug")
+);
+
+ALTER TABLE "plans" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "plans_slug_idx" ON "plans" USING btree ("slug");
+CREATE INDEX "plans_active_order_idx" ON "plans" USING btree ("is_active", "display_order");
+
+-- Plans are a public catalog — any authenticated user can read
+CREATE POLICY "plans_select" ON "plans"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (true);
+
+-- All writes via service_role only
+CREATE POLICY "plans_insert" ON "plans"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+CREATE POLICY "plans_update" ON "plans"
+  AS PERMISSIVE FOR UPDATE
+  TO "service_role"
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "plans_delete" ON "plans"
+  AS PERMISSIVE FOR DELETE
+  TO "service_role"
+  USING (true);
+
+-- ============================================================================
+-- tenant_subscriptions
+-- ============================================================================
+
+CREATE TABLE "tenant_subscriptions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "plan_id" uuid NOT NULL,
+  "status" "subscription_status" NOT NULL,
+  "billing_cycle" "billing_cycle" NOT NULL,
+  "current_period_start" timestamp with time zone NOT NULL,
+  "current_period_end" timestamp with time zone NOT NULL,
+  "cancel_at_period_end" boolean DEFAULT false NOT NULL,
+  "canceled_at" timestamp with time zone,
+  "trial_ends_at" timestamp with time zone,
+  "grace_ends_at" timestamp with time zone,
+  "external_subscription_id" text,
+  "external_customer_id" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "tenant_subscriptions_tenant_id_unique" UNIQUE("tenant_id"),
+  CONSTRAINT "tenant_subscriptions_external_subscription_id_unique" UNIQUE("external_subscription_id")
+);
+
+ALTER TABLE "tenant_subscriptions"
+  ADD CONSTRAINT "tenant_subscriptions_tenant_id_tenants_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "tenant_subscriptions"
+  ADD CONSTRAINT "tenant_subscriptions_plan_id_plans_id_fk"
+  FOREIGN KEY ("plan_id") REFERENCES "public"."plans"("id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "tenant_subscriptions" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "subscriptions_tenant_idx" ON "tenant_subscriptions" USING btree ("tenant_id");
+CREATE INDEX "subscriptions_external_id_idx" ON "tenant_subscriptions" USING btree ("external_subscription_id");
+CREATE INDEX "subscriptions_status_idx" ON "tenant_subscriptions" USING btree ("status");
+
+-- Only owner and admin can read their tenant's subscription
+CREATE POLICY "subscriptions_select" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (
+    ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)
+    AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))
+  );
+
+-- All writes via service_role only (webhook handler + service layer)
+CREATE POLICY "subscriptions_insert_sr" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+CREATE POLICY "subscriptions_update_sr" ON "tenant_subscriptions"
+  AS PERMISSIVE FOR UPDATE
+  TO "service_role"
+  USING (true)
+  WITH CHECK (true);
+
+-- No DELETE policy — status transitions only, never hard delete
+
+-- ============================================================================
+-- billing_events
+-- ============================================================================
+
+CREATE TABLE "billing_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "subscription_id" uuid,
+  "event_type" text NOT NULL,
+  "provider" text NOT NULL,
+  "external_event_id" text,
+  "payload" text,
+  "processed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "billing_events_external_event_id_unique" UNIQUE("external_event_id")
+);
+
+ALTER TABLE "billing_events"
+  ADD CONSTRAINT "billing_events_tenant_id_tenants_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "billing_events"
+  ADD CONSTRAINT "billing_events_subscription_id_tenant_subscriptions_id_fk"
+  FOREIGN KEY ("subscription_id") REFERENCES "public"."tenant_subscriptions"("id") ON DELETE no action ON UPDATE no action;
+
+ALTER TABLE "billing_events" ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX "billing_events_tenant_idx" ON "billing_events" USING btree ("tenant_id");
+CREATE INDEX "billing_events_external_event_idx" ON "billing_events" USING btree ("external_event_id");
+CREATE INDEX "billing_events_subscription_idx" ON "billing_events" USING btree ("subscription_id");
+
+-- Only owner and admin can read their tenant's billing events
+CREATE POLICY "billing_events_select" ON "billing_events"
+  AS PERMISSIVE FOR SELECT
+  TO "authenticated"
+  USING (
+    ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)
+    AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin'))
+  );
+
+-- All writes via service_role only — immutable after insert
+CREATE POLICY "billing_events_insert_sr" ON "billing_events"
+  AS PERMISSIVE FOR INSERT
+  TO "service_role"
+  WITH CHECK (true);
+
+-- No UPDATE — immutable after insert
+-- No DELETE — audit records must be retained
+
+-- ============================================================================
+-- Reload PostgREST schema cache
+-- ============================================================================
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/meta/0001_snapshot.json
+++ b/supabase/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1605 @@
+{
+  "id": "979c4b2c-50d8-490e-9e38-5d3a39bb2d8b",
+  "prevId": "bd7e8b72-8351-4d34-be92-fb5b66d77b75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_events_tenant_idx": {
+          "name": "billing_events_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_external_event_idx": {
+          "name": "billing_events_external_event_idx",
+          "columns": [
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_subscription_idx": {
+          "name": "billing_events_subscription_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_events_tenant_id_tenants_id_fk": {
+          "name": "billing_events_tenant_id_tenants_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_events_subscription_id_tenant_subscriptions_id_fk": {
+          "name": "billing_events_subscription_id_tenant_subscriptions_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenant_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_external_event_id_unique": {
+          "name": "billing_events_external_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_event_id"
+          ]
+        }
+      },
+      "policies": {
+        "billing_events_select": {
+          "name": "billing_events_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "billing_events_insert_sr": {
+          "name": "billing_events_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_yearly": {
+          "name": "price_yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "features": {
+          "name": "features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limits": {
+          "name": "limits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trial_days": {
+          "name": "trial_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_active_order_idx": {
+          "name": "plans_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_slug_unique": {
+          "name": "plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "plans_select": {
+          "name": "plans_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "plans_insert": {
+          "name": "plans_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "plans_update": {
+          "name": "plans_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        },
+        "plans_delete": {
+          "name": "plans_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_subscriptions": {
+      "name": "tenant_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subscription_id": {
+          "name": "external_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_customer_id": {
+          "name": "external_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_external_id_idx": {
+          "name": "subscriptions_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_subscriptions_tenant_id_tenants_id_fk": {
+          "name": "tenant_subscriptions_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_subscriptions_plan_id_plans_id_fk": {
+          "name": "tenant_subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_subscriptions_tenant_id_unique": {
+          "name": "tenant_subscriptions_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id"
+          ]
+        },
+        "tenant_subscriptions_external_subscription_id_unique": {
+          "name": "tenant_subscriptions_external_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_subscription_id"
+          ]
+        }
+      },
+      "policies": {
+        "subscriptions_select": {
+          "name": "subscriptions_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "subscriptions_insert_sr": {
+          "name": "subscriptions_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "subscriptions_update_sr": {
+          "name": "subscriptions_update_sr",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_tenant_idx": {
+          "name": "audit_log_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_idx": {
+          "name": "audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_idx": {
+          "name": "audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_log_select": {
+          "name": "audit_log_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "audit_log_insert": {
+          "name": "audit_log_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND auth.uid() = user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_tenant_idx": {
+          "name": "profiles_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_email_idx": {
+          "name": "profiles_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "profiles_select": {
+          "name": "profiles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "profiles_insert": {
+          "name": "profiles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid() = id AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "profiles_update": {
+          "name": "profiles_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "profiles_delete": {
+          "name": "profiles_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_invitations": {
+      "name": "tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_tenant_idx": {
+          "name": "invitations_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_token_hash_idx": {
+          "name": "invitations_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_invitations_tenant_id_tenants_id_fk": {
+          "name": "tenant_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "invitations_select": {
+          "name": "invitations_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_insert": {
+          "name": "invitations_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_update": {
+          "name": "invitations_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_delete": {
+          "name": "invitations_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-US'"
+        },
+        "allow_admin_invites": {
+          "name": "allow_admin_invites",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_slug_idx": {
+          "name": "tenants_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenants_status_idx": {
+          "name": "tenants_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "tenants_select": {
+          "name": "tenants_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = id)"
+        },
+        "tenants_insert": {
+          "name": "tenants_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "tenants_update": {
+          "name": "tenants_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_roles_user_tenant_idx": {
+          "name": "user_roles_user_tenant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_roles_select": {
+          "name": "user_roles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "user_roles_insert": {
+          "name": "user_roles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_tenant_idx": {
+          "name": "resources_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_status_idx": {
+          "name": "resources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_type_idx": {
+          "name": "resources_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_created_by_idx": {
+          "name": "resources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "resources_select": {
+          "name": "resources_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "resources_insert": {
+          "name": "resources_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_update": {
+          "name": "resources_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_delete": {
+          "name": "resources_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "yearly"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "read",
+        "update",
+        "delete",
+        "login",
+        "logout",
+        "custom"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.tenant_status": {
+      "name": "tenant_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "suspended"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "guest"
+      ]
+    },
+    "public.resource_status": {
+      "name": "resource_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "draft",
+        "archived",
+        "suspended"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "service",
+        "asset",
+        "document",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776909061381,
       "tag": "0000_late_scorpion",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779396142849,
+      "tag": "0001_happy_the_renegades",
+      "breakpoints": true
     }
   ]
 }

--- a/ui/app/api/webhooks/billing/route.ts
+++ b/ui/app/api/webhooks/billing/route.ts
@@ -1,0 +1,63 @@
+import { createPaymentAdapter } from "@enterprise/core/services/adapters/payment-adapter-factory";
+import { processWebhookEvent } from "@enterprise/core/services/billing-service";
+import { getAdminClient } from "@enterprise/core/supabase/admin";
+
+// Webhook Route Handler — NOT a Server Action
+// Sits outside (protected)/ — no auth middleware applies
+// Raw body is required for Stripe signature verification
+
+function extractExternalSubscriptionId(event: Record<string, unknown>): string {
+  const data = event["data"] as Record<string, unknown> | undefined;
+  const obj = data?.["object"] as Record<string, unknown> | undefined;
+  return (obj?.["subscription"] as string | undefined) ?? "";
+}
+
+export async function POST(request: Request) {
+  try {
+    const rawBody = await request.text();
+    const signature = request.headers.get("stripe-signature") ?? "";
+
+    const adapter = createPaymentAdapter();
+    const isValid = await adapter.verifyWebhookSignature(rawBody, signature);
+
+    if (!isValid) {
+      return new Response(JSON.stringify({ error: "Invalid signature" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Parse the raw event payload
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON payload" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const adminClient = getAdminClient();
+    const result = await processWebhookEvent(adminClient, {
+      eventType: (event["type"] as string | undefined) ?? "unknown",
+      externalEventId: (event["id"] as string | undefined) ?? "",
+      externalSubscriptionId: extractExternalSubscriptionId(event),
+      provider: "stripe",
+      payload: event,
+    });
+
+    if (!result.success) {
+      // Log failures but still return 200 — prevents provider retry loops for non-transient errors
+      console.error("[webhook/billing] Processing failed:", result.error, result.code);
+    }
+
+    return new Response("ok", { status: 200 });
+  } catch (error) {
+    console.error("[webhook/billing] Unexpected error:", error);
+    return new Response(JSON.stringify({ error: "Internal error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/ui/features/billing/actions.ts
+++ b/ui/features/billing/actions.ts
@@ -1,0 +1,300 @@
+"use server";
+
+import type { ActionResult } from "@enterprise/contracts";
+import { cancelSubscriptionSchema, changePlanSchema } from "@enterprise/contracts";
+import { createPaymentAdapter } from "@enterprise/core/services/adapters/payment-adapter-factory";
+import {
+  cancelSubscription,
+  changePlan,
+  getSubscription,
+  resumeSubscription,
+} from "@enterprise/core/services/billing-service";
+import { getAdminClient } from "@enterprise/core/supabase/admin";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { getAppUrl } from "@enterprise/core/utils/env";
+import { revalidatePath } from "next/cache";
+import { ROUTES } from "@/lib/routes";
+import { captureActionError } from "@/lib/sentry";
+
+// ─── Auth Context ─────────────────────────────────────────────────────────────
+
+async function getAuthContext(supabase: Awaited<ReturnType<typeof getServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+  const role = (user.app_metadata?.["role"] as string | undefined) ?? null;
+
+  return { userId: user.id, tenantId, role };
+}
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+export async function changePlanAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = Object.fromEntries(formData.entries());
+  const parsed = changePlanSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can change plans" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await changePlan(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      parsed.data,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "CHANGE_PLAN_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "changePlanAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function cancelSubscriptionAction(
+  _prevState: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  const raw = Object.fromEntries(formData.entries());
+  // cancelAtPeriodEnd comes as a string from FormData; coerce it
+  const coerced = {
+    cancelAtPeriodEnd:
+      raw["cancelAtPeriodEnd"] === "false" ? false : raw["cancelAtPeriodEnd"] !== "false",
+  };
+  const parsed = cancelSubscriptionSchema.safeParse(coerced);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can cancel subscriptions" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await cancelSubscription(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      parsed.data,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "CANCEL_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "cancelSubscriptionAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function resumeSubscriptionAction(
+  _prevState: ActionResult | null,
+  _formData: FormData,
+): Promise<ActionResult> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can resume subscriptions" },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const adapter = createPaymentAdapter();
+    const result = await resumeSubscription(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      adapter,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "RESUME_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.billing);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "resumeSubscriptionAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+export async function getPortalUrlAction(): Promise<ActionResult<{ url: string }>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId || !auth.role) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only workspace owners can access the billing portal" },
+    };
+  }
+
+  try {
+    // Get subscription to extract the external customer ID
+    const subResult = await getSubscription(supabase, auth.tenantId);
+
+    if (!subResult.success || !subResult.data) {
+      return {
+        success: false,
+        error: {
+          code: subResult.success
+            ? "SUBSCRIPTION_NOT_FOUND"
+            : (subResult.code ?? "SUBSCRIPTION_FETCH_FAILED"),
+          message: subResult.success ? "No active subscription found" : subResult.error,
+        },
+      };
+    }
+
+    const customerId = subResult.data.externalCustomerId ?? `local_${auth.tenantId}`;
+    const returnUrl = `${getAppUrl()}${ROUTES.billing}`;
+
+    const adapter = createPaymentAdapter();
+    const portalResult = await adapter.getPortalUrl({ customerId, returnUrl });
+
+    return { success: true, data: { url: portalResult.url } };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "getPortalUrlAction",
+      area: "billing",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}

--- a/ui/features/billing/queries.ts
+++ b/ui/features/billing/queries.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import type { BillingHistoryQueryDto } from "@enterprise/contracts";
+import type {
+  BillingEventRecord,
+  PlanRecord,
+  SubscriptionWithPlan,
+} from "@enterprise/core/services/billing-service";
+import {
+  getBillingHistory,
+  getSubscription,
+  listPlans,
+} from "@enterprise/core/services/billing-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+
+export async function getSubscriptionQuery(tenantId: string): Promise<SubscriptionWithPlan | null> {
+  const supabase = await getServerClient();
+  const result = await getSubscription(supabase, tenantId);
+  if (!result.success) return null;
+  return result.data;
+}
+
+export async function listPlansQuery(): Promise<PlanRecord[]> {
+  const supabase = await getServerClient();
+  const result = await listPlans(supabase);
+  if (!result.success) return [];
+  return result.data;
+}
+
+export async function getBillingHistoryQuery(
+  tenantId: string,
+  query: BillingHistoryQueryDto,
+): Promise<BillingEventRecord[]> {
+  const supabase = await getServerClient();
+  const result = await getBillingHistory(supabase, tenantId, query);
+  if (!result.success) return [];
+  return result.data;
+}

--- a/ui/features/billing/types.ts
+++ b/ui/features/billing/types.ts
@@ -1,0 +1,21 @@
+import type { BillingEventDto, PlanDto, SubscriptionDto } from "@enterprise/contracts";
+
+// ─── Page Props ────────────────────────────────────────────────────────────────
+
+export interface BillingPageProps {
+  subscription: SubscriptionDto | null;
+  plans: PlanDto[];
+  history: BillingEventDto[];
+}
+
+// ─── Component Props ───────────────────────────────────────────────────────────
+
+export interface PlanCardProps {
+  plan: PlanDto;
+  currentPlanId: string | null;
+  isOwner: boolean;
+}
+
+export interface HistoryRowProps {
+  event: BillingEventDto;
+}

--- a/ui/lib/routes.ts
+++ b/ui/lib/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
   dashboard: "/dashboard",
+  billing: "/billing",
   settings: "/settings",
   team: "/team",
   resources: {

--- a/ui/lib/sentry.ts
+++ b/ui/lib/sentry.ts
@@ -3,7 +3,14 @@ import * as Sentry from "@sentry/nextjs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type SentryArea = "auth" | "dashboard" | "resources" | "settings" | "team" | "webhook";
+export type SentryArea =
+  | "auth"
+  | "billing"
+  | "dashboard"
+  | "resources"
+  | "settings"
+  | "team"
+  | "webhook";
 
 export interface ActionErrorContext {
   actionName: string;


### PR DESCRIPTION
## Summary

- Register billing Sentry area and /billing route
- Add 4 Server Actions: changePlanAction, cancelSubscriptionAction, resumeSubscriptionAction, getPortalUrlAction
- Add server-side queries and feature types
- Add webhook Route Handler with signature verification

## Type of Change
- [x] New feature

## Test Results
- pnpm typecheck ✅ / pnpm lint ✅ / pnpm test ✅

## Part of
Billing & Plans — PR 5 of 7