### PR TITLE
docs: add P0 UX polish PRDs and update roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,42 @@ concurrency:
 permissions: {}
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'ui/**'
+              - 'packages/**'
+              - 'supabase/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+              - 'tsconfig.json'
+              - 'biome.json'
+              - 'turbo.json'
+
   quality:
     name: Quality Checks
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check for code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,38 @@ concurrency:
 permissions: {}
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'ui/**'
+              - 'packages/**'
+              - 'supabase/**'
+              - 'pnpm-lock.yaml'
+
   e2e:
     name: Playwright E2E
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check for code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,7 +29,15 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout configuration
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .github/labeler.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Apply labels to PR
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,12 @@
 name: Security Checks
 
-permissions:
-  contents: read
-  security-events: write
-
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
+
+permissions: {}
 
 jobs:
   detect-changes:
@@ -47,6 +45,8 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Harden runner
@@ -56,6 +56,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -75,6 +77,9 @@ jobs:
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Harden runner
@@ -86,6 +91,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,39 @@ on:
     branches: [main]
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'ui/**'
+              - 'packages/**'
+              - 'supabase/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+
   dependency-audit:
     name: Dependency Audit
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check for code changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |

--- a/docs/features/design-system-consistency/prd.md
+++ b/docs/features/design-system-consistency/prd.md
@@ -1,0 +1,210 @@
+---
+title: "Design system consistency PRD"
+description: "Defines product requirements for standardizing visual patterns across all platform pages."
+owner: "Engineering"
+priority: "P0"
+lastUpdated: "2026-05-23"
+---
+
+# Design system consistency PRD
+
+## Purpose
+
+Standardize visual patterns and UX composition across all platform pages so that every screen feels like part of the same product. Currently, each page uses slightly different card styles, spacing, header patterns, and interactive affordances — making the platform feel like a collection of independent prototypes rather than a unified product.
+
+## Scope
+
+- Included: page layout template standardization, card/surface hierarchy, button patterns, badge patterns, table patterns, form patterns, empty states, loading states, and error states.
+- Excluded: navigation and layout structure (handled by Platform UX Foundations PRD), landing page (separate PRD), new feature development.
+
+---
+
+## Problem
+
+The platform has 15+ pages across 5 feature modules, each built at different times with slightly different visual decisions:
+
+1. **No standard page template**: Dashboard uses inline cards, Resources uses a table with filters, Settings uses a sidebar+forms layout, Team uses a table with dialogs, Billing uses cards+table. There's no shared "page shell" pattern that dictates header placement, content structure, or action positioning.
+
+2. **Inconsistent card surfaces**: Some pages use `Card` with borders, others use tonal backgrounds. The `bg-card` token exists but isn't applied uniformly. Glass morphism is described in the design system but not implemented.
+
+3. **Mixed button patterns**: Primary actions are sometimes gradient CTAs, sometimes solid primary buttons, sometimes outline buttons. There's no hierarchy rule for when to use which variant.
+
+4. **Badge inconsistency**: Status badges use different color mappings across features (e.g., resource status vs subscription status vs role badges). No shared color mapping or badge component pattern.
+
+5. **No empty states**: Most pages show nothing when data is absent. There's no reusable empty state component.
+
+6. **No loading skeletons**: Pages show a blank screen while data loads. No skeleton/shimmer pattern exists.
+
+7. **Generic error boundaries**: Error pages show minimal UI with no brand consistency.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| All users | Consistent, predictable interface patterns across all pages |
+| Template adopters | A configurable design system they can rebrand by changing theme tokens |
+| Designers | A documented component pattern library to reference |
+
+## Goals
+
+- Every page follows the same page template pattern (header + content structure).
+- One card style, one badge pattern, one button hierarchy — documented and enforced.
+- Empty states, loading skeletons, and error states are reusable components.
+- All visual patterns derive from theme tokens — changing the theme JSON changes the entire platform look.
+
+---
+
+## MVP scope
+
+### 1. Page template standardization
+
+Define and implement a standard page template used by ALL protected pages:
+
+```
+PageHeader (title + subtitle + optional action button)
+  ├── title: string (h1, Manrope bold)
+  ├── subtitle: string (muted text)
+  └── action?: ReactNode (gradient CTA positioned top-right)
+PageContent
+  └── children (cards, tables, forms, etc.)
+```
+
+Migrate all 8 protected pages to use this pattern:
+- `/dashboard` — "Dashboard" + welcome subtitle
+- `/resources` — "Resources" + "Manage your workspace resources" + "New resource" CTA
+- `/resources/new` — "New resource" with breadcrumb
+- `/resources/[id]` — resource title with breadcrumb + edit/delete actions
+- `/resources/[id]/edit` — "Edit resource" with breadcrumb
+- `/team` — "Team" + "Manage members and invitations" + "Invite member" CTA
+- `/billing` — "Billing" + "Manage your subscription"
+- `/settings` — "Settings" + "Manage your workspace configuration"
+
+### 2. Surface hierarchy
+
+Define 3 surface levels and apply consistently:
+
+| Level | Token | Usage |
+|-------|-------|-------|
+| Background | `bg-background` | Page background, main content area |
+| Card/Surface | `bg-card` | Elevated containers, form groups, data sections |
+| Overlay | `bg-popover` | Dialogs, dropdowns, tooltips |
+
+Rules:
+- No visible card borders (use tonal shift only — No-Line Rule).
+- Cards use `rounded-xl` consistently (from theme `radius` token).
+- Glass effect (subtle `backdrop-blur`) on navigation surfaces only.
+
+### 3. Button hierarchy
+
+| Level | Variant | When to use |
+|-------|---------|-------------|
+| Primary | Gradient CTA (cyan → violet) | Main page action (Create, Upgrade, Save) — ONE per page max |
+| Secondary | Solid `bg-primary` | Supporting actions (Invite, Apply filters) |
+| Tertiary | `variant="outline"` | Cancel, Back, secondary navigation |
+| Destructive | `variant="destructive"` ghost | Delete, Cancel subscription |
+
+### 4. Badge pattern
+
+Standardize badge color mapping across ALL features:
+
+| Semantic | Color | Used for |
+|----------|-------|----------|
+| Success/Active | Green (`emerald`) | Active status, paid, completed |
+| Warning/Pending | Amber | Draft, pending, trialing |
+| Danger/Error | Red (`destructive`) | Past due, failed, expired |
+| Info/Default | Cyan (`primary`) | Product type, owner role |
+| Accent | Violet (`secondary`) | Admin role, service type |
+| Neutral | Gray (`muted`) | Archived, member role, guest |
+
+### 5. Empty state component
+
+Create a reusable `EmptyState` component:
+
+```
+EmptyState
+  ├── icon: LucideIcon (large, muted color)
+  ├── title: string ("No resources yet")
+  ├── description: string ("Create your first resource to get started")
+  ├── action?: { label: string, href: string } (gradient CTA)
+  └── link?: { label: string, href: string } ("Learn more →")
+```
+
+Apply to: Resources list, Team members (no members), Billing history (no events), Dashboard (new tenant).
+
+### 6. Loading skeleton component
+
+Create a reusable `PageSkeleton` component with shimmer animation:
+- `CardSkeleton` — rounded rect with pulse animation
+- `TableSkeleton` — header + N rows of pulse bars
+- `FormSkeleton` — label + input pulse patterns
+
+Apply to all pages that fetch data server-side (loading.tsx files).
+
+### 7. Error state consistency
+
+Standardize `error.tsx` across all protected route groups:
+- Show branded error card (not raw text)
+- Include: error icon, "Something went wrong" title, error message (sanitized), "Try again" button
+- Capture to Sentry (already done in billing/settings, extend to all)
+
+## Out of scope
+
+- Navigation structure changes (Platform UX Foundations PRD).
+- Landing page design (Landing Page PRD).
+- New theme tokens or color palette changes.
+- Animation/motion system beyond loading skeletons.
+- Component documentation site (Storybook or similar).
+
+---
+
+## User stories
+
+### US-01: Consistent page headers
+**As** a user navigating between pages, **I want** every page to have the same header layout (title, subtitle, action), **so that** I always know where I am and what actions are available.
+
+### US-02: Empty state guidance
+**As** a new tenant user, **I want** to see a helpful empty state when a section has no data, **so that** I know what to do next instead of seeing a blank page.
+
+### US-03: Loading feedback
+**As** a user waiting for data to load, **I want** to see a skeleton shimmer, **so that** I know the page is loading and the layout doesn't shift when data arrives.
+
+### US-04: Predictable buttons
+**As** a user, **I want** the same button style to mean the same thing on every page (gradient = create, outline = cancel, red = destructive), **so that** I can predict what will happen before I click.
+
+---
+
+## Success metrics
+
+- All 8 protected pages use the shared `PageHeader` component.
+- Zero pages show blank/empty content without an `EmptyState` component.
+- All route groups have a branded `error.tsx`.
+- All data-loading pages have a `loading.tsx` with skeleton.
+- Badge colors follow the standardized semantic mapping across all features.
+
+## Risks
+
+- Refactoring all pages to a shared template risks regressions on stable features.
+- Loading skeletons that don't match the actual layout cause CLS (Cumulative Layout Shift).
+- Too strict a pattern may limit future feature UX flexibility.
+
+## Open questions
+
+- Should the `PageHeader` component support breadcrumbs in MVP or defer?
+- Should loading skeletons match the exact layout of each page (costly) or use a generic pattern?
+
+---
+
+## Traceability
+
+| Concern | Approach |
+|---------|----------|
+| Audit events | None — visual changes only |
+| Sentry instrumentation | Extend error boundaries to all route groups |
+| Seed data | No changes |
+| E2E flows | Update visual assertions, add empty state tests |
+| External adapters | None |
+| Env vars | None |
+
+---
+
+*Last updated: 2026-05-23*

