### PR TITLE
feat(ui): add mobile bottom tab bar and navigation coverage

### DIFF
--- a/ui/components/layout/bottom-tab-bar.tsx
+++ b/ui/components/layout/bottom-tab-bar.tsx
@@ -89,7 +89,12 @@ export function BottomTabBar({ userRole, userLabel }: BottomTabBarProps) {
               <span>More</span>
             </Button>
           </SheetTrigger>
-          <SheetContent side="bottom" className="rounded-t-2xl" showCloseButton={false}>
+          <SheetContent
+            side="bottom"
+            className="rounded-t-2xl"
+            showCloseButton={false}
+            data-testid="bottom-tab-more-drawer"
+          >
             <SheetHeader>
               <SheetTitle>More</SheetTitle>
               <SheetDescription>Workspace actions and account shortcuts</SheetDescription>

--- a/ui/components/layout/bottom-tab-bar.tsx
+++ b/ui/components/layout/bottom-tab-bar.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { UserRole } from "@enterprise/contracts";
+import { Button } from "@enterprise/ui/components/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@enterprise/ui/components/sheet";
+import { cn } from "@enterprise/ui/lib/utils";
+import {
+  CreditCard,
+  Ellipsis,
+  LayoutDashboard,
+  LogOut,
+  Package,
+  Settings,
+  Users,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signOut } from "@/features/auth/actions";
+import { ROUTES } from "@/lib/routes";
+import type { NavItem } from "./nav-utils";
+import { filterNavItemsByRole, isNavItemActive } from "./nav-utils";
+
+interface BottomTabBarProps {
+  userRole: UserRole;
+  userLabel: string;
+}
+
+const BOTTOM_TAB_ITEMS: readonly NavItem[] = [
+  { label: "Dashboard", href: ROUTES.dashboard, icon: LayoutDashboard },
+  { label: "Resources", href: ROUTES.resources.root, icon: Package },
+  { label: "Team", href: ROUTES.team, icon: Users },
+  { label: "Billing", href: ROUTES.billing, icon: CreditCard, roles: ["owner", "admin"] },
+];
+
+function canAccessSettings(userRole: UserRole): boolean {
+  return userRole === "owner" || userRole === "admin";
+}
+
+export function BottomTabBar({ userRole, userLabel }: BottomTabBarProps) {
+  const pathname = usePathname();
+  const items = filterNavItemsByRole(BOTTOM_TAB_ITEMS, userRole);
+  const showSettings = canAccessSettings(userRole);
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-50 border-t bg-background/80 backdrop-blur-xl lg:hidden"
+      data-testid="bottom-tab-bar"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <div className="grid h-16 grid-cols-5 items-center px-1">
+        {items.map((item) => {
+          const active = isNavItemActive(item.href, pathname, ROUTES.dashboard);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex h-full flex-col items-center justify-center gap-1 rounded-md px-1 text-[11px] font-medium transition-colors",
+                active
+                  ? "text-primary"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+              )}
+              data-testid={`bottom-tab-item-${item.label.toLowerCase()}`}
+            >
+              <item.icon className="size-4" />
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-full flex-col gap-1 rounded-md px-1 text-[11px] text-muted-foreground"
+              data-testid="bottom-tab-more"
+            >
+              <Ellipsis className="size-4" />
+              <span>More</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="bottom" className="rounded-t-2xl" showCloseButton={false}>
+            <SheetHeader>
+              <SheetTitle>More</SheetTitle>
+              <SheetDescription>Workspace actions and account shortcuts</SheetDescription>
+            </SheetHeader>
+
+            <div className="space-y-1 px-4 pb-2">
+              {showSettings ? (
+                <SheetClose asChild>
+                  <Link
+                    href={ROUTES.settings}
+                    className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent"
+                    data-testid="bottom-tab-more-settings"
+                  >
+                    <Settings className="size-4" />
+                    Settings
+                  </Link>
+                </SheetClose>
+              ) : null}
+
+              <form action={signOut}>
+                <button
+                  type="submit"
+                  className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium hover:bg-accent"
+                  data-testid="bottom-tab-more-sign-out"
+                >
+                  <LogOut className="size-4" />
+                  Sign out
+                </button>
+              </form>
+            </div>
+
+            <div
+              className="border-t px-4 py-3 text-xs text-muted-foreground"
+              data-testid="bottom-tab-tenant-info"
+            >
+              {userLabel}
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </nav>
+  );
+}

--- a/ui/components/layout/dashboard-shell.tsx
+++ b/ui/components/layout/dashboard-shell.tsx
@@ -13,11 +13,11 @@ interface DashboardShellProps {
 
 export function DashboardShell({ children, userRole, userLabel }: DashboardShellProps) {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen lg:h-screen">
       <Sidebar userRole={userRole} userLabel={userLabel} />
-      <div className="flex min-h-screen flex-1 flex-col lg:ml-[var(--sidebar-width)]">
+      <div className="flex min-h-screen flex-1 flex-col lg:ml-[var(--sidebar-width)] lg:h-screen lg:overflow-hidden">
         <Header userRole={userRole} userLabel={userLabel} />
-        <main className="flex-1 p-6 pb-20 lg:pb-6">{children}</main>
+        <main className="flex-1 overflow-y-auto p-6 pb-20 lg:pb-6">{children}</main>
       </div>
       <BottomTabBar userRole={userRole} userLabel={userLabel} />
     </div>

--- a/ui/components/layout/dashboard-shell.tsx
+++ b/ui/components/layout/dashboard-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { UserRole } from "@enterprise/contracts";
+import { BottomTabBar } from "./bottom-tab-bar";
 import { Header } from "./header";
 import { Sidebar } from "./sidebar";
 
@@ -18,6 +19,7 @@ export function DashboardShell({ children, userRole, userLabel }: DashboardShell
         <Header userRole={userRole} userLabel={userLabel} />
         <main className="flex-1 p-6 pb-20 lg:pb-6">{children}</main>
       </div>
+      <BottomTabBar userRole={userRole} userLabel={userLabel} />
     </div>
   );
 }

--- a/ui/e2e/navigation/navigation-page.ts
+++ b/ui/e2e/navigation/navigation-page.ts
@@ -7,7 +7,7 @@ export class NavigationPage {
 
   constructor(private readonly page: Page) {
     this.moreButton = this.page.getByTestId("bottom-tab-more");
-    this.moreDrawer = this.page.locator('[data-slot="sheet-content"]');
+    this.moreDrawer = this.page.getByTestId("bottom-tab-more-drawer");
   }
 
   async gotoDashboard(): Promise<void> {

--- a/ui/e2e/navigation/navigation-page.ts
+++ b/ui/e2e/navigation/navigation-page.ts
@@ -1,0 +1,38 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import { ROUTES } from "../helpers/routes";
+
+export class NavigationPage {
+  readonly moreButton: Locator;
+  readonly moreDrawer: Locator;
+
+  constructor(private readonly page: Page) {
+    this.moreButton = this.page.getByTestId("bottom-tab-more");
+    this.moreDrawer = this.page.locator('[data-slot="sheet-content"]');
+  }
+
+  async gotoDashboard(): Promise<void> {
+    await this.page.goto(ROUTES.dashboard);
+    await this.page.waitForURL(new RegExp(ROUTES.dashboard));
+  }
+
+  sidebarLink(label: string): Locator {
+    return this.page.locator("aside").getByRole("link", { name: label, exact: true });
+  }
+
+  bottomTabItem(label: string): Locator {
+    return this.page.getByTestId(`bottom-tab-item-${label.toLowerCase()}`);
+  }
+
+  async expectBottomBarVisible(): Promise<void> {
+    await expect(this.page.getByTestId("bottom-tab-bar")).toBeVisible();
+  }
+
+  async expectBottomBarHidden(): Promise<void> {
+    await expect(this.page.getByTestId("bottom-tab-bar")).toBeHidden();
+  }
+
+  async openMoreDrawer(): Promise<void> {
+    await this.moreButton.click();
+    await expect(this.moreDrawer).toBeVisible();
+  }
+}

--- a/ui/e2e/navigation/navigation.spec.ts
+++ b/ui/e2e/navigation/navigation.spec.ts
@@ -4,6 +4,7 @@ import { ROUTES } from "../helpers/routes";
 import { NavigationPage } from "./navigation-page";
 
 const OWNER_EMAIL = "admin@enterprise.dev";
+const ADMIN_EMAIL = "admin-role@enterprise.dev";
 const MEMBER_EMAIL = "member@enterprise.dev";
 const PASSWORD = "password123";
 
@@ -76,6 +77,16 @@ test.describe("Navigation", () => {
       await expect(navigationPage.bottomTabItem("Billing")).toBeVisible();
     });
 
+    test("owner Billing bottom tab navigates to billing route", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await navigationPage.bottomTabItem("Billing").click();
+      await expect(page).toHaveURL(new RegExp(ROUTES.billing));
+    });
+
     test("member hides Billing and Settings in mobile nav", { tag: ["@critical"] }, async ({
       page,
     }) => {
@@ -99,6 +110,30 @@ test.describe("Navigation", () => {
       await expect(page.getByTestId("bottom-tab-more-settings")).toBeVisible();
       await expect(page.getByTestId("bottom-tab-more-sign-out")).toBeVisible();
       await expect(page.getByTestId("bottom-tab-tenant-info")).toBeVisible();
+    });
+
+    test("admin sees Settings action in More drawer", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, ADMIN_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+      await navigationPage.openMoreDrawer();
+
+      await expect(page.getByTestId("bottom-tab-more-settings")).toBeVisible();
+    });
+  });
+
+  test.describe("Auth pages", () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test("bottom tab bar is hidden on auth pages", { tag: ["@critical"] }, async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await page.goto("/sign-in");
+      await navigationPage.expectBottomBarHidden();
+
+      await page.goto("/sign-up");
+      await navigationPage.expectBottomBarHidden();
     });
   });
 

