### PR TITLE
docs(notifications): add implementation-ready PRD and RFC

### DIFF
--- a/docs/features/notifications/prd.md
+++ b/docs/features/notifications/prd.md
@@ -1,76 +1,458 @@
 ---
 title: "Notifications PRD"
-description: "Defines product requirements for in-app and outbound notification workflows."
+description: "Defines product requirements for tenant-scoped in-app notifications, email delivery for critical events, and user notification preferences."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-05-29"
 ---
 
 # Notifications PRD
 
 ## Purpose
 
-Define roadmap-level requirements for notifying users about key tenant events while avoiding noisy or low-value messaging.
+Define implementation-ready product requirements for tenant-scoped notifications in a multi-tenant SaaS template, including an in-app notification center, email delivery for critical events, user-configurable preferences, and a service-level notification dispatch API.
 
 ## Scope
 
-- Included: in-app notification center and foundational outbound events.
-- Excluded: full campaign automation, advanced segmentation, and marketing messaging.
+- Included: in-app notification center, email delivery for critical events, per-user preference controls, event-to-notification catalog, notification bell with unread badge, Supabase Realtime for badge updates, and traceability.
+- Excluded: SMS or push channels, workflow builder and conditional rules engine, multi-step digest customization, campaign automation, advanced segmentation, marketing messaging, webhook delivery failure notifications (follow-up with webhooks feature).
 
 ---
 
 ## Problem
 
-Users miss important events (invites, role changes, billing issues) when the product has no consistent notification model.
+Users miss important events (invitations, role changes, billing issues) because the platform has no consistent notification model. Critical billing alerts go unseen, team changes happen without awareness, and there is no way for users to control notification volume.
 
 ## Users and stakeholders
 
 | Role | Need |
 |------|------|
-| Tenant members | Timely awareness of relevant actions |
-| Tenant admins | Visibility into operational or security events |
-| Product team | Reusable event-to-notification framework |
+| Tenant members | Timely awareness of team and billing events relevant to their role |
+| Tenant admins | Visibility into operational events and team changes |
+| Tenant owners | Immediate alerts for critical billing issues and subscription changes |
+| Product team | Reusable notification dispatch API that other features can hook into |
+| Template adopter | A notification foundation they can extend with custom event types |
 
 ## Goals
 
-- Surface important events in-app with clear relevance.
-- Support baseline outbound delivery for critical workflows.
-- Provide user-level preference controls for non-critical signals.
+- Surface important events in-app with clear relevance and read/unread state.
+- Deliver critical billing and access events via email regardless of user preferences.
+- Provide per-user, per-category preference controls for non-critical notifications.
+- Expose a service-level `createNotification()` API that other services call to dispatch notifications.
+- Keep the notification bell updated in real-time via Supabase Realtime.
+
+---
+
+## Permission matrix
+
+| Action | Owner | Admin | Member | Guest |
+|--------|-------|-------|--------|-------|
+| View own notifications | Yes | Yes | Yes | No |
+| View unread badge in header | Yes | Yes | Yes | No |
+| Mark own notification as read | Yes | Yes | Yes | No |
+| Mark all own notifications as read | Yes | Yes | Yes | No |
+| Configure notification preferences | Yes | Yes | Yes | No |
+| Access /notifications page | Yes | Yes | Yes | No (redirect) |
+| Access /settings/notifications | Yes | Yes | Yes | No (redirect) |
+
+> **Important**: Guests have no notification access in MVP. All notification operations are scoped to the current tenant — users only see notifications for their active tenant.
 
 ---
 
 ## MVP scope
 
-- In-app notification feed with read/unread state.
-- Event types: invitation, role change, subscription issue, webhook delivery failure.
-- Basic email delivery for critical events.
-- Per-user opt-out for non-critical categories.
+### Notification model and lifecycle
 
-## Out of scope
+- Each notification represents a single event dispatched to a single user.
+- Notifications are tenant-scoped and user-scoped — a user sees only notifications for their current tenant.
+- Notifications have: id, tenant, recipient user, type, category, title, body, metadata, read state, source event reference, and creation timestamp.
+- Notifications are immutable after creation — only the `is_read` flag and `read_at` timestamp change.
+- Notification retention: 90 days. No automatic cleanup in MVP (configurable cleanup is a follow-up).
 
-- SMS or push channels.
+### Channel strategy
+
+Notifications are delivered via two channels: in-app (always active) and email (for critical events).
+
+| Event | Type | Category | In-app | Email | Opt-out allowed |
+|-------|------|----------|--------|-------|-----------------|
+| Team member invited | `team_invited` | `team` | Yes | Yes (always) | No — invitation delivery is essential |
+| Invitation accepted | `team_invitation_accepted` | `team` | Yes | No | Yes |
+| Member role changed | `team_role_changed` | `team` | Yes | No | Yes |
+| Member removed | `team_removed` | `team` | No (loses access) | Yes (always) | No — access revocation notice |
+| Subscription past due | `billing_past_due` | `billing` | Yes | Yes (always) | No — critical financial alert |
+| Plan upgraded | `billing_plan_upgraded` | `billing` | Yes | No | Yes |
+| Plan downgraded | `billing_plan_downgraded` | `billing` | Yes | No | Yes |
+| Subscription canceled | `billing_canceled` | `billing` | Yes | Yes (always) | No — critical financial alert |
+| Subscription activated | `billing_activated` | `billing` | Yes | No | Yes |
+
+### Recipient determination
+
+| Event | Recipients |
+|-------|-----------|
+| `team_invited` | The invited user (by email) |
+| `team_invitation_accepted` | The user who sent the invitation |
+| `team_role_changed` | The affected member |
+| `team_removed` | The removed member (email only) |
+| `billing_past_due` | Owner + all admins |
+| `billing_plan_upgraded` | Owner |
+| `billing_plan_downgraded` | Owner |
+| `billing_canceled` | Owner + all admins |
+| `billing_activated` | Owner |
+
+### Preference model
+
+- Per-user, per-tenant, per-category preference rows.
+- Categories: `team`, `billing`, `system` (system reserved for future use).
+- Each preference row controls `in_app_enabled` and `email_enabled` independently.
+- Default behavior (no preference row exists): both channels enabled.
+- Critical notifications bypass preferences entirely — always delivered.
+- Preferences UI lives at `/settings/notifications`.
+
+### Notification center
+
+- Accessible at `/notifications` from the header bell icon.
+- Full-page list with pagination (not a dropdown in MVP).
+- Each notification shows: icon (by category), title, body, relative timestamp, read/unread indicator.
+- Click on a notification marks it as read.
+- "Mark all as read" bulk action.
+- Filter by category (team, billing) and read state (all, unread).
+
+### Real-time badge updates
+
+- The notification bell in the header shows an unread count badge.
+- Badge updates via Supabase Realtime subscription on the `notifications` table, filtered by `user_id`.
+- When a new notification is inserted, the badge count increments without page reload.
+- The full notification list page uses server-side pagination — it does NOT use Realtime for the list (follow-up).
+
+### Out of scope (MVP)
+
+- SMS or push notification channels.
 - Workflow builder and conditional rules engine.
