### PR TITLE
feat(ui): semantic badge variants, gradient button, form-banner fix [1/4]

### DIFF
--- a/packages/ui/src/components/__tests__/badge.test.ts
+++ b/packages/ui/src/components/__tests__/badge.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Badge — unit tests for semantic variants
+ *
+ * Tests the 5 new semantic variants added in T-01:
+ * success, warning, info, accent, neutral
+ *
+ * We invoke the Badge component function directly and inspect the returned
+ * React element's className — no DOM or rendering context required.
+ *
+ * Scenarios covered per variant:
+ * - Rendered element has the expected background token class
+ * - Rendered element has the expected text token class
+ * - Rendered element has the expected border token class (or border-transparent for neutral)
+ * - No raw color class (no bg-green-*, bg-yellow-*, etc.) present on semantic variants
+ */
+
+import { describe, expect, it } from "vitest";
+import { Badge } from "../badge";
+
+// Helper: extract className string from rendered Badge element
+function getClassName(variant: Parameters<typeof Badge>[0]["variant"]): string {
+  const result = Badge({ variant, children: "Label" });
+  if (!result) throw new Error("Badge returned null");
+  return (result as { props: { className: string } }).props.className ?? "";
+}
+
+describe("Badge — success variant", () => {
+  it("includes bg-success/15 token", () => {
+    expect(getClassName("success")).toContain("bg-success/15");
+  });
+
+  it("includes text-success token", () => {
+    expect(getClassName("success")).toContain("text-success");
+  });
+
+  it("includes border-success/25 token", () => {
+    expect(getClassName("success")).toContain("border-success/25");
+  });
+
+  it("does not use raw green color class", () => {
+    expect(getClassName("success")).not.toMatch(/bg-green-\d+/);
+    expect(getClassName("success")).not.toMatch(/text-green-\d+/);
+  });
+});
+
+describe("Badge — warning variant", () => {
+  it("includes bg-warning/15 token", () => {
+    expect(getClassName("warning")).toContain("bg-warning/15");
+  });
+
+  it("includes text-warning token", () => {
+    expect(getClassName("warning")).toContain("text-warning");
+  });
+
+  it("includes border-warning/25 token", () => {
+    expect(getClassName("warning")).toContain("border-warning/25");
+  });
+
+  it("does not use raw yellow/amber color class", () => {
+    expect(getClassName("warning")).not.toMatch(/bg-yellow-\d+/);
+    expect(getClassName("warning")).not.toMatch(/bg-amber-\d+/);
+  });
+});
+
+describe("Badge — info variant", () => {
+  it("includes bg-info/15 token", () => {
+    expect(getClassName("info")).toContain("bg-info/15");
+  });
+
+  it("includes text-info token", () => {
+    expect(getClassName("info")).toContain("text-info");
+  });
+
+  it("includes border-info/25 token", () => {
+    expect(getClassName("info")).toContain("border-info/25");
+  });
+
+  it("does not use raw blue/cyan color class", () => {
+    expect(getClassName("info")).not.toMatch(/bg-blue-\d+/);
+    expect(getClassName("info")).not.toMatch(/bg-cyan-\d+/);
+  });
+});
+
+describe("Badge — accent variant", () => {
+  it("includes bg-secondary/15 token", () => {
+    expect(getClassName("accent")).toContain("bg-secondary/15");
+  });
+
+  it("includes text-secondary token", () => {
+    expect(getClassName("accent")).toContain("text-secondary");
+  });
+
+  it("includes border-secondary/25 token", () => {
+    expect(getClassName("accent")).toContain("border-secondary/25");
+  });
+});
+
+describe("Badge — neutral variant", () => {
+  it("includes bg-accent token", () => {
+    expect(getClassName("neutral")).toContain("bg-accent");
+  });
+
+  it("includes text-muted-foreground token", () => {
+    expect(getClassName("neutral")).toContain("text-muted-foreground");
+  });
+
+  it("includes border-transparent (no visible border)", () => {
+    expect(getClassName("neutral")).toContain("border-transparent");
+  });
+
+  it("does not use any raw color class", () => {
+    expect(getClassName("neutral")).not.toMatch(/bg-gray-\d+/);
+    expect(getClassName("neutral")).not.toMatch(/bg-slate-\d+/);
+  });
+});