--- a/ui/e2e/navigation/navigation.spec.ts
+++ b/ui/e2e/navigation/navigation.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+import { login } from "../helpers/auth";
+import { ROUTES } from "../helpers/routes";
+import { NavigationPage } from "./navigation-page";
+
+const OWNER_EMAIL = "admin@enterprise.dev";
+const MEMBER_EMAIL = "member@enterprise.dev";
+const PASSWORD = "password123";
+
+test.describe("Navigation", () => {
+  test.describe("Desktop sidebar", () => {
+    test("owner sees full sidebar navigation", { tag: ["@critical"] }, async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await expect(navigationPage.sidebarLink("Dashboard")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Resources")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Team")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Billing")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Settings")).toBeVisible();
+    });
+
+    test("member sees role-gated sidebar links", { tag: ["@critical"] }, async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, MEMBER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await expect(navigationPage.sidebarLink("Dashboard")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Resources")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Team")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Billing")).toHaveCount(0);
+      await expect(navigationPage.sidebarLink("Settings")).toHaveCount(0);
+    });
+
+    test("sidebar links navigate to target routes", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await navigationPage.sidebarLink("Resources").click();
+      await expect(page).toHaveURL(new RegExp(ROUTES.resources.root));
+
+      await navigationPage.sidebarLink("Team").click();
+      await expect(page).toHaveURL(new RegExp(ROUTES.team));
+
+      await navigationPage.sidebarLink("Billing").click();
+      await expect(page).toHaveURL(new RegExp(ROUTES.billing));
+    });
+  });
+
+  test.describe("Mobile bottom tab bar", () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test("bottom tab bar is visible on mobile", { tag: ["@critical"] }, async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await navigationPage.expectBottomBarVisible();
+      await expect(navigationPage.bottomTabItem("Dashboard")).toBeVisible();
+      await expect(navigationPage.bottomTabItem("Resources")).toBeVisible();
+      await expect(navigationPage.bottomTabItem("Team")).toBeVisible();
+    });
+
+    test("owner sees Billing item in bottom bar", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await expect(navigationPage.bottomTabItem("Billing")).toBeVisible();
+    });
+
+    test("member hides Billing and Settings in mobile nav", { tag: ["@critical"] }, async ({
+      page,
+    }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, MEMBER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await expect(navigationPage.bottomTabItem("Billing")).toHaveCount(0);
+      await navigationPage.openMoreDrawer();
+      await expect(page.getByTestId("bottom-tab-more-settings")).toHaveCount(0);
+    });
+
+    test("More drawer opens and shows owner actions", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+      await navigationPage.openMoreDrawer();
+
+      await expect(page.getByTestId("bottom-tab-more-settings")).toBeVisible();
+      await expect(page.getByTestId("bottom-tab-more-sign-out")).toBeVisible();
+      await expect(page.getByTestId("bottom-tab-tenant-info")).toBeVisible();
+    });
+  });
+
+  test("bottom tab bar is hidden on desktop", { tag: ["@critical"] }, async ({ page }) => {
+    const navigationPage = new NavigationPage(page);
+
+    await login(page, OWNER_EMAIL, PASSWORD);
+    await navigationPage.gotoDashboard();
+
+    await navigationPage.expectBottomBarHidden();
+  });
+});