-- Multi-step digest customization.
+- Digest emails (daily/weekly summary).
+- Notification grouping or batching.
+- Rich notification actions (inline buttons to accept invite, etc.).
+- Event-driven architecture (message queue, pub/sub) — direct service calls in MVP.
+- Webhook delivery failure notifications (comes with webhooks feature).
+- System category notifications (reserved for future features).
+- Automatic cleanup/retention enforcement.
+
+---
+
+## UX specification
+
+### Routes
+
+- `/notifications` — notification center (full page)
+- `/settings/notifications` — notification preferences
+
+### Notification bell (global header component)
+
+The notification bell is a persistent icon in the application header, visible on all protected pages.
+
+- Shows a red dot or numeric badge when unread count > 0.
+- Badge shows count up to 99; shows "99+" for higher counts.
+- Clicking the bell navigates to `/notifications`.
+- Badge updates in real-time via Supabase Realtime.
+
+### Notification center page layout
+
+```
++------------------------------------------------------------------+
+| Header: "Notifications" + "Stay updated on team and billing"     |
+|                                              [Mark all as read]  |
++------------------------------------------------------------------+
+| Filters row:                                                     |
+|   [All] [Unread]  |  Category: [All] [Team] [Billing]           |
++------------------------------------------------------------------+
+| Notification list:                                               |
+|   +------------------------------------------------------------+ |
+|   | * [Team icon] You were invited to join Acme Corp           | |
+|   |    John Doe invited you as a member - 2 hours ago          | |
+|   +------------------------------------------------------------+ |
+|   |    [Billing icon] Your subscription is past due            | |
+|   |    Update your payment method before Jun 15 - 1 day ago    | |
+|   +------------------------------------------------------------+ |
+|   |    [Team icon] Your role was changed to admin              | |
+|   |    Jane Smith updated your role - 3 days ago               | |
+|   +------------------------------------------------------------+ |
+|                                                                  |
+| Pagination: [<- Previous] Page 1 of 3 [Next ->]                 |
++------------------------------------------------------------------+
+```
+
+### Notification preferences page layout
+
+```
++------------------------------------------------------------------+
+| Header: "Notification preferences"                               |
+| "Choose which notifications you receive"                         |
++------------------------------------------------------------------+
+| Team notifications                                               |
+|   Invitation accepted        [In-app: on] [Email: on]           |
+|   Role changes               [In-app: on] [Email: on]           |
+|   Note: Invitation and removal notices are always sent           |
++------------------------------------------------------------------+
+| Billing notifications                                            |
+|   Plan upgrades              [In-app: on] [Email: on]           |
+|   Plan downgrades            [In-app: on] [Email: on]           |
+|   Subscription activated     [In-app: on] [Email: on]           |
+|   Note: Past due and cancellation alerts are always sent         |
++------------------------------------------------------------------+
+|                                                   [Save changes] |
++------------------------------------------------------------------+
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **Notification bell** | Persistent header icon. Shows unread count badge (red dot for 1-9, numeric for 10+). Navigates to `/notifications` on click. Updates via Realtime subscription. |
+| **Notification list** | Paginated list of notifications. Unread items have a blue dot indicator and slightly different background. Clicking an item marks it as read. Supports category and read-state filters. |
+| **Notification item** | Displays category icon, title, body (truncated to 2 lines), relative timestamp. Unread indicator (blue dot) on left edge. |
+| **Mark all as read button** | Bulk action in header. Disabled when no unread notifications exist. Shows confirmation count: "Mark 5 as read". |
+| **Filter bar** | Toggle between All/Unread. Category dropdown: All, Team, Billing. Filters are URL query params for shareable state. |
+| **Preferences form** | Toggle switches per category per channel. Critical events shown as always-on (disabled toggles with explanation). Save button submits all changes at once. |
+| **Empty state** | "You're all caught up" message when no notifications match the current filter. |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Loading** | Skeleton rows in notification list, skeleton toggle in preferences |
+| **Empty (no notifications ever)** | "No notifications yet" with illustration. Subtitle: "We'll let you know when something happens." |
+| **Empty (all read, unread filter active)** | "You're all caught up" message |
+| **Unread notifications present** | Blue dot on unread items, badge on bell |
+| **All notifications read** | No badge on bell, no blue dots |
+| **Error loading notifications** | "Could not load notifications. Try again." with retry button |
+| **Preferences saved** | Toast: "Notification preferences updated" |
+| **Guest access** | Redirect to `/dashboard` — guests have no notification access |
+
+### Role-specific visibility
+
+| Element | Owner | Admin | Member | Guest |
+|---------|-------|-------|--------|-------|
+| Notification bell + badge | Yes | Yes | Yes | No |
+| `/notifications` page | Yes | Yes | Yes | No (redirect) |
+| `/settings/notifications` | Yes | Yes | Yes | No (redirect) |
+| Mark as read actions | Yes | Yes | Yes | No |
+| Preference toggles | Yes | Yes | Yes | No |
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: User receives in-app notification for team invitation
+
+**As** a registered user, **I want** to receive an in-app notification when I am invited to a tenant so I can respond promptly.
+
+Acceptance criteria:
+1. When an admin invites a user by email, a notification of type `team_invited` is created for the invited user.
+2. The notification appears in the user's notification center immediately.
+3. The unread badge on the bell increments without page reload (Realtime).
+4. The notification title says "You were invited to join {tenant_name}".
+5. The notification body includes the inviter's name and assigned role.
+6. An invitation email is also sent (always — not affected by preferences).
+
+### US-2: User views notification center
+
+**As** a tenant member, **I want** to view all my notifications in one place so I can stay informed about team and billing activity.
+
+Acceptance criteria:
+1. Navigating to `/notifications` displays a paginated list of the user's notifications for the current tenant.
+2. Unread notifications show a blue dot indicator.
+3. Notifications are ordered by creation date, newest first.
+4. Each notification displays category icon, title, body, and relative timestamp.
+5. Default page size is 20 notifications.
+
+### US-3: User marks a notification as read
+
+**As** a tenant member, **I want** to mark a notification as read so I can track which events I have already acknowledged.
+
+Acceptance criteria:
+1. Clicking on an unread notification marks it as read.
+2. The blue dot indicator disappears.
+3. The unread badge count in the header decrements.
+4. A `notification.marked_read` audit event is NOT logged (read actions are too frequent for audit).
+
+### US-4: User marks all notifications as read
+
+**As** a tenant member, **I want** to mark all my notifications as read so I can clear my notification backlog.
+
+Acceptance criteria:
+1. Clicking "Mark all as read" marks all unread notifications for the current tenant as read.
+2. The header badge disappears (count becomes 0).
+3. All blue dot indicators disappear in the list.
+4. The button is disabled when no unread notifications exist.
+
+### US-5: User receives email for critical billing event
+
+**As** a tenant owner, **I want** to receive an email when my subscription enters past_due status so I can resolve billing issues even if I am not using the app.
+
+Acceptance criteria:
+1. When the billing system transitions a subscription to `past_due`, email notifications are sent to the owner and all admins.
+2. The email includes the tenant name, grace period end date, and a link to the billing page.
+3. This email is sent regardless of the user's notification preferences (critical, no opt-out).
+4. A `notification.email_sent` audit event is logged.
+
+### US-6: User configures notification preferences
+
+**As** a tenant member, **I want** to control which non-critical notifications I receive so I am not overwhelmed by low-priority alerts.
+
+Acceptance criteria:
+1. Navigating to `/settings/notifications` shows toggle switches per category (team, billing).
+2. Each category has independent toggles for in-app and email channels.
+3. Critical events (billing.past_due, billing.canceled, team.invited, team.removed) are shown as always-on with a disabled toggle and explanation text.
+4. Saving preferences updates the user's notification preferences for the current tenant.
+5. Preferences take effect immediately — the next notification dispatch checks updated preferences.
+6. A toast confirms "Notification preferences updated" on save.
+
+### US-7: System generates notification on billing event
+
+**As** the system, **I want** to create notifications when billing events occur so affected users are informed.
+
+Acceptance criteria:
+1. When `billing-service.changePlan()` succeeds, a `billing_plan_upgraded` or `billing_plan_downgraded` notification is created for the owner.
+2. When `billing-service.cancelSubscription()` succeeds, a `billing_canceled` notification is created for the owner and all admins.
+3. When `billing-service.processWebhookEvent()` transitions to `past_due`, a `billing_past_due` notification is created for the owner and all admins.
+4. When subscription activates, a `billing_activated` notification is created for the owner.
+5. For critical events (past_due, canceled), email is also dispatched regardless of preferences.
+
+### US-8: System generates notification on team event
+
+**As** the system, **I want** to create notifications when team membership changes so affected users are informed.
+
+Acceptance criteria:
+1. When `tenant-team-service.inviteTenantMember()` succeeds, a `team_invited` notification is created for the invited user.
+2. When `tenant-team-service.acceptTenantInvitation()` succeeds, a `team_invitation_accepted` notification is created for the inviter.
+3. When `tenant-team-service.changeTenantMemberRole()` succeeds, a `team_role_changed` notification is created for the affected member.
+4. When `tenant-team-service.removeTenantMember()` succeeds, a `team_removed` email notification is sent to the removed member (no in-app — they lose access).
+
+### US-9: Guest cannot access notifications
+
+**As** the system, **I want** to prevent guests from accessing notifications so the permission model is consistent.
+
+Acceptance criteria:
+1. Guests do not see the notification bell in the header.
+2. Navigating to `/notifications` as a guest redirects to `/dashboard`.
+3. Navigating to `/settings/notifications` as a guest redirects to `/dashboard`.
+4. Notification service does not create notifications for users with the `guest` role.
 
 ---
 
 ## Success metrics
 
-- Read rate for critical notifications.
-- Median time to acknowledge high-priority events.
-- Reduction in missed-action support incidents.
+- Read rate for critical notifications (billing past_due, canceled): target > 95% within 24 hours.
+- Median time from event to notification read: target < 4 hours for in-app.
+- Notification preference opt-out rate: target < 30% of users disable any category (healthy signal balance).
+- Email delivery success rate for critical events: target > 99%.
+- Reduction in missed-action support incidents (billing past_due not noticed): target > 60% reduction.
 
 ## Risks
 
-- Over-notification can reduce trust in the channel.
-- Poor event classification can hide critical alerts.
-- Delivery failures can go unnoticed without observability.
-
-## Open questions
-
-- Should unread badges be global or tenant-scoped in MVP?
-- Which events are always non-optional?
-- How long should notification history be retained by default?
+| Risk | Mitigation |
+|------|------------|
+| Over-notification reduces trust in the channel | Category preferences allow users to opt out of non-critical notifications |
+| Poor event classification hides critical alerts | Critical events (past_due, canceled, invited, removed) bypass preferences entirely |
+| Delivery failures go unnoticed | Email adapter failures logged to audit; Sentry captures delivery errors |
+| Realtime subscription exhausts Supabase connections | Badge subscription uses a single channel per user; unsubscribe on logout |
+| High notification volume degrades page performance | Server-side pagination with limit/offset; no client-side notification accumulation |
+| Notification table grows unbounded | 90-day retention policy defined; cleanup job is a follow-up |
+| Stale badge count after preference change | Badge count re-fetched after preference save |
 
 ---
 
-*Last updated: 2026-05-07*
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `notification.created` | Service creates a new notification | `{ type, category, recipientUserId, sourceEvent, tenantId }` |
+| `notification.email_sent` | Email adapter successfully sends notification email | `{ type, recipientEmail, tenantId }` |
+| `notification.email_failed` | Email adapter fails to send | `{ type, recipientEmail, errorCode, tenantId }` |
+| `notification.preferences_updated` | User updates notification preferences | `{ userId, tenantId, changes }` |
+
+> **Note**: `notification.marked_read` and `notification.marked_all_read` are NOT audited — read actions are too frequent and low-value for audit.
+
+### Sentry
+
+- Area: `notifications`
+- Instrumented actions: `listNotificationsAction`, `getUnreadCountAction`, `markAsReadAction`, `markAllAsReadAction`, `getPreferencesAction`, `updatePreferencesAction`
+- Captured errors: DB failures, email delivery failures, Realtime subscription errors
+- PII exclusions: notification body content, email addresses, user names
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`, `notificationType`, `category`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Notification | unread | `team_invited` — "You were invited to join Demo Workspace" for member user |
+| Notification | unread | `billing_past_due` — "Your subscription is past due" for owner user |
+| Notification | read | `billing_plan_upgraded` — "Plan upgraded to Pro" for owner user, read 2 days ago |
+| Notification | read | `team_invitation_accepted` — "John accepted your invitation" for admin user, read 5 days ago |
+| Notification | unread | `team_role_changed` — "Your role was changed to admin" for member user |
+| Preference | default | Owner: all categories enabled (default) |
+| Preference | customized | Member: billing email disabled |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| User sees notification bell with unread count | Member | Bell shows badge with correct unread count |
+| User opens notification center | Member | Paginated list of notifications loads |
+| User marks single notification as read | Member | Blue dot disappears, badge decrements |
+| User marks all as read | Member | All dots disappear, badge disappears |
+| User filters by category | Member | Only notifications of selected category shown |
+| User filters by unread | Member | Only unread notifications shown |
+| User configures preferences | Member | Toggle switches save correctly |
+| Critical notification always shows | Owner | Past due notification appears even with billing disabled |
+| Guest cannot access notifications | Guest | Redirected to /dashboard, no bell visible |
+| Owner sees billing notifications | Owner | Past due and canceled notifications present |
+| Empty state renders | Member (clean user) | "No notifications yet" message displayed |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Email delivery | `NotificationEmailPort` | Console adapter — logs email content | Resend adapter | `RESEND_API_KEY` |
+
+### Environment variables
+
+| Variable | Required | Scope | Fallback behavior |
+|----------|----------|-------|-------------------|
+| `RESEND_API_KEY` | Optional | Server | Console adapter logs email content locally |
+
+### Production readiness
+
+- [ ] All audit events verified in `audit_log` table for notification creation and email delivery
+- [ ] Sentry area `notifications` registered and all Server Actions instrumented
+- [ ] `NotificationEmailPort` interface documented with adapter contract
+- [ ] Unit tests pass for `notification-service.ts` (all service functions)
+- [ ] E2E tests pass for all defined flows
+- [ ] RLS policies on `notifications` and `notification_preferences` tables verified (no cross-tenant or cross-user leaks)
+- [ ] Seed data committed and `supabase db reset` runs cleanly
+- [ ] Realtime subscription for badge count verified (increments on insert)
+- [ ] Critical events bypass preference check verified
+- [ ] `/notifications` and `/settings/notifications` routes added to `ui/lib/routes.ts`
+- [ ] Notification bell component integrated in global header
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Notification center as full page or dropdown? | Full page at `/notifications` | Better for pagination, filtering, and mobile responsiveness. Dropdown is a follow-up UX enhancement. |
+| Direct service calls or event-driven dispatch? | Direct service calls in MVP | Simpler implementation, no message queue dependency. Event-driven architecture is a follow-up. |
+| Notification metadata as JSONB or text? | JSON string (`text`) | Consistent with billing pattern (plans.features, plans.limits). Parsed at service layer. |
+| Guest notification access? | No access in MVP | Consistent with limited guest permission model across the platform. |
+| Real-time for full feed or badge only? | Badge only via Supabase Realtime | Full feed realtime adds complexity; server-side pagination is sufficient for MVP. |
+| Critical event opt-out? | No opt-out for billing.past_due, billing.canceled, team.invited, team.removed | These are essential operational and financial alerts that users must receive. |
+| Notification retention? | 90 days, no auto-cleanup in MVP | Defines expectation; cleanup cron job is a follow-up. |
+| Per-tenant or global preferences? | Per-tenant | User may want different preferences for different workspaces. Consistent with multi-tenant model. |
+| Notification grouping? | No grouping in MVP | Individual notifications are simpler and sufficient for current event volume. |
+| Email template per type or generic? | Generic notification email template in MVP | Reduces template maintenance; per-type templates are a follow-up for better UX. |
+| Unread badge scope? | Tenant-scoped | User sees badge count only for their current tenant. Consistent with all other tenant-scoped data. |
+
+---
+
+*Last updated: 2026-05-29*