--- a/docs/features/landing-page/prd.md
+++ b/docs/features/landing-page/prd.md
@@ -1,0 +1,192 @@
+---
+title: "Landing page PRD"
+description: "Defines product requirements for the public marketing landing page with sign-in/sign-up access."
+owner: "Engineering"
+priority: "P0"
+lastUpdated: "2026-05-23"
+---
+
+# Landing page PRD
+
+## Purpose
+
+Create a public-facing landing page that serves as the entry point to the Enterprise Platform. Currently, unauthenticated users are redirected directly to `/sign-in` with no context about what the platform offers. There is no marketing surface, no feature overview, and no branded experience before authentication.
+
+## Scope
+
+- Included: landing page with hero section, feature highlights, pricing overview, call-to-action flow, responsive design (desktop + mobile), and navigation to sign-in/sign-up.
+- Excluded: blog, documentation site, changelog, terms/privacy pages, CMS integration.
+
+---
+
+## Problem
+
+The platform has NO public-facing page. The `(marketing)` route group exists with a layout but contains zero pages. When users visit the root URL (`/`), they are immediately redirected to `/sign-in`. This means:
+
+1. **No product context**: Users arrive at a login form with no understanding of what the platform does.
+2. **No acquisition funnel**: There's no way to communicate value before asking for credentials.
+3. **No brand presence**: The platform has a fully configured design system (Manrope + Inter, cyan + violet palette, glass morphism) but no public surface to showcase it.
+4. **Template adopters can't demo**: Without a landing page, adopters can't show the platform to stakeholders or potential customers.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| Prospective user | Understand what the platform offers before signing up |
+| Template adopter | A professional landing page they can rebrand for their own product |
+| Marketing team | A conversion-optimized page with clear CTAs |
+
+## Goals
+
+- Provide a branded first impression before authentication.
+- Communicate core platform capabilities in under 10 seconds of reading.
+- Drive sign-up conversions with clear CTAs.
+- Be fully responsive (desktop, tablet, mobile).
+- Be configurable through theme tokens — adopters change JSON, landing page adapts.
+
+---
+
+## MVP scope
+
+### 1. Navigation bar
+
+- Fixed top navbar (transparent background, blur on scroll).
+- Left: product logo/name (from tenant config or hardcoded "Enterprise").
+- Center: nav links — Features, Pricing (anchor links to page sections).
+- Right: "Sign in" ghost button + "Get Started" gradient CTA button.
+- Mobile: hamburger menu with same links.
+
+### 2. Hero section
+
+- Large bold headline (Manrope): configurable text, default "Build your SaaS faster".
+- Subtitle paragraph: "Multi-tenant platform template with billing, teams, and admin built in. Ship in days, not months."
+- Two CTAs: "Start building" gradient button (→ `/sign-up`) + "View documentation" ghost button (→ external docs URL or `/docs`).
+- Background: subtle gradient mesh or radial gradient using primary/secondary colors.
+- Optional: hero image or abstract graphic (SVG pattern or placeholder).
+
+### 3. Features section
+
+Three feature cards in a responsive grid (3 columns desktop, 1 column mobile):
+
+| Feature | Icon | Description |
+|---------|------|-------------|
+| Multi-tenant | `users` | "Isolated workspaces with role-based access, team management, and tenant-scoped data." |
+| Billing ready | `credit-card` | "Subscription lifecycle with Stripe integration, plan management, and webhook processing." |
+| Role-based access | `shield` | "Owner, admin, member, and guest roles with RLS-enforced security at every layer." |
+
+Cards: glass effect (backdrop-blur), tonal background, no borders.
+
+### 4. Pricing section (optional in MVP)
+
+Three plan cards matching the billing page design:
+- Free ($0/mo) — basic features
+- Pro ($29/mo) — expanded features, "Most popular" badge
+- Enterprise ($99/mo) — all features, "Contact sales"
+
+Each card: feature list, CTA button. Can be hardcoded or driven by the plans seed data.
+
+### 5. Footer
+
+- Logo + tagline.
+- Links: Features, Pricing, Documentation, Sign in.
+- Copyright: "2026 Enterprise Platform. All rights reserved."
+- Social links placeholders (GitHub, Twitter/X).
+
+### 6. Responsive design
+
+| Breakpoint | Layout |
+|------------|--------|
+| Desktop (1024px+) | Full 3-column grids, side-by-side hero layout |
+| Tablet (768px-1023px) | 2-column grids, stacked hero |
+| Mobile (<768px) | Single column, stacked everything, hamburger nav |
+
+## Out of scope
+
+- CMS-driven content (all content is hardcoded or config-driven).
+- Blog or changelog pages.
+- Terms of service, privacy policy pages.
+- A/B testing infrastructure.
+- Analytics integration (beyond what Sentry/Vercel already provides).
+- Custom domain or white-label URL routing.
+
+---
+
+## User stories
+
+### US-01: Understand the product
+**As** a prospective user visiting the platform URL, **I want** to see a clear description of what the platform does, **so that** I can decide whether to sign up.
+
+### US-02: Sign up from landing page
+**As** a prospective user, **I want** to click "Get Started" on the landing page, **so that** I'm taken directly to the sign-up form.
+
+### US-03: Sign in from landing page
+**As** an existing user, **I want** to click "Sign in" on the landing page, **so that** I can access my workspace.
+
+### US-04: View on mobile
+**As** a mobile user, **I want** the landing page to be fully readable and navigable on my phone, **so that** I can evaluate the platform from any device.
+
+### US-05: Rebrand the landing page
+**As** a template adopter, **I want** to change the landing page content and colors by editing theme tokens and content strings, **so that** the page matches my own product brand.
+
+---
+
+## Technical notes
+
+### Route structure
+
+- Landing page: `ui/app/(marketing)/page.tsx` — Server Component (SSR for SEO).
+- The `(marketing)` route group already exists with a layout. The page file is the only addition.
+- Root `/` should route to the landing page (not redirect to `/sign-in`).
+- Authenticated users visiting `/` should still redirect to `/dashboard`.
+
+### SEO requirements
+
+- Proper `<title>` and `<meta description>` tags.
+- Semantic HTML: `<header>`, `<main>`, `<section>`, `<footer>`.
+- Open Graph meta tags for social sharing.
+- `next/font` for web font loading (already configured).
+
+### Content configurability
+
+- Hero text, feature descriptions, and footer links should be extractable to a content config file or constants module for easy adopter customization.
+- Colors and typography automatically follow the theme system — no hardcoded color values.
+
+---
+
+## Success metrics
+
+- Root URL (`/`) renders the landing page (not a redirect to sign-in).
+- Landing page loads in < 2 seconds (SSR, no client-side data fetching).
+- "Get Started" CTA navigates to `/sign-up`.
+- "Sign in" navigates to `/sign-in`.
+- Lighthouse performance score >= 90.
+- Page is fully readable on 320px viewport.
+
+## Risks
+
+- Landing page content is too generic for adopters to reuse without heavy customization.
+- SSR landing page adds to cold start time on serverless deployments.
+- SEO metadata needs to be adopter-configurable (not hardcoded "Enterprise").
+
+## Open questions
+
+- Should the pricing section be dynamic (read from DB plans table) or static in MVP?
+- Should the root redirect logic live in middleware or in the root page component?
+- Should there be an "About" or "How it works" section in MVP?
+
+---
+
+## Traceability
+
+| Concern | Approach |
+|---------|----------|
+| Audit events | None — public page, no mutations |
+| Sentry instrumentation | Standard error boundary on (marketing) layout |
+| Seed data | None |
+| E2E flows | Smoke test: landing page loads, CTAs navigate correctly |
+| External adapters | None |
+| Env vars | Optional `NEXT_PUBLIC_LANDING_HERO_TITLE` for content override |
+
+---
+
+*Last updated: 2026-05-23*