--- a/ui/e2e/navigation/navigation.spec.ts
+++ b/ui/e2e/navigation/navigation.spec.ts
@@ -6,6 +6,7 @@ import { NavigationPage } from "./navigation-page";
 const OWNER_EMAIL = "admin@enterprise.dev";
 const ADMIN_EMAIL = "admin-role@enterprise.dev";
 const MEMBER_EMAIL = "member@enterprise.dev";
+const GUEST_EMAIL = "guest@enterprise.dev";
 const PASSWORD = "password123";
 
 test.describe("Navigation", () => {
@@ -27,6 +28,19 @@ test.describe("Navigation", () => {
       const navigationPage = new NavigationPage(page);
 
       await login(page, MEMBER_EMAIL, PASSWORD);
+      await navigationPage.gotoDashboard();
+
+      await expect(navigationPage.sidebarLink("Dashboard")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Resources")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Team")).toBeVisible();
+      await expect(navigationPage.sidebarLink("Billing")).toHaveCount(0);
+      await expect(navigationPage.sidebarLink("Settings")).toHaveCount(0);
+    });
+
+    test("guest sees only public sidebar links", async ({ page }) => {
+      const navigationPage = new NavigationPage(page);
+
+      await login(page, GUEST_EMAIL, PASSWORD);
       await navigationPage.gotoDashboard();
 
       await expect(navigationPage.sidebarLink("Dashboard")).toBeVisible();

--- a/ui/e2e/workspace-admin/workspace-admin-page.ts
+++ b/ui/e2e/workspace-admin/workspace-admin-page.ts
@@ -42,6 +42,14 @@ export class WorkspaceAdminPage {
     await expect(this.page.getByTestId("settings-tab-security")).toHaveCount(0);
   }
 
+  async expectSettingsUrlStable(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`^.*${ROUTES.settings}$`));
+  }
+
+  async expectSecondarySettingsSidebarAbsent(): Promise<void> {
+    await expect(this.page.locator("main aside")).toHaveCount(0);
+  }
+
   // ─── Profile section ───────────────────────────────────────────────────────
 
   async fillName(name: string): Promise<void> {

--- a/ui/e2e/workspace-admin/workspace-admin.spec.ts
+++ b/ui/e2e/workspace-admin/workspace-admin.spec.ts
@@ -47,6 +47,24 @@ test.describe("Workspace Admin Settings", () => {
   // ─── Owner flows ────────────────────────────────────────────────────────────
 
   test.describe("Owner flows", () => {
+    test("settings tabs keep stable URL and no secondary sidebar", async ({ page }) => {
+      const settingsPage = new WorkspaceAdminPage(page);
+
+      await login(page, OWNER_EMAIL, PASSWORD);
+      await settingsPage.goto();
+
+      await settingsPage.expectSettingsUrlStable();
+      await settingsPage.expectSecondarySettingsSidebarAbsent();
+
+      await settingsPage.clickTab("regional");
+      await settingsPage.expectTabActive("regional");
+      await settingsPage.expectSettingsUrlStable();
+
+      await settingsPage.clickTab("logo");
+      await settingsPage.expectTabActive("logo");
+      await settingsPage.expectSettingsUrlStable();
+    });
+
     test("owner updates workspace name", { tag: ["@critical"] }, async ({ page }) => {
       const settingsPage = new WorkspaceAdminPage(page);
       const newName = `E2E Workspace ${Date.now()}`;


### PR DESCRIPTION
## What
- Add a mobile-only bottom tab bar with Dashboard, Resources, Team, Billing, and More
- Gate Billing and Settings visibility by role in mobile navigation
- Add a More drawer with Settings, Sign out, and tenant/user context
- Integrate the bottom bar into DashboardShell without regressing desktop layout
- Add desktop/mobile navigation E2E coverage and stabilize the More drawer selector

## Why
Platform UX Foundations requires thumb-friendly mobile navigation and parity with the desktop information architecture.

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## Chain
PR 4/4 → base: `feat/ux-settings-tabs` (PR #96)
Next: verify + archive for `platform-ux-foundations`