--- a/docs/features/notifications/rfc.md
+++ b/docs/features/notifications/rfc.md
@@ -1,0 +1,771 @@
+---
+title: "Notifications RFC"
+description: "Defines the implementation-ready technical architecture for tenant-scoped notifications, email delivery, user preferences, and real-time badge updates."
+owner: "Engineering"
+lastUpdated: "2026-05-29"
+---
+
+# Notifications RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for tenant-scoped notifications aligned with the service layer, contracts, adapter, and traceability conventions of the Enterprise Platform.
+
+## Scope
+
+- Included: data model, Row-Level Security (RLS) policies, Zod contracts, service APIs, notification dispatch integration, email adapter, Supabase Realtime for badge updates, Server Actions, UI routes, seed data, and testing strategy.
+- Excluded: SMS/push channels, event-driven architecture (message queue, pub/sub), digest emails, notification grouping, rich notification actions, webhook delivery failure notifications.
+
+---
+
+## Summary
+
+Implement notifications as a tenant-bounded, user-scoped module using Drizzle schema for `notifications` and `notification_preferences` tables with RLS policies, Zod contracts in `@enterprise/contracts` for all inputs and outputs, function-based services in `@enterprise/core/src/services/notification-service.ts`, a port/adapter pattern for email delivery (Resend in production, console in development), thin Server Actions in `ui/features/notifications/actions.ts`, and Supabase Realtime for live unread badge updates. Other services (billing, team) call `createNotification()` directly after their mutations — no event bus in MVP. All mutations are auditable via `AuditService.log()` and traceable via Sentry instrumentation under the `notifications` area.
+
+## Technical objectives
+
+- Notifications are always tenant-scoped and user-scoped — no cross-tenant or cross-user data leaks.
+- Critical events (billing past_due, billing canceled, team invited, team removed) bypass user preferences and always deliver.
+- Local development works without Resend credentials via `ConsoleNotificationEmailAdapter`.
+- Notification dispatch is synchronous and direct — other services call `createNotification()` without a message queue.
+- Unread badge count updates in real-time via Supabase Realtime subscription without page reload.
+
+---
+
+## Data model
+
+Location: `packages/db/src/schema/notifications.ts` — **new file**
+
+### New enums
+
+```typescript
+export const notificationTypeEnum = pgEnum("notification_type", [
+  "team_invited",
+  "team_invitation_accepted",
+  "team_role_changed",
+  "team_removed",
+  "billing_past_due",
+  "billing_plan_upgraded",
+  "billing_plan_downgraded",
+  "billing_canceled",
+  "billing_activated",
+]);
+
+export const notificationCategoryEnum = pgEnum("notification_category", [
+  "team",
+  "billing",
+  "system",
+]);
+```
+
+### `notifications` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `user_id` | `uuid` | NOT NULL (recipient — references `auth.users.id`) |
+| `type` | `notification_type` enum | NOT NULL |
+| `category` | `notification_category` enum | NOT NULL |
+| `title` | `text` | NOT NULL |
+| `body` | `text` | NOT NULL |
+| `metadata` | `text` | NULLABLE (JSON string — source event details) |
+| `is_read` | `boolean` | NOT NULL, default `false` |
+| `read_at` | `timestamptz` | NULLABLE |
+| `source_event` | `text` | NULLABLE (original event name, e.g. `'tenant_member.invited'`) |
+| `source_entity_id` | `uuid` | NULLABLE (ID of the entity that triggered notification) |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### `notification_preferences` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `user_id` | `uuid` | NOT NULL (references `auth.users.id`) |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `category` | `notification_category` enum | NOT NULL |
+| `in_app_enabled` | `boolean` | NOT NULL, default `true` |
+| `email_enabled` | `boolean` | NOT NULL, default `true` |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `notifications_user_tenant_idx` | `user_id`, `tenant_id` | User+tenant scoped queries |
+| `notifications_user_unread_idx` | `user_id`, `tenant_id`, `is_read` | Unread count queries |
+| `notifications_category_idx` | `category` | Category filtering |
+| `notifications_created_at_idx` | `created_at` | Pagination ordering |
+| `notifications_source_event_idx` | `source_event` | Source event lookup |
+| `preferences_user_tenant_idx` | `user_id`, `tenant_id` | User preferences lookup |
+
+### Constraints
+
+- UNIQUE on `notification_preferences(user_id, tenant_id, category)` — one preference row per user per tenant per category.
+- `notifications.metadata` stores JSON as `text`; parsing happens at the service layer.
+- No foreign key from `notifications.user_id` to `profiles` — notifications may be created for users who were subsequently removed.
+
+### Type exports
+
+```typescript
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+
+export type NotificationPreference = typeof notificationPreferences.$inferSelect;
+export type NewNotificationPreference = typeof notificationPreferences.$inferInsert;
+```
+
+---
+
+## RLS policies
+
+### `notifications`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `notifications_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `notifications_insert` | INSERT | `service_role` | Service role only — notifications created by services |
+| `notifications_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim (mark as read only) |
+| `notifications_delete` | DELETE | — | No deletes — retention cleanup is a follow-up |
+
+### `notification_preferences`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `preferences_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_insert` | INSERT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_delete` | DELETE | — | No deletes — preferences are updated, not removed |
+
+> **Note**: Notification creation uses the **admin client** (`service_role`) because notifications are generated by service-layer code (billing, team services) that may not have the recipient's JWT context. The admin client is used ONLY for creating notifications, never for reading or updating.
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/notifications.ts`
+
+### Output schemas
+
+```typescript
+import { z } from "zod";
+
+// Notification display shape
+export const notificationSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum([
+    "team_invited",
+    "team_invitation_accepted",
+    "team_role_changed",
+    "team_removed",
+    "billing_past_due",
+    "billing_plan_upgraded",
+    "billing_plan_downgraded",
+    "billing_canceled",
+    "billing_activated",
+  ]),
+  category: z.enum(["team", "billing", "system"]),
+  title: z.string(),
+  body: z.string(),
+  metadata: z.string().nullable(),
+  isRead: z.boolean(),
+  readAt: z.string().datetime().nullable(),
+  sourceEvent: z.string().nullable(),
+  sourceEntityId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+// Notification preference display shape
+export const notificationPreferenceSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  category: z.enum(["team", "billing", "system"]),
+  inAppEnabled: z.boolean(),
+  emailEnabled: z.boolean(),
+});
+
+// Unread count shape
+export const unreadCountSchema = z.object({
+  count: z.number().int().min(0),
+});
+```
+
+### Input schemas
+
+```typescript
+// Mark single notification as read
+export const markAsReadSchema = z.object({
+  notificationId: z.string().uuid(),
+});
+
+// Mark all as read (no input — uses auth context)
+export const markAllAsReadSchema = z.object({});
+
+// Update preferences
+export const updatePreferencesSchema = z.object({
+  preferences: z.array(
+    z.object({
+      category: z.enum(["team", "billing", "system"]),
+      inAppEnabled: z.boolean(),
+      emailEnabled: z.boolean(),
+    }),
+  ),
+});
+
+// List notifications query
+export const notificationsQuerySchema = z.object({
+  category: z.enum(["team", "billing", "system"]).optional(),
+  isRead: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+// Create notification (internal — used by services, not exposed as Server Action)
+export const createNotificationSchema = z.object({
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum([
+    "team_invited",
+    "team_invitation_accepted",
+    "team_role_changed",
+    "team_removed",
+    "billing_past_due",
+    "billing_plan_upgraded",
+    "billing_plan_downgraded",
+    "billing_canceled",
+    "billing_activated",
+  ]),
+  category: z.enum(["team", "billing", "system"]),
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(1000),
+  metadata: z.string().nullable().optional(),
+  sourceEvent: z.string().nullable().optional(),
+  sourceEntityId: z.string().uuid().nullable().optional(),
+});
+```
+
+### Type exports
+
+All DTOs derive types via `z.infer<typeof schema>`.
+
+---
+
+## Service layer
+
+Location: `packages/core/src/services/notification-service.ts`
+
+Pattern: function-based (per `packages/core/AGENTS.md`).
+
+### Service functions
+
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `listNotifications` | `client, tenantId, userId, query` | `ServiceResult<Notification[]>` | RLS-scoped read with pagination and filters |
+| `getUnreadCount` | `client, tenantId, userId` | `ServiceResult<{ count: number }>` | Count of unread notifications for badge |
+| `markAsRead` | `client, tenantId, userId, notificationId` | `ServiceResult<null>` | Sets `is_read = true`, `read_at = now()` |
+| `markAllAsRead` | `client, tenantId, userId` | `ServiceResult<{ updated: number }>` | Bulk update all unread for user+tenant |
+| `createNotification` | `adminClient, input` | `ServiceResult<Notification>` | Creates notification, checks preferences, dispatches email if needed |
+| `createBulkNotifications` | `adminClient, inputs[]` | `ServiceResult<Notification[]>` | Creates notifications for multiple recipients (e.g. billing events for owner+admins) |
+| `getPreferences` | `client, tenantId, userId` | `ServiceResult<NotificationPreference[]>` | Returns user's preferences; missing categories use default (enabled) |
+| `updatePreferences` | `client, tenantId, userId, input` | `ServiceResult<NotificationPreference[]>` | Upserts preference rows; audit logs the change |
+
+### Critical event bypass
+
+`createNotification` and `createBulkNotifications` MUST check if the notification type is critical before consulting preferences:
+
+```typescript
+const CRITICAL_TYPES: NotificationType[] = [
+  "billing_past_due",
+  "billing_canceled",
+  "team_invited",
+  "team_removed",
+];
+
+function isCritical(type: NotificationType): boolean {
+  return CRITICAL_TYPES.includes(type);
+}
+```
+
+If the type is critical, skip preference check and always deliver to all applicable channels.
+
+### Email dispatch flow
+
+```
+createNotification(adminClient, input)
+  |
+  +- 1. Determine if type requires email (see channel strategy table)
+  +- 2. If email required AND (isCritical(type) OR user preference allows email):
+  |       +- Call emailAdapter.sendNotificationEmail(...)
+  |             +- Success -> log audit event: notification.email_sent
+  |             +- Failure -> log audit event: notification.email_failed
+  |                          -> capture in Sentry (non-blocking)
+  +- 3. If in-app required AND (isCritical(type) OR user preference allows in-app):
+  |       +- INSERT into notifications table via adminClient
+  |             +- Supabase Realtime broadcasts to subscribed clients
+  +- 4. Return created notification(s)
+```
+
+### Integration pattern (notification dispatch)
+
+Other services call `createNotification()` or `createBulkNotifications()` after their mutations succeed. This is a DIRECT SERVICE CALL, not an event-driven dispatch.
+
+Example integration in `billing-service.ts`:
+
+```typescript
+// After successful plan upgrade
+await createNotification(adminClient, {
+  tenantId,
+  userId: ownerId,
+  type: "billing_plan_upgraded",
+  category: "billing",
+  title: "Plan upgraded",
+  body: `Your plan has been upgraded to ${newPlan.name}.`,
+  metadata: JSON.stringify({ fromPlanId, toPlanId }),
+  sourceEvent: "billing.plan_upgraded",
+  sourceEntityId: subscriptionId,
+});
+```
+
+Example integration in `tenant-team-service.ts`:
+
+```typescript
+// After successful invitation
+await createNotification(adminClient, {
+  tenantId,
+  userId: invitedUserId,
+  type: "team_invited",
+  category: "team",
+  title: `You were invited to join ${tenantName}`,
+  body: `${inviterName} invited you as ${role}.`,
+  metadata: JSON.stringify({ inviterId, role }),
+  sourceEvent: "tenant_member.invited",
+  sourceEntityId: invitationId,
+});
+```
+
+> **Important**: Notification creation failures MUST NOT break the parent operation. Wrap `createNotification` calls in try/catch and log failures to Sentry — the billing or team mutation should still succeed even if notification dispatch fails.
+
+---
+
+## Server Actions
+
+Location: `ui/features/notifications/actions.ts`
+
+All actions follow the thin wrapper pattern:
+
+```
+validate input (Zod) -> get authenticated client -> call service -> map to ActionResult -> revalidatePath
+```
+
+### Actions list
+
+| Action | Schema | Service function | Sentry area |
+|--------|--------|-----------------|-------------|
+| `listNotificationsAction` | `notificationsQuerySchema` | `listNotifications` | `notifications` |
+| `getUnreadCountAction` | — | `getUnreadCount` | `notifications` |
+| `markAsReadAction` | `markAsReadSchema` | `markAsRead` | `notifications` |
+| `markAllAsReadAction` | `markAllAsReadSchema` | `markAllAsRead` | `notifications` |
+| `getPreferencesAction` | — | `getPreferences` | `notifications` |
+| `updatePreferencesAction` | `updatePreferencesSchema` | `updatePreferences` | `notifications` |
+
+### Sentry instrumentation
+
+Every action wraps its body with `Sentry.withServerActionInstrumentation`. Non-validation errors call `captureActionError` with:
+- `actionName`: the action function name
+- `area`: `"notifications"`
+- `tenantId`, `userId`, `userRole` from auth context
+- `inputShape`: `Object.keys(parsed.data)` — NEVER values
+- `errorCode`: from `ServiceResult.code`
+
+---
+
+## Sentry area registration
+
+Add `notifications` to the `SentryArea` union in `ui/lib/sentry.ts`:
+
+```typescript
+export type SentryArea = "auth" | "billing" | "dashboard" | "notifications" | "resources" | "settings" | "team" | "webhook";
+```
+
+---
+
+## Email adapter
+
+### Interface
+
+Location: `packages/core/src/services/ports/notification-email-port.ts`
+
+```typescript
+export interface NotificationEmailPort {
+  sendNotificationEmail(params: {
+    to: string;
+    subject: string;
+    title: string;
+    body: string;
+    ctaUrl?: string;
+    ctaLabel?: string;
+  }): Promise<{ success: boolean; error?: string }>;
+}
+```
+
+### Implementations
+
+| Adapter | Location | Behavior | Selection |
+|---------|----------|----------|-----------|
+| `ConsoleNotificationEmailAdapter` | `packages/core/src/services/adapters/console-notification-email.ts` | Logs email content to `console.info` | Default when `RESEND_API_KEY` is not set |
+| `ResendNotificationEmailAdapter` | `packages/core/src/services/adapters/resend-notification-email.ts` | Sends via Resend API using a generic notification template | When `RESEND_API_KEY` is set |
+
+### Adapter factory
+
+```typescript
+// packages/core/src/services/adapters/notification-email-adapter-factory.ts
+
+export function createNotificationEmailAdapter(): NotificationEmailPort {
+  const resendKey = process.env["RESEND_API_KEY"];
+  if (resendKey) {
+    return new ResendNotificationEmailAdapter(resendKey);
+  }
+  return new ConsoleNotificationEmailAdapter();
+}
+```
+
+Selection is based on env var presence, NOT `NODE_ENV`.
+
+---
+
+## Realtime integration
+
+### Unread badge subscription
+
+The notification bell component subscribes to Supabase Realtime on the `notifications` table to receive live unread count updates.
+
+```typescript
+// ui/features/notifications/hooks/use-unread-count.ts
+
+// Subscribe to INSERT events on notifications table
+// Filter: user_id = current user, tenant_id = current tenant
+// On INSERT event: increment local unread count
+// On component unmount: unsubscribe
+
+const channel = supabase
+  .channel("notifications-badge")
+  .on(
+    "postgres_changes",
+    {
+      event: "INSERT",
+      schema: "public",
+      table: "notifications",
+      filter: `user_id=eq.${userId}`,
+    },
+    (payload) => {
+      setUnreadCount((prev) => prev + 1);
+    },
+  )
+  .subscribe();
+```
+
+### Realtime scope
+
+| Feature | Realtime | Polling | Rationale |
+|---------|----------|---------|-----------|
+| Unread badge count | Yes (INSERT events) | No | Immediate feedback on new notifications |
+| Notification list page | No | Manual refresh / revalidate | Pagination complexity; Realtime full-feed is follow-up |
+| Preference changes | No | N/A | Preference saves trigger server-side revalidation |
+
+### Realtime RLS
+
+Supabase Realtime respects RLS policies. The subscription only receives events for rows where the user's JWT satisfies the `notifications_select` policy. No additional filtering is needed beyond the channel filter.
+
+---
+
+## UI routes and components
+
+### Routes
+
+| Route | Component | Auth | Description |
+|-------|-----------|------|-------------|
+| `/notifications` | `NotificationsPage` | Required, owner/admin/member | Notification center with filters and pagination |
+| `/settings/notifications` | `NotificationPreferencesPage` | Required, owner/admin/member | Per-category preference toggles |
+
+### Feature module structure
+
+```
+ui/features/notifications/
++-- actions.ts                              # Server Actions (thin wrappers)
++-- queries.ts                              # Server-side data fetching
++-- types.ts                                # Feature-local types
++-- components/
+|   +-- notification-bell.tsx               # Header bell icon with unread badge
+|   +-- notification-list.tsx               # Paginated notification list
+|   +-- notification-item.tsx               # Single notification row
+|   +-- notification-filters.tsx            # Category and read-state filter bar
+|   +-- notification-empty-state.tsx        # Empty state illustrations
+|   +-- notification-preferences-form.tsx   # Per-category toggle grid
+|   +-- mark-all-read-button.tsx            # Bulk action button
++-- hooks/
+    +-- use-unread-count.ts                 # Supabase Realtime subscription hook
+```
+
+### App routes
+
+```
+ui/app/(protected)/notifications/
++-- page.tsx                                # Server Component — fetches data, passes to views
++-- error.tsx                               # Error boundary with Sentry
+
+ui/app/(protected)/settings/notifications/
++-- page.tsx                                # Server Component — preferences page
++-- error.tsx                               # Error boundary with Sentry
+```
+
+> Routes registered in `ui/lib/routes.ts`:
+> ```typescript
+> notifications: "/notifications",
+> notificationPreferences: "/settings/notifications",
+> ```
+
+---
+
+## Seed data
+
+Location: additions to `supabase/seed.sql`
+
+### Seed notifications
+
+```sql
+-- Unread team invitation notification for member user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000001',
+  '<demo_tenant_id>',
+  '<member_user_id>',
+  'team_invited', 'team',
+  'You were invited to join Demo Workspace',
+  'Admin User invited you as a member.',
+  '{"inviterId":"<admin_user_id>","role":"member"}',
+  false, 'tenant_member.invited', null,
+  now() - interval '2 hours'
+);
+
+-- Unread billing past_due notification for owner user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000002',
+  '<demo_tenant_id>',
+  '<owner_user_id>',
+  'billing_past_due', 'billing',
+  'Your subscription is past due',
+  'Update your payment method before the grace period ends.',
+  '{"graceEndsAt":"2026-06-15T00:00:00Z"}',
+  false, 'billing.subscription_past_due', null,
+  now() - interval '1 day'
+);
+
+-- Read billing upgrade notification for owner user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, read_at, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000003',
+  '<demo_tenant_id>',
+  '<owner_user_id>',
+  'billing_plan_upgraded', 'billing',
+  'Plan upgraded to Pro',
+  'Your plan has been upgraded from Free to Pro.',
+  '{"fromPlan":"free","toPlan":"pro"}',
+  true, now() - interval '2 days',
+  'billing.plan_upgraded', null,
+  now() - interval '3 days'
+);
+
+-- Read invitation accepted notification for admin user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, read_at, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000004',
+  '<demo_tenant_id>',
+  '<admin_user_id>',
+  'team_invitation_accepted', 'team',
+  'Member User accepted your invitation',
+  'Member User joined Demo Workspace as member.',
+  '{"acceptedByName":"Member User","role":"member"}',
+  true, now() - interval '5 days',
+  'tenant_invitation.accepted', null,
+  now() - interval '6 days'
+);
+
+-- Unread role changed notification for member user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000005',
+  '<demo_tenant_id>',
+  '<member_user_id>',
+  'team_role_changed', 'team',
+  'Your role was changed to admin',
+  'Owner User updated your role from member to admin.',
+  '{"previousRole":"member","newRole":"admin","changedBy":"<owner_user_id>"}',
+  false, 'tenant_member.role_changed', null,
+  now() - interval '12 hours'
+);
+```
+
+### Seed notification preferences
+
+```sql
+-- Member user has billing email disabled
+INSERT INTO public.notification_preferences (
+  id, user_id, tenant_id, category,
+  in_app_enabled, email_enabled,
+  created_at, updated_at
+) VALUES (
+  'c0000002-0000-0000-0000-000000000001',
+  '<member_user_id>',
+  '<demo_tenant_id>',
+  'billing',
+  true, false,
+  now(), now()
+);
+```
+
+> **Note**: `<demo_tenant_id>`, `<owner_user_id>`, `<admin_user_id>`, and `<member_user_id>` reference existing deterministic seed IDs from `seed.sql`.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/core/src/services/__tests__/notification-service.test.ts`
+
+| Test | What it verifies |
+|------|------------------|
+| `listNotifications` returns user's notifications | Correct tenant+user scoping, pagination, ordering |
+| `listNotifications` with category filter | Only matching category returned |
+| `listNotifications` with isRead filter | Only read or unread returned |
+| `getUnreadCount` with mixed notifications | Correct count of unread only |
+| `getUnreadCount` with no notifications | Returns 0 |
+| `markAsRead` success | Sets `is_read = true`, `read_at` to now |
+| `markAsRead` already read | No-op, returns success |
+| `markAsRead` wrong user | Returns permission error |
+| `markAllAsRead` success | Updates all unread for user+tenant |
+| `markAllAsRead` no unread | Returns success with `updated: 0` |
+| `createNotification` non-critical, preferences allow | Creates notification in DB |
+| `createNotification` non-critical, in-app disabled | Does NOT create in-app notification |
+| `createNotification` critical type | Creates notification regardless of preferences |
+| `createNotification` with email channel | Calls email adapter |
+| `createNotification` email adapter fails | Notification still created; error logged to Sentry |
+| `createBulkNotifications` multiple recipients | Creates one notification per recipient |
+| `getPreferences` with existing rows | Returns saved preferences |
+| `getPreferences` with no rows | Returns defaults (all enabled) |
+| `updatePreferences` success | Upserts preference rows |
+
+### Contract tests
+
+Location: `packages/contracts/src/__tests__/notifications.test.ts`
+
+Test all schemas for valid input, boundary values, and rejection of invalid input.
+
+### E2E tests
+
+Location: `ui/e2e/notifications/notifications.spec.ts`
+
+| Test | Tag | Flow |
+|------|-----|------|
+| User sees notification bell with badge | `@critical` | Login as member -> verify bell shows unread count |
+| User opens notification center | `@critical` | Login as member -> click bell -> verify notification list |
+| User marks notification as read | `@critical` | Login as member -> click notification -> verify read state |
+| User marks all as read | | Login as member -> click "Mark all as read" -> verify badge gone |
+| User filters by category | | Login as member -> select "Team" filter -> verify only team notifications |
+| User filters by unread | | Login as member -> select "Unread" -> verify only unread shown |
+| User configures preferences | | Login as member -> navigate to preferences -> toggle billing email -> save -> verify |
+| Guest cannot see bell | `@critical` | Login as guest -> verify no notification bell in header |
+| Guest redirected from /notifications | | Login as guest -> navigate -> verify redirect to /dashboard |
+| Empty state renders correctly | | Login as clean user -> verify "No notifications yet" message |
+| Owner sees billing notifications | | Login as owner -> verify billing notifications in list |
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Notification dispatch model | Direct service calls | Event-driven (pub/sub, message queue) | Simpler for MVP; no infrastructure dependency; event-driven is follow-up |
+| Metadata storage | JSON string (`text`) | JSONB column | Consistent with billing pattern; parsed at service layer |
+| Preference default behavior | Missing row = enabled | Explicit rows for all categories on user creation | Less data, simpler onboarding; explicit rows only created when user changes defaults |
+| Realtime scope | Badge count only | Full feed realtime | Badge is the highest-value use case; full feed adds pagination complexity |
+| Email template | Generic notification template | Per-type custom templates | Fewer templates to maintain in MVP; per-type templates are follow-up |
+| Notification delivery | Non-blocking (try/catch in callers) | Transactional (fail parent if notification fails) | Notification failures must not break billing or team operations |
+| Schema file | New `notifications.ts` | Add to `platform.ts` | Separation of concerns; notifications schema grows independently |
+| Guest access | No notifications | Limited read-only | Consistent with guest permission model across all features |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Notification table grows unbounded | 90-day retention defined; cleanup cron is follow-up |
+| Realtime subscription leak (not unsubscribed) | Hook cleanup in `useEffect` return; unsubscribe on logout |
+| Email adapter outage blocks critical alerts | Adapter failure is non-blocking; audit event logged; Sentry captures error |
+| Preference bypass for critical events not enforced | `isCritical()` check is centralized and unit-tested |
+| Cross-tenant notification leak | RLS policies enforce `user_id = auth.uid()` AND `tenant_id` match |
+| Race condition: notification created after user removed | Non-blocking; orphaned notifications are harmless (no user to see them) |
+| Supabase Realtime connection limit exhaustion | One channel per authenticated user; unsubscribe on unmount |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Contracts: Zod schemas and types in `@enterprise/contracts` | None |
+| 2 | Data model: `notifications.ts` Drizzle schema, enums, RLS policies, migration | Phase 1 |
+| 3 | Email adapter: `NotificationEmailPort` interface + `ConsoleNotificationEmailAdapter` + `ResendNotificationEmailAdapter` | Phase 1 |
+| 4 | Services: `notification-service.ts` + unit tests | Phases 1-3 |
+| 5 | Integration: wire `createNotification()` calls into `billing-service.ts` and `tenant-team-service.ts` | Phase 4 |
+| 6 | Server Actions + Sentry area registration | Phase 4 |
+| 7 | UI: notification center page, bell component, preferences page, route registration | Phase 6 |
+| 8 | Realtime: unread badge subscription hook + header integration | Phase 7 |
+| 9 | Seed data + E2E tests | Phase 7 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| New schema file or add to `platform.ts`? | New `notifications.ts` file | Separation of concerns; notification schema grows independently |
+| `metadata` as JSON string or JSONB? | JSON string (`text`) | Consistent with billing pattern (features, limits); parsed at service layer |
+| Direct dispatch or event-driven? | Direct service calls | No message queue dependency; event-driven is architectural follow-up |
+| Notification retention policy? | 90 days defined, no auto-cleanup in MVP | Sets expectation; cleanup cron job is follow-up |
+| Critical event handling? | Bypass preferences entirely | User safety: billing alerts and access changes must always reach the user |
+| Realtime for badge or full feed? | Badge count only | Highest value for lowest complexity; full feed Realtime is follow-up |
+| Guest notification access? | No access | Consistent with limited guest model; guests see no bell, no page |
+| Per-tenant or global preferences? | Per-tenant | User may work in multiple tenants with different notification needs |
+| Email template strategy? | Generic template | Fewer templates; per-type customization is follow-up |
+| Notification immutability? | Only `is_read` and `read_at` are mutable | Audit trail integrity; notifications are an immutable event log |
+| Preference default? | Missing row = all enabled | Reduces initial data; users only create preference rows when they customize |
+| Notification failure impact? | Non-blocking — parent operation succeeds | Billing upgrade should not fail because notification dispatch failed |
+
+---
+
+*Last updated: 2026-05-29*


### PR DESCRIPTION
## Summary

- Rewrite notifications PRD from 76-line skeleton to 458-line implementation-ready document
- Create 771-line RFC with complete technical architecture

## Changes

| File | Change |
|------|--------|
| `docs/features/notifications/prd.md` | Complete PRD: permission matrix, channel strategy, 9 user stories, traceability, decisions log |
| `docs/features/notifications/rfc.md` | New RFC: data model, RLS, Zod contracts, service layer, adapters, Realtime, 9 phases |

## Verification

- [x] No code changes — documentation only
- [x] Follows enterprise-docs skill conventions
- [x] All sections match billing/team-management PRD/RFC quality

**PR 1 of 6** in the notifications feature chain (stacked-to-main).