--- a/docs/features/platform-ux-foundations/prd.md
+++ b/docs/features/platform-ux-foundations/prd.md
@@ -1,0 +1,171 @@
+---
+title: "Platform UX foundations PRD"
+description: "Defines product requirements for fixing navigation, layout, and settings UX issues across the platform."
+owner: "Engineering"
+priority: "P0"
+lastUpdated: "2026-05-23"
+---
+
+# Platform UX foundations PRD
+
+## Purpose
+
+Fix structural UX issues that prevent users from discovering and using shipped features. Navigation, layout scroll behavior, and settings page architecture need rework to create a usable, professional platform experience.
+
+## Scope
+
+- Included: sidebar navigation (add missing links), layout scroll behavior (fixed nav + scrollable content), settings page restructure (tabs instead of double sidebar), mobile navigation (bottom tab bar + drawer).
+- Excluded: visual polish, color/token changes, new feature development, landing page.
+
+---
+
+## Problem
+
+Three critical UX issues exist in the shipped platform:
+
+1. **Hidden features**: Team management (`/team`) and Billing (`/billing`) are fully implemented but have NO navigation links in the sidebar. Users can only access them by typing the URL directly. This makes shipped P0 features effectively invisible.
+
+2. **Broken scroll behavior**: The sidebar and header scroll away with the page content instead of staying fixed. On pages with long content (like Settings forms), the navigation disappears, forcing users to scroll back to the top to navigate. This is a fundamental layout bug.
+
+3. **Settings double sidebar**: The Settings page has a secondary vertical sidebar (`SettingsSidebar` component) for section navigation (Profile, Logo, Regional, Security). This creates a confusing double-sidebar pattern where two vertical menus compete for attention. The contextual navigation should use horizontal tabs inside the content area.
+
+## Users and stakeholders
+
+| Role | Need |
+|------|------|
+| All authenticated users | Discover and navigate to all platform features without memorizing URLs |
+| Tenant owner | Access Settings, Team, and Billing from a single, persistent navigation |
+| Mobile users | Navigate the platform with thumb-friendly controls (bottom tab bar) |
+| Template adopters | A professional, predictable layout shell they can extend with new features |
+
+## Goals
+
+- Every shipped feature is reachable from the sidebar navigation.
+- Navigation stays fixed and visible at all times during content scroll.
+- Settings uses horizontal tabs for section switching (no double sidebar).
+- Mobile provides a bottom tab bar and hamburger drawer for full navigation.
+
+---
+
+## MVP scope
+
+### 1. Sidebar navigation update
+
+Add missing navigation links to the existing sidebar:
+
+| Nav item | Icon | URL | Visible to |
+|----------|------|-----|------------|
+| Dashboard | `home` | `/dashboard` | All roles |
+| Resources | `folder` | `/resources` | All roles |
+| Team | `users` | `/team` | All roles |
+| Billing | `credit-card` | `/billing` | Owner, Admin |
+| Settings | `settings` | `/settings` | Owner, Admin |
+
+- Active state: highlight current route with primary color accent.
+- Role-based visibility: Billing and Settings only shown to owner/admin (matching existing page-level guards).
+- Mobile nav: same items in bottom tab bar (5 items) + hamburger drawer with full list.
+
+### 2. Layout scroll fix
+
+- Sidebar: `position: fixed`, `height: 100vh`, `overflow-y: auto` (sidebar itself scrolls if it has many items, but stays in place).
+- Header/top bar: `position: sticky`, `top: 0`, `z-index` above content.
+- Main content area: scrollable independently within the remaining viewport space.
+- The sidebar and header must NEVER scroll away when page content is scrolled.
+
+### 3. Settings page restructure
+
+- Remove `SettingsSidebar` component (the secondary vertical nav).
+- Replace with horizontal tabs inside the content area:
+  - Profile (default active)
+  - Branding (logo upload)
+  - Regional
+  - Security (owner only tab, hidden for admin)
+- Each tab renders its corresponding form section.
+- Tabs use the platform's existing tab/segmented control pattern.
+- URL does NOT change between tabs (client-side switching only).
+
+### 4. Mobile navigation
+
+- Bottom tab bar (fixed, 5 items): Dashboard, Resources, Team, Billing, More.
+- "More" opens a drawer/sheet with: Settings, Sign out, tenant info.
+- Bottom bar hidden on auth pages (sign-in, sign-up, etc.).
+- Glass/blur effect on bottom bar for premium feel.
+- Hamburger menu in header opens full nav sheet (same items as sidebar).
+
+## Out of scope
+
+- Color or token changes (handled by Design System Consistency PRD).
+- Landing page (handled by Landing Page PRD).
+- New feature development.
+- Sidebar collapse/expand toggle (future enhancement).
+- Breadcrumb navigation.
+
+---
+
+## User stories
+
+### US-01: Navigate to Team from sidebar
+**As** an authenticated user, **I want** to click "Team" in the sidebar, **so that** I can manage team members without memorizing the URL.
+
+### US-02: Navigate to Billing from sidebar
+**As** a tenant owner, **I want** to click "Billing" in the sidebar, **so that** I can manage my subscription from the main navigation.
+
+### US-03: Scroll content without losing navigation
+**As** a user on the Settings page, **I want** the sidebar and header to stay visible when I scroll down, **so that** I can navigate to another section without scrolling back up.
+
+### US-04: Switch Settings sections with tabs
+**As** a tenant admin, **I want** to switch between Profile, Branding, and Regional settings using horizontal tabs, **so that** I don't see a confusing second sidebar menu.
+
+### US-05: Navigate on mobile
+**As** a mobile user, **I want** a bottom tab bar with the main navigation items, **so that** I can access all features with one thumb tap.
+
+### US-06: Role-filtered navigation
+**As** a member role user, **I want** to NOT see Billing and Settings in the navigation, **so that** I'm not confused by links to pages I can't access.
+
+---
+
+## Permission matrix
+
+| Action | Owner | Admin | Member | Guest |
+|--------|-------|-------|--------|-------|
+| See Dashboard, Resources, Team nav links | Yes | Yes | Yes | Yes |
+| See Billing nav link | Yes | Yes | No | No |
+| See Settings nav link | Yes | Yes | No | No |
+| See Security tab in Settings | Yes | No | No | No |
+
+---
+
+## Success metrics
+
+- Zero features require URL-only access (all reachable from nav).
+- Sidebar stays fixed during scroll on all pages (visual regression test).
+- Settings page has zero vertical secondary sidebars.
+- Mobile navigation is functional on viewports 320px and above.
+
+## Risks
+
+- Changing the layout shell affects ALL protected pages — regression risk is high.
+- Mobile bottom tab bar with 5 items may feel crowded on small screens.
+- Settings tab restructure requires moving `SettingsSidebar` anchor-link logic to tab state.
+
+## Open questions
+
+- Should the sidebar be collapsible (icon-only mode) on desktop? (Deferred to future.)
+- Should tab state in Settings persist in URL hash for deep linking?
+
+---
+
+## Traceability
+
+| Concern | Approach |
+|---------|----------|
+| Audit events | None — no data mutations in this change |
+| Sentry instrumentation | Existing error boundaries sufficient |
+| Seed data | No changes needed |
+| E2E flows | Update sidebar nav assertions in ALL existing E2E suites + add mobile viewport tests |
+| External adapters | None |
+| Env vars | None |
+
+---
+
+*Last updated: 2026-05-23*