--- a/packages/ui/src/components/__tests__/button.test.ts
+++ b/packages/ui/src/components/__tests__/button.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Button — unit tests for gradient and destructive-ghost variants
+ *
+ * Tests the 2 new variants added in T-03:
+ * gradient, destructive-ghost
+ *
+ * We invoke the Button component function directly and inspect the returned
+ * React element's className — no DOM or rendering context required.
+ *
+ * Scenarios covered:
+ * - gradient: bg-gradient-to-r, from-primary, to-secondary, text-white
+ * - destructive-ghost: text-destructive, hover:bg-destructive/10
+ */
+
+import { describe, expect, it } from "vitest";
+import { Button } from "../button";
+
+// Helper: extract className string from rendered Button element
+function getClassName(variant: Parameters<typeof Button>[0]["variant"]): string {
+  const result = Button({ variant, children: "Label" });
+  if (!result) throw new Error("Button returned null");
+  return (result as { props: { className: string } }).props.className ?? "";
+}
+
+describe("Button — gradient variant", () => {
+  it("includes bg-gradient-to-r class", () => {
+    expect(getClassName("gradient")).toContain("bg-gradient-to-r");
+  });
+
+  it("includes from-primary class", () => {
+    expect(getClassName("gradient")).toContain("from-primary");
+  });
+
+  it("includes to-secondary class", () => {
+    expect(getClassName("gradient")).toContain("to-secondary");
+  });
+
+  it("includes text-white class", () => {
+    expect(getClassName("gradient")).toContain("text-white");
+  });
+
+  it("includes hover:opacity-90 for hover effect", () => {
+    expect(getClassName("gradient")).toContain("hover:opacity-90");
+  });
+});
+
+describe("Button — destructive-ghost variant", () => {
+  it("includes text-destructive class", () => {
+    expect(getClassName("destructive-ghost")).toContain("text-destructive");
+  });
+
+  it("includes hover:bg-destructive/10 class", () => {
+    expect(getClassName("destructive-ghost")).toContain("hover:bg-destructive/10");
+  });
+
+  it("does not include a solid bg-destructive (non-hover) background class", () => {
+    const cls = getClassName("destructive-ghost");
+    // The variant should not have solid `bg-destructive` without a modifier prefix
+    // (hover:bg-destructive/10 is allowed, but bare bg-destructive is not)
+    const classes = cls.split(" ");
+    expect(classes).not.toContain("bg-destructive");
+  });
+});

--- a/packages/ui/src/components/__tests__/form-banner.test.ts
+++ b/packages/ui/src/components/__tests__/form-banner.test.ts
@@ -61,13 +61,13 @@ describe("FormBanner", () => {
     expect(result).toBeNull();
   });
 
-  it("renders success banner (green classes) when state.success && successMessage provided", () => {
+  it("renders success banner (semantic success token) when state.success && successMessage provided", () => {
     const state: ActionResult = { success: true, data: undefined };
     const result = FormBanner({ state, successMessage: "Saved successfully." });
     expect(result).not.toBeNull();
     const className: string = (result as { props: { className: string } }).props.className;
-    expect(className).toContain("bg-green-500");
-    expect(className).toContain("text-green-500");
+    expect(className).toContain("bg-success/10");
+    expect(className).toContain("text-success");
   });
 
   it("success banner has no role='alert'", () => {

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -16,6 +16,11 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
+        success: "bg-success/15 text-success border-success/25 [a&]:hover:bg-success/25",
+        warning: "bg-warning/15 text-warning border-warning/25 [a&]:hover:bg-warning/25",
+        info: "bg-info/15 text-info border-info/25 [a&]:hover:bg-info/25",
+        accent: "bg-secondary/15 text-secondary border-secondary/25 [a&]:hover:bg-secondary/25",
+        neutral: "bg-accent text-muted-foreground border-transparent [a&]:hover:bg-accent/80",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -16,6 +16,10 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        /** One gradient CTA per page max. Use for primary creation-flow navigation only. */
+        gradient:
+          "bg-gradient-to-r from-primary to-secondary text-white shadow-sm hover:opacity-90 focus-visible:ring-primary/20",
+        "destructive-ghost": "text-destructive hover:bg-destructive/10 hover:text-destructive",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/packages/ui/src/components/form-banner.tsx
+++ b/packages/ui/src/components/form-banner.tsx
@@ -15,7 +15,7 @@ export function FormBanner<T>({ state, successMessage, className }: FormBannerPr
   // Success
   if (state.success && successMessage) {
     return (
-      <p className={cn("rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-500", className)}>
+      <p className={cn("rounded-md bg-success/10 px-3 py-2 text-sm text-success", className)}>
         {successMessage}
       </p>
     );


### PR DESCRIPTION
## Part 1/4 of Design System Consistency

### Changes
- Add 5 semantic Badge CVA variants: `success`, `warning`, `info`, `accent`, `neutral`
- Add Button `gradient` and `destructive-ghost` CVA variants
- Fix FormBanner success variant: `bg-green-500` → `bg-success` token

### Testing
- 27 new unit tests (19 badge + 8 button)
- All 164 UI tests pass

### PR Chain
- **PR1 (this)**: Primitives → Badge + Button + FormBanner
- PR2: Structural → 6 new @enterprise/ui components
- PR3: Migrations → 8 pages + feature components
- PR4: Route coverage → loading.tsx + error.tsx + E2E