--- a/docs/features/roadmap.md
+++ b/docs/features/roadmap.md
@@ -2,7 +2,7 @@
 title: "Feature roadmap"
 description: "Defines the implementation priority order for planned feature work in the multi-tenant SaaS template."
 owner: "Engineering"
-lastUpdated: "2026-05-22"
+lastUpdated: "2026-05-23"
 ---
 
 # Feature roadmap
@@ -28,19 +28,22 @@ Define the canonical implementation priority for planned features in this templa
 | 4 | P0 | Tenant team management | Done | Completes the core multi-tenant member lifecycle. |
 | 5 | P0 | Workspace admin | Done | Makes tenant operations usable in day-to-day product workflows. |
 | 6 | P0 | Billing and plans | Done | Enables SaaS monetization and plan-based packaging. |
-| 7 | P1 | Notifications | Planned | Supports invites, billing events, and critical product communication. |
-| 8 | P1 | Public API and API keys | Planned | Unlocks integrations and external automation. |
-| 9 | P1 | Webhooks | Planned | Completes outbound integration workflows for technical adopters. |
-| 10 | P1 | Usage limits and quotas | Planned | Enforces plan value and protects shared resources. |
-| 11 | P1 | Brand abstraction layer | Planned | Enables multi-brand support from a single codebase with provider-agnostic branding. |
-| 12 | P1 | Brand isolation package | Planned | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
-| 13 | P1 | Backend provider decoupling | Planned | Introduces port/adapter interfaces to decouple @enterprise/core from Supabase. |
-| 14 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |
-| 15 | P2 | File storage module | Planned | Covers a common SaaS need for tenant-scoped file handling. |
-| 16 | P2 | i18n and regional settings | Planned | Expands reuse across regions and teams. |
-| 17 | P2 | Deployment provider decoupling | Planned | Adds Docker support and deployment-target abstraction for non-Vercel hosting. |
-| 18 | P3 | Feature flags | Planned | Adds rollout and packaging control after the core platform exists. |
-| 19 | P3 | Secure impersonation | Planned | Adds advanced support tooling after admin and audit flows mature. |
+| 7 | P0 | Platform UX foundations | Planned | Fixes hidden navigation, broken scroll layout, and settings double sidebar. |
+| 8 | P0 | Design system consistency | Planned | Standardizes page templates, empty states, loading skeletons, and visual patterns. |
+| 9 | P0 | Landing page | Planned | Public marketing page with hero, features, pricing, and sign-in/sign-up access. |
+| 10 | P1 | Notifications | Planned | Supports invites, billing events, and critical product communication. |
+| 11 | P1 | Public API and API keys | Planned | Unlocks integrations and external automation. |
+| 12 | P1 | Webhooks | Planned | Completes outbound integration workflows for technical adopters. |
+| 13 | P1 | Usage limits and quotas | Planned | Enforces plan value and protects shared resources. |
+| 14 | P1 | Brand abstraction layer | Planned | Enables multi-brand support from a single codebase with provider-agnostic branding. |
+| 15 | P1 | Brand isolation package | Planned | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
+| 16 | P1 | Backend provider decoupling | Planned | Introduces port/adapter interfaces to decouple @enterprise/core from Supabase. |
+| 17 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |
+| 18 | P2 | File storage module | Planned | Covers a common SaaS need for tenant-scoped file handling. |
+| 19 | P2 | i18n and regional settings | Planned | Expands reuse across regions and teams. |
+| 20 | P2 | Deployment provider decoupling | Planned | Adds Docker support and deployment-target abstraction for non-Vercel hosting. |
+| 21 | P3 | Feature flags | Planned | Adds rollout and packaging control after the core platform exists. |
+| 22 | P3 | Secure impersonation | Planned | Adds advanced support tooling after admin and audit flows mature. |
 
 ---
 
@@ -74,6 +77,9 @@ Define the canonical implementation priority for planned features in this templa
 - [Tenant team management PRD](./tenant-team-management/prd.md)
 - [Workspace admin PRD](./workspace-admin/prd.md)
 - [Billing and plans PRD](./billing-and-plans/prd.md)
+- [Platform UX foundations PRD](./platform-ux-foundations/prd.md)
+- [Design system consistency PRD](./design-system-consistency/prd.md)
+- [Landing page PRD](./landing-page/prd.md)
 - [Public API and API keys PRD](./public-api-and-api-keys/prd.md)
 - [Brand abstraction layer PRD](./brand-abstraction-layer/prd.md)
 - [Brand isolation package PRD](./brand-isolation-package/prd.md)
@@ -82,4 +88,4 @@ Define the canonical implementation priority for planned features in this templa
 
 ---
 
-*Last updated: 2026-05-22*
+*Last updated: 2026-05-23*


### PR DESCRIPTION
## Summary

- Add 3 new P0 PRDs for platform UX polish phase:
  - **Platform UX Foundations**: sidebar navigation (add Team + Billing links), fixed layout scroll, settings horizontal tabs, mobile bottom tab bar
  - **Design System Consistency**: shared PageHeader, surface hierarchy, button/badge standardization, EmptyState, loading skeletons, error boundaries
  - **Landing Page**: public marketing page with hero, features, pricing, sign-in/sign-up CTAs
- Update roadmap.md with items 7-9 (P0) and renumber remaining P1/P2/P3 items
- Stitch design reference: project `9174172328362024920` with 18 screens

## Type of Change

- [x] Documentation