### PR TITLE
feat(ui): add notification center, preferences page, bell, and Realtime badge

### DIFF
--- a/docs/features/notifications/prd.md
+++ b/docs/features/notifications/prd.md
@@ -1,76 +1,458 @@
 ---
 title: "Notifications PRD"
-description: "Defines product requirements for in-app and outbound notification workflows."
+description: "Defines product requirements for tenant-scoped in-app notifications, email delivery for critical events, and user notification preferences."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-05-29"
 ---
 
 # Notifications PRD
 
 ## Purpose
 
-Define roadmap-level requirements for notifying users about key tenant events while avoiding noisy or low-value messaging.
+Define implementation-ready product requirements for tenant-scoped notifications in a multi-tenant SaaS template, including an in-app notification center, email delivery for critical events, user-configurable preferences, and a service-level notification dispatch API.
 
 ## Scope
 
-- Included: in-app notification center and foundational outbound events.
-- Excluded: full campaign automation, advanced segmentation, and marketing messaging.
+- Included: in-app notification center, email delivery for critical events, per-user preference controls, event-to-notification catalog, notification bell with unread badge, Supabase Realtime for badge updates, and traceability.
+- Excluded: SMS or push channels, workflow builder and conditional rules engine, multi-step digest customization, campaign automation, advanced segmentation, marketing messaging, webhook delivery failure notifications (follow-up with webhooks feature).
 
 ---
 
 ## Problem
 
-Users miss important events (invites, role changes, billing issues) when the product has no consistent notification model.
+Users miss important events (invitations, role changes, billing issues) because the platform has no consistent notification model. Critical billing alerts go unseen, team changes happen without awareness, and there is no way for users to control notification volume.
 
 ## Users and stakeholders
 
 | Role | Need |
 |------|------|
-| Tenant members | Timely awareness of relevant actions |
-| Tenant admins | Visibility into operational or security events |
-| Product team | Reusable event-to-notification framework |
+| Tenant members | Timely awareness of team and billing events relevant to their role |
+| Tenant admins | Visibility into operational events and team changes |
+| Tenant owners | Immediate alerts for critical billing issues and subscription changes |
+| Product team | Reusable notification dispatch API that other features can hook into |
+| Template adopter | A notification foundation they can extend with custom event types |
 
 ## Goals
 
-- Surface important events in-app with clear relevance.
-- Support baseline outbound delivery for critical workflows.
-- Provide user-level preference controls for non-critical signals.
+- Surface important events in-app with clear relevance and read/unread state.
+- Deliver critical billing and access events via email regardless of user preferences.
+- Provide per-user, per-category preference controls for non-critical notifications.
+- Expose a service-level `createNotification()` API that other services call to dispatch notifications.
+- Keep the notification bell updated in real-time via Supabase Realtime.
+
+---
+
+## Permission matrix
+
+| Action | Owner | Admin | Member | Guest |
+|--------|-------|-------|--------|-------|
+| View own notifications | Yes | Yes | Yes | No |
+| View unread badge in header | Yes | Yes | Yes | No |
+| Mark own notification as read | Yes | Yes | Yes | No |
+| Mark all own notifications as read | Yes | Yes | Yes | No |
+| Configure notification preferences | Yes | Yes | Yes | No |
+| Access /notifications page | Yes | Yes | Yes | No (redirect) |
+| Access /settings/notifications | Yes | Yes | Yes | No (redirect) |
+
+> **Important**: Guests have no notification access in MVP. All notification operations are scoped to the current tenant — users only see notifications for their active tenant.
 
 ---
 
 ## MVP scope
 
-- In-app notification feed with read/unread state.
-- Event types: invitation, role change, subscription issue, webhook delivery failure.
-- Basic email delivery for critical events.
-- Per-user opt-out for non-critical categories.
+### Notification model and lifecycle
 
-## Out of scope
+- Each notification represents a single event dispatched to a single user.
+- Notifications are tenant-scoped and user-scoped — a user sees only notifications for their current tenant.
+- Notifications have: id, tenant, recipient user, type, category, title, body, metadata, read state, source event reference, and creation timestamp.
+- Notifications are immutable after creation — only the `is_read` flag and `read_at` timestamp change.
+- Notification retention: 90 days. No automatic cleanup in MVP (configurable cleanup is a follow-up).
 
-- SMS or push channels.
+### Channel strategy
+
+Notifications are delivered via two channels: in-app (always active) and email (for critical events).
+
+| Event | Type | Category | In-app | Email | Opt-out allowed |
+|-------|------|----------|--------|-------|-----------------|
+| Team member invited | `team_invited` | `team` | Yes | Yes (always) | No — invitation delivery is essential |
+| Invitation accepted | `team_invitation_accepted` | `team` | Yes | No | Yes |
+| Member role changed | `team_role_changed` | `team` | Yes | No | Yes |
+| Member removed | `team_removed` | `team` | No (loses access) | Yes (always) | No — access revocation notice |
+| Subscription past due | `billing_past_due` | `billing` | Yes | Yes (always) | No — critical financial alert |
+| Plan upgraded | `billing_plan_upgraded` | `billing` | Yes | No | Yes |
+| Plan downgraded | `billing_plan_downgraded` | `billing` | Yes | No | Yes |
+| Subscription canceled | `billing_canceled` | `billing` | Yes | Yes (always) | No — critical financial alert |
+| Subscription activated | `billing_activated` | `billing` | Yes | No | Yes |
+
+### Recipient determination
+
+| Event | Recipients |
+|-------|-----------|
+| `team_invited` | The invited user (by email) |
+| `team_invitation_accepted` | The user who sent the invitation |
+| `team_role_changed` | The affected member |
+| `team_removed` | The removed member (email only) |
+| `billing_past_due` | Owner + all admins |
+| `billing_plan_upgraded` | Owner |
+| `billing_plan_downgraded` | Owner |
+| `billing_canceled` | Owner + all admins |
+| `billing_activated` | Owner |
+
+### Preference model
+
+- Per-user, per-tenant, per-category preference rows.
+- Categories: `team`, `billing`, `system` (system reserved for future use).
+- Each preference row controls `in_app_enabled` and `email_enabled` independently.
+- Default behavior (no preference row exists): both channels enabled.
+- Critical notifications bypass preferences entirely — always delivered.
+- Preferences UI lives at `/settings/notifications`.
+
+### Notification center
+
+- Accessible at `/notifications` from the header bell icon.
+- Full-page list with pagination (not a dropdown in MVP).
+- Each notification shows: icon (by category), title, body, relative timestamp, read/unread indicator.
+- Click on a notification marks it as read.
+- "Mark all as read" bulk action.
+- Filter by category (team, billing) and read state (all, unread).
+
+### Real-time badge updates
+
+- The notification bell in the header shows an unread count badge.
+- Badge updates via Supabase Realtime subscription on the `notifications` table, filtered by `user_id`.
+- When a new notification is inserted, the badge count increments without page reload.
+- The full notification list page uses server-side pagination — it does NOT use Realtime for the list (follow-up).
+
+### Out of scope (MVP)
+
+- SMS or push notification channels.
 - Workflow builder and conditional rules engine.
-- Multi-step digest customization.
+- Digest emails (daily/weekly summary).
+- Notification grouping or batching.
+- Rich notification actions (inline buttons to accept invite, etc.).
+- Event-driven architecture (message queue, pub/sub) — direct service calls in MVP.
+- Webhook delivery failure notifications (comes with webhooks feature).
+- System category notifications (reserved for future features).
+- Automatic cleanup/retention enforcement.
+
+---
+
+## UX specification
+
+### Routes
+
+- `/notifications` — notification center (full page)
+- `/settings/notifications` — notification preferences
+
+### Notification bell (global header component)
+
+The notification bell is a persistent icon in the application header, visible on all protected pages.
+
+- Shows a red dot or numeric badge when unread count > 0.
+- Badge shows count up to 99; shows "99+" for higher counts.
+- Clicking the bell navigates to `/notifications`.
+- Badge updates in real-time via Supabase Realtime.
+
+### Notification center page layout
+
+```
++------------------------------------------------------------------+
+| Header: "Notifications" + "Stay updated on team and billing"     |
+|                                              [Mark all as read]  |
++------------------------------------------------------------------+
+| Filters row:                                                     |
+|   [All] [Unread]  |  Category: [All] [Team] [Billing]           |
++------------------------------------------------------------------+
+| Notification list:                                               |
+|   +------------------------------------------------------------+ |
+|   | * [Team icon] You were invited to join Acme Corp           | |
+|   |    John Doe invited you as a member - 2 hours ago          | |
+|   +------------------------------------------------------------+ |
+|   |    [Billing icon] Your subscription is past due            | |
+|   |    Update your payment method before Jun 15 - 1 day ago    | |
+|   +------------------------------------------------------------+ |
+|   |    [Team icon] Your role was changed to admin              | |
+|   |    Jane Smith updated your role - 3 days ago               | |
+|   +------------------------------------------------------------+ |
+|                                                                  |
+| Pagination: [<- Previous] Page 1 of 3 [Next ->]                 |
++------------------------------------------------------------------+
+```
+
+### Notification preferences page layout
+
+```
++------------------------------------------------------------------+
+| Header: "Notification preferences"                               |
+| "Choose which notifications you receive"                         |
++------------------------------------------------------------------+
+| Team notifications                                               |
+|   Invitation accepted        [In-app: on] [Email: on]           |
+|   Role changes               [In-app: on] [Email: on]           |
+|   Note: Invitation and removal notices are always sent           |
++------------------------------------------------------------------+
+| Billing notifications                                            |
+|   Plan upgrades              [In-app: on] [Email: on]           |
+|   Plan downgrades            [In-app: on] [Email: on]           |
+|   Subscription activated     [In-app: on] [Email: on]           |
+|   Note: Past due and cancellation alerts are always sent         |
++------------------------------------------------------------------+
+|                                                   [Save changes] |
++------------------------------------------------------------------+
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **Notification bell** | Persistent header icon. Shows unread count badge (red dot for 1-9, numeric for 10+). Navigates to `/notifications` on click. Updates via Realtime subscription. |
+| **Notification list** | Paginated list of notifications. Unread items have a blue dot indicator and slightly different background. Clicking an item marks it as read. Supports category and read-state filters. |
+| **Notification item** | Displays category icon, title, body (truncated to 2 lines), relative timestamp. Unread indicator (blue dot) on left edge. |
+| **Mark all as read button** | Bulk action in header. Disabled when no unread notifications exist. Shows confirmation count: "Mark 5 as read". |
+| **Filter bar** | Toggle between All/Unread. Category dropdown: All, Team, Billing. Filters are URL query params for shareable state. |
+| **Preferences form** | Toggle switches per category per channel. Critical events shown as always-on (disabled toggles with explanation). Save button submits all changes at once. |
+| **Empty state** | "You're all caught up" message when no notifications match the current filter. |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Loading** | Skeleton rows in notification list, skeleton toggle in preferences |
+| **Empty (no notifications ever)** | "No notifications yet" with illustration. Subtitle: "We'll let you know when something happens." |
+| **Empty (all read, unread filter active)** | "You're all caught up" message |
+| **Unread notifications present** | Blue dot on unread items, badge on bell |
+| **All notifications read** | No badge on bell, no blue dots |
+| **Error loading notifications** | "Could not load notifications. Try again." with retry button |
+| **Preferences saved** | Toast: "Notification preferences updated" |
+| **Guest access** | Redirect to `/dashboard` — guests have no notification access |
+
+### Role-specific visibility
+
+| Element | Owner | Admin | Member | Guest |
+|---------|-------|-------|--------|-------|
+| Notification bell + badge | Yes | Yes | Yes | No |
+| `/notifications` page | Yes | Yes | Yes | No (redirect) |
+| `/settings/notifications` | Yes | Yes | Yes | No (redirect) |
+| Mark as read actions | Yes | Yes | Yes | No |
+| Preference toggles | Yes | Yes | Yes | No |
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: User receives in-app notification for team invitation
+
+**As** a registered user, **I want** to receive an in-app notification when I am invited to a tenant so I can respond promptly.
+
+Acceptance criteria:
+1. When an admin invites a user by email, a notification of type `team_invited` is created for the invited user.
+2. The notification appears in the user's notification center immediately.
+3. The unread badge on the bell increments without page reload (Realtime).
+4. The notification title says "You were invited to join {tenant_name}".
+5. The notification body includes the inviter's name and assigned role.
+6. An invitation email is also sent (always — not affected by preferences).
+
+### US-2: User views notification center
+
+**As** a tenant member, **I want** to view all my notifications in one place so I can stay informed about team and billing activity.
+
+Acceptance criteria:
+1. Navigating to `/notifications` displays a paginated list of the user's notifications for the current tenant.
+2. Unread notifications show a blue dot indicator.
+3. Notifications are ordered by creation date, newest first.
+4. Each notification displays category icon, title, body, and relative timestamp.
+5. Default page size is 20 notifications.
+
+### US-3: User marks a notification as read
+
+**As** a tenant member, **I want** to mark a notification as read so I can track which events I have already acknowledged.
+
+Acceptance criteria:
+1. Clicking on an unread notification marks it as read.
+2. The blue dot indicator disappears.
+3. The unread badge count in the header decrements.
+4. A `notification.marked_read` audit event is NOT logged (read actions are too frequent for audit).
+
+### US-4: User marks all notifications as read
+
+**As** a tenant member, **I want** to mark all my notifications as read so I can clear my notification backlog.
+
+Acceptance criteria:
+1. Clicking "Mark all as read" marks all unread notifications for the current tenant as read.
+2. The header badge disappears (count becomes 0).
+3. All blue dot indicators disappear in the list.
+4. The button is disabled when no unread notifications exist.
+
+### US-5: User receives email for critical billing event
+
+**As** a tenant owner, **I want** to receive an email when my subscription enters past_due status so I can resolve billing issues even if I am not using the app.
+
+Acceptance criteria:
+1. When the billing system transitions a subscription to `past_due`, email notifications are sent to the owner and all admins.
+2. The email includes the tenant name, grace period end date, and a link to the billing page.
+3. This email is sent regardless of the user's notification preferences (critical, no opt-out).
+4. A `notification.email_sent` audit event is logged.
+
+### US-6: User configures notification preferences
+
+**As** a tenant member, **I want** to control which non-critical notifications I receive so I am not overwhelmed by low-priority alerts.
+
+Acceptance criteria:
+1. Navigating to `/settings/notifications` shows toggle switches per category (team, billing).
+2. Each category has independent toggles for in-app and email channels.
+3. Critical events (billing.past_due, billing.canceled, team.invited, team.removed) are shown as always-on with a disabled toggle and explanation text.
+4. Saving preferences updates the user's notification preferences for the current tenant.
+5. Preferences take effect immediately — the next notification dispatch checks updated preferences.
+6. A toast confirms "Notification preferences updated" on save.
+
+### US-7: System generates notification on billing event
+
+**As** the system, **I want** to create notifications when billing events occur so affected users are informed.
+
+Acceptance criteria:
+1. When `billing-service.changePlan()` succeeds, a `billing_plan_upgraded` or `billing_plan_downgraded` notification is created for the owner.
+2. When `billing-service.cancelSubscription()` succeeds, a `billing_canceled` notification is created for the owner and all admins.
+3. When `billing-service.processWebhookEvent()` transitions to `past_due`, a `billing_past_due` notification is created for the owner and all admins.
+4. When subscription activates, a `billing_activated` notification is created for the owner.
+5. For critical events (past_due, canceled), email is also dispatched regardless of preferences.
+
+### US-8: System generates notification on team event
+
+**As** the system, **I want** to create notifications when team membership changes so affected users are informed.
+
+Acceptance criteria:
+1. When `tenant-team-service.inviteTenantMember()` succeeds, a `team_invited` notification is created for the invited user.
+2. When `tenant-team-service.acceptTenantInvitation()` succeeds, a `team_invitation_accepted` notification is created for the inviter.
+3. When `tenant-team-service.changeTenantMemberRole()` succeeds, a `team_role_changed` notification is created for the affected member.
+4. When `tenant-team-service.removeTenantMember()` succeeds, a `team_removed` email notification is sent to the removed member (no in-app — they lose access).
+
+### US-9: Guest cannot access notifications
+
+**As** the system, **I want** to prevent guests from accessing notifications so the permission model is consistent.
+
+Acceptance criteria:
+1. Guests do not see the notification bell in the header.
+2. Navigating to `/notifications` as a guest redirects to `/dashboard`.
+3. Navigating to `/settings/notifications` as a guest redirects to `/dashboard`.
+4. Notification service does not create notifications for users with the `guest` role.
 
 ---
 
 ## Success metrics
 
-- Read rate for critical notifications.
-- Median time to acknowledge high-priority events.
-- Reduction in missed-action support incidents.
+- Read rate for critical notifications (billing past_due, canceled): target > 95% within 24 hours.
+- Median time from event to notification read: target < 4 hours for in-app.
+- Notification preference opt-out rate: target < 30% of users disable any category (healthy signal balance).
+- Email delivery success rate for critical events: target > 99%.
+- Reduction in missed-action support incidents (billing past_due not noticed): target > 60% reduction.
 
 ## Risks
 
-- Over-notification can reduce trust in the channel.
-- Poor event classification can hide critical alerts.
-- Delivery failures can go unnoticed without observability.
-
-## Open questions
-
-- Should unread badges be global or tenant-scoped in MVP?
-- Which events are always non-optional?
-- How long should notification history be retained by default?
+| Risk | Mitigation |
+|------|------------|
+| Over-notification reduces trust in the channel | Category preferences allow users to opt out of non-critical notifications |
+| Poor event classification hides critical alerts | Critical events (past_due, canceled, invited, removed) bypass preferences entirely |
+| Delivery failures go unnoticed | Email adapter failures logged to audit; Sentry captures delivery errors |
+| Realtime subscription exhausts Supabase connections | Badge subscription uses a single channel per user; unsubscribe on logout |
+| High notification volume degrades page performance | Server-side pagination with limit/offset; no client-side notification accumulation |
+| Notification table grows unbounded | 90-day retention policy defined; cleanup job is a follow-up |
+| Stale badge count after preference change | Badge count re-fetched after preference save |
 
 ---
 
-*Last updated: 2026-05-07*
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `notification.created` | Service creates a new notification | `{ type, category, recipientUserId, sourceEvent, tenantId }` |
+| `notification.email_sent` | Email adapter successfully sends notification email | `{ type, recipientEmail, tenantId }` |
+| `notification.email_failed` | Email adapter fails to send | `{ type, recipientEmail, errorCode, tenantId }` |
+| `notification.preferences_updated` | User updates notification preferences | `{ userId, tenantId, changes }` |
+
+> **Note**: `notification.marked_read` and `notification.marked_all_read` are NOT audited — read actions are too frequent and low-value for audit.
+
+### Sentry
+
+- Area: `notifications`
+- Instrumented actions: `listNotificationsAction`, `getUnreadCountAction`, `markAsReadAction`, `markAllAsReadAction`, `getPreferencesAction`, `updatePreferencesAction`
+- Captured errors: DB failures, email delivery failures, Realtime subscription errors
+- PII exclusions: notification body content, email addresses, user names
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`, `notificationType`, `category`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Notification | unread | `team_invited` — "You were invited to join Demo Workspace" for member user |
+| Notification | unread | `billing_past_due` — "Your subscription is past due" for owner user |
+| Notification | read | `billing_plan_upgraded` — "Plan upgraded to Pro" for owner user, read 2 days ago |
+| Notification | read | `team_invitation_accepted` — "John accepted your invitation" for admin user, read 5 days ago |
+| Notification | unread | `team_role_changed` — "Your role was changed to admin" for member user |
+| Preference | default | Owner: all categories enabled (default) |
+| Preference | customized | Member: billing email disabled |
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| User sees notification bell with unread count | Member | Bell shows badge with correct unread count |
+| User opens notification center | Member | Paginated list of notifications loads |
+| User marks single notification as read | Member | Blue dot disappears, badge decrements |
+| User marks all as read | Member | All dots disappear, badge disappears |
+| User filters by category | Member | Only notifications of selected category shown |
+| User filters by unread | Member | Only unread notifications shown |
+| User configures preferences | Member | Toggle switches save correctly |
+| Critical notification always shows | Owner | Past due notification appears even with billing disabled |
+| Guest cannot access notifications | Guest | Redirected to /dashboard, no bell visible |
+| Owner sees billing notifications | Owner | Past due and canceled notifications present |
+| Empty state renders | Member (clean user) | "No notifications yet" message displayed |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Email delivery | `NotificationEmailPort` | Console adapter — logs email content | Resend adapter | `RESEND_API_KEY` |
+
+### Environment variables
+
+| Variable | Required | Scope | Fallback behavior |
+|----------|----------|-------|-------------------|
+| `RESEND_API_KEY` | Optional | Server | Console adapter logs email content locally |
+
+### Production readiness
+
+- [ ] All audit events verified in `audit_log` table for notification creation and email delivery
+- [ ] Sentry area `notifications` registered and all Server Actions instrumented
+- [ ] `NotificationEmailPort` interface documented with adapter contract
+- [ ] Unit tests pass for `notification-service.ts` (all service functions)
+- [ ] E2E tests pass for all defined flows
+- [ ] RLS policies on `notifications` and `notification_preferences` tables verified (no cross-tenant or cross-user leaks)
+- [ ] Seed data committed and `supabase db reset` runs cleanly
+- [ ] Realtime subscription for badge count verified (increments on insert)
+- [ ] Critical events bypass preference check verified
+- [ ] `/notifications` and `/settings/notifications` routes added to `ui/lib/routes.ts`
+- [ ] Notification bell component integrated in global header
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Notification center as full page or dropdown? | Full page at `/notifications` | Better for pagination, filtering, and mobile responsiveness. Dropdown is a follow-up UX enhancement. |
+| Direct service calls or event-driven dispatch? | Direct service calls in MVP | Simpler implementation, no message queue dependency. Event-driven architecture is a follow-up. |
+| Notification metadata as JSONB or text? | JSON string (`text`) | Consistent with billing pattern (plans.features, plans.limits). Parsed at service layer. |
+| Guest notification access? | No access in MVP | Consistent with limited guest permission model across the platform. |
+| Real-time for full feed or badge only? | Badge only via Supabase Realtime | Full feed realtime adds complexity; server-side pagination is sufficient for MVP. |
+| Critical event opt-out? | No opt-out for billing.past_due, billing.canceled, team.invited, team.removed | These are essential operational and financial alerts that users must receive. |
+| Notification retention? | 90 days, no auto-cleanup in MVP | Defines expectation; cleanup cron job is a follow-up. |
+| Per-tenant or global preferences? | Per-tenant | User may want different preferences for different workspaces. Consistent with multi-tenant model. |
+| Notification grouping? | No grouping in MVP | Individual notifications are simpler and sufficient for current event volume. |
+| Email template per type or generic? | Generic notification email template in MVP | Reduces template maintenance; per-type templates are a follow-up for better UX. |
+| Unread badge scope? | Tenant-scoped | User sees badge count only for their current tenant. Consistent with all other tenant-scoped data. |
+
+---
+
+*Last updated: 2026-05-29*

--- a/docs/features/notifications/rfc.md
+++ b/docs/features/notifications/rfc.md
@@ -1,0 +1,771 @@
+---
+title: "Notifications RFC"
+description: "Defines the implementation-ready technical architecture for tenant-scoped notifications, email delivery, user preferences, and real-time badge updates."
+owner: "Engineering"
+lastUpdated: "2026-05-29"
+---
+
+# Notifications RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for tenant-scoped notifications aligned with the service layer, contracts, adapter, and traceability conventions of the Enterprise Platform.
+
+## Scope
+
+- Included: data model, Row-Level Security (RLS) policies, Zod contracts, service APIs, notification dispatch integration, email adapter, Supabase Realtime for badge updates, Server Actions, UI routes, seed data, and testing strategy.
+- Excluded: SMS/push channels, event-driven architecture (message queue, pub/sub), digest emails, notification grouping, rich notification actions, webhook delivery failure notifications.
+
+---
+
+## Summary
+
+Implement notifications as a tenant-bounded, user-scoped module using Drizzle schema for `notifications` and `notification_preferences` tables with RLS policies, Zod contracts in `@enterprise/contracts` for all inputs and outputs, function-based services in `@enterprise/core/src/services/notification-service.ts`, a port/adapter pattern for email delivery (Resend in production, console in development), thin Server Actions in `ui/features/notifications/actions.ts`, and Supabase Realtime for live unread badge updates. Other services (billing, team) call `createNotification()` directly after their mutations — no event bus in MVP. All mutations are auditable via `AuditService.log()` and traceable via Sentry instrumentation under the `notifications` area.
+
+## Technical objectives
+
+- Notifications are always tenant-scoped and user-scoped — no cross-tenant or cross-user data leaks.
+- Critical events (billing past_due, billing canceled, team invited, team removed) bypass user preferences and always deliver.
+- Local development works without Resend credentials via `ConsoleNotificationEmailAdapter`.
+- Notification dispatch is synchronous and direct — other services call `createNotification()` without a message queue.
+- Unread badge count updates in real-time via Supabase Realtime subscription without page reload.
+
+---
+
+## Data model
+
+Location: `packages/db/src/schema/notifications.ts` — **new file**
+
+### New enums
+
+```typescript
+export const notificationTypeEnum = pgEnum("notification_type", [
+  "team_invited",
+  "team_invitation_accepted",
+  "team_role_changed",
+  "team_removed",
+  "billing_past_due",
+  "billing_plan_upgraded",
+  "billing_plan_downgraded",
+  "billing_canceled",
+  "billing_activated",
+]);
+
+export const notificationCategoryEnum = pgEnum("notification_category", [
+  "team",
+  "billing",
+  "system",
+]);
+```
+
+### `notifications` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `user_id` | `uuid` | NOT NULL (recipient — references `auth.users.id`) |
+| `type` | `notification_type` enum | NOT NULL |
+| `category` | `notification_category` enum | NOT NULL |
+| `title` | `text` | NOT NULL |
+| `body` | `text` | NOT NULL |
+| `metadata` | `text` | NULLABLE (JSON string — source event details) |
+| `is_read` | `boolean` | NOT NULL, default `false` |
+| `read_at` | `timestamptz` | NULLABLE |
+| `source_event` | `text` | NULLABLE (original event name, e.g. `'tenant_member.invited'`) |
+| `source_entity_id` | `uuid` | NULLABLE (ID of the entity that triggered notification) |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### `notification_preferences` table
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `user_id` | `uuid` | NOT NULL (references `auth.users.id`) |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `category` | `notification_category` enum | NOT NULL |
+| `in_app_enabled` | `boolean` | NOT NULL, default `true` |
+| `email_enabled` | `boolean` | NOT NULL, default `true` |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `notifications_user_tenant_idx` | `user_id`, `tenant_id` | User+tenant scoped queries |
+| `notifications_user_unread_idx` | `user_id`, `tenant_id`, `is_read` | Unread count queries |
+| `notifications_category_idx` | `category` | Category filtering |
+| `notifications_created_at_idx` | `created_at` | Pagination ordering |
+| `notifications_source_event_idx` | `source_event` | Source event lookup |
+| `preferences_user_tenant_idx` | `user_id`, `tenant_id` | User preferences lookup |
+
+### Constraints
+
+- UNIQUE on `notification_preferences(user_id, tenant_id, category)` — one preference row per user per tenant per category.
+- `notifications.metadata` stores JSON as `text`; parsing happens at the service layer.
+- No foreign key from `notifications.user_id` to `profiles` — notifications may be created for users who were subsequently removed.
+
+### Type exports
+
+```typescript
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+
+export type NotificationPreference = typeof notificationPreferences.$inferSelect;
+export type NewNotificationPreference = typeof notificationPreferences.$inferInsert;
+```
+
+---
+
+## RLS policies
+
+### `notifications`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `notifications_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `notifications_insert` | INSERT | `service_role` | Service role only — notifications created by services |
+| `notifications_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim (mark as read only) |
+| `notifications_delete` | DELETE | — | No deletes — retention cleanup is a follow-up |
+
+### `notification_preferences`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `preferences_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_insert` | INSERT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_delete` | DELETE | — | No deletes — preferences are updated, not removed |
+
+> **Note**: Notification creation uses the **admin client** (`service_role`) because notifications are generated by service-layer code (billing, team services) that may not have the recipient's JWT context. The admin client is used ONLY for creating notifications, never for reading or updating.
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/notifications.ts`
+
+### Output schemas
+
+```typescript
+import { z } from "zod";
+
+// Notification display shape
+export const notificationSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum([
+    "team_invited",
+    "team_invitation_accepted",
+    "team_role_changed",
+    "team_removed",
+    "billing_past_due",
+    "billing_plan_upgraded",
+    "billing_plan_downgraded",
+    "billing_canceled",
+    "billing_activated",
+  ]),
+  category: z.enum(["team", "billing", "system"]),
+  title: z.string(),
+  body: z.string(),
+  metadata: z.string().nullable(),
+  isRead: z.boolean(),
+  readAt: z.string().datetime().nullable(),
+  sourceEvent: z.string().nullable(),
+  sourceEntityId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+// Notification preference display shape
+export const notificationPreferenceSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  category: z.enum(["team", "billing", "system"]),
+  inAppEnabled: z.boolean(),
+  emailEnabled: z.boolean(),
+});
+
+// Unread count shape
+export const unreadCountSchema = z.object({
+  count: z.number().int().min(0),
+});
+```
+
+### Input schemas
+
+```typescript
+// Mark single notification as read
+export const markAsReadSchema = z.object({
+  notificationId: z.string().uuid(),
+});
+
+// Mark all as read (no input — uses auth context)
+export const markAllAsReadSchema = z.object({});
+
+// Update preferences
+export const updatePreferencesSchema = z.object({
+  preferences: z.array(
+    z.object({
+      category: z.enum(["team", "billing", "system"]),
+      inAppEnabled: z.boolean(),
+      emailEnabled: z.boolean(),
+    }),
+  ),
+});
+
+// List notifications query
+export const notificationsQuerySchema = z.object({
+  category: z.enum(["team", "billing", "system"]).optional(),
+  isRead: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+// Create notification (internal — used by services, not exposed as Server Action)
+export const createNotificationSchema = z.object({
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum([
+    "team_invited",
+    "team_invitation_accepted",
+    "team_role_changed",
+    "team_removed",
+    "billing_past_due",
+    "billing_plan_upgraded",
+    "billing_plan_downgraded",
+    "billing_canceled",
+    "billing_activated",
+  ]),
+  category: z.enum(["team", "billing", "system"]),
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(1000),
+  metadata: z.string().nullable().optional(),
+  sourceEvent: z.string().nullable().optional(),
+  sourceEntityId: z.string().uuid().nullable().optional(),
+});
+```
+
+### Type exports
+
+All DTOs derive types via `z.infer<typeof schema>`.
+
+---
+
+## Service layer
+
+Location: `packages/core/src/services/notification-service.ts`
+
+Pattern: function-based (per `packages/core/AGENTS.md`).
+
+### Service functions
+
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `listNotifications` | `client, tenantId, userId, query` | `ServiceResult<Notification[]>` | RLS-scoped read with pagination and filters |
+| `getUnreadCount` | `client, tenantId, userId` | `ServiceResult<{ count: number }>` | Count of unread notifications for badge |
+| `markAsRead` | `client, tenantId, userId, notificationId` | `ServiceResult<null>` | Sets `is_read = true`, `read_at = now()` |
+| `markAllAsRead` | `client, tenantId, userId` | `ServiceResult<{ updated: number }>` | Bulk update all unread for user+tenant |
+| `createNotification` | `adminClient, input` | `ServiceResult<Notification>` | Creates notification, checks preferences, dispatches email if needed |
+| `createBulkNotifications` | `adminClient, inputs[]` | `ServiceResult<Notification[]>` | Creates notifications for multiple recipients (e.g. billing events for owner+admins) |
+| `getPreferences` | `client, tenantId, userId` | `ServiceResult<NotificationPreference[]>` | Returns user's preferences; missing categories use default (enabled) |
+| `updatePreferences` | `client, tenantId, userId, input` | `ServiceResult<NotificationPreference[]>` | Upserts preference rows; audit logs the change |
+
+### Critical event bypass
+
+`createNotification` and `createBulkNotifications` MUST check if the notification type is critical before consulting preferences:
+
+```typescript
+const CRITICAL_TYPES: NotificationType[] = [
+  "billing_past_due",
+  "billing_canceled",
+  "team_invited",
+  "team_removed",
+];
+
+function isCritical(type: NotificationType): boolean {
+  return CRITICAL_TYPES.includes(type);
+}
+```
+
+If the type is critical, skip preference check and always deliver to all applicable channels.
+
+### Email dispatch flow
+
+```
+createNotification(adminClient, input)
+  |
+  +- 1. Determine if type requires email (see channel strategy table)
+  +- 2. If email required AND (isCritical(type) OR user preference allows email):
+  |       +- Call emailAdapter.sendNotificationEmail(...)
+  |             +- Success -> log audit event: notification.email_sent
+  |             +- Failure -> log audit event: notification.email_failed
+  |                          -> capture in Sentry (non-blocking)
+  +- 3. If in-app required AND (isCritical(type) OR user preference allows in-app):
+  |       +- INSERT into notifications table via adminClient
+  |             +- Supabase Realtime broadcasts to subscribed clients
+  +- 4. Return created notification(s)
+```
+
+### Integration pattern (notification dispatch)
+
+Other services call `createNotification()` or `createBulkNotifications()` after their mutations succeed. This is a DIRECT SERVICE CALL, not an event-driven dispatch.
+
+Example integration in `billing-service.ts`:
+
+```typescript
+// After successful plan upgrade
+await createNotification(adminClient, {
+  tenantId,
+  userId: ownerId,
+  type: "billing_plan_upgraded",
+  category: "billing",
+  title: "Plan upgraded",
+  body: `Your plan has been upgraded to ${newPlan.name}.`,
+  metadata: JSON.stringify({ fromPlanId, toPlanId }),
+  sourceEvent: "billing.plan_upgraded",
+  sourceEntityId: subscriptionId,
+});
+```
+
+Example integration in `tenant-team-service.ts`:
+
+```typescript
+// After successful invitation
+await createNotification(adminClient, {
+  tenantId,
+  userId: invitedUserId,
+  type: "team_invited",
+  category: "team",
+  title: `You were invited to join ${tenantName}`,
+  body: `${inviterName} invited you as ${role}.`,
+  metadata: JSON.stringify({ inviterId, role }),
+  sourceEvent: "tenant_member.invited",
+  sourceEntityId: invitationId,
+});
+```
+
+> **Important**: Notification creation failures MUST NOT break the parent operation. Wrap `createNotification` calls in try/catch and log failures to Sentry — the billing or team mutation should still succeed even if notification dispatch fails.
+
+---
+
+## Server Actions
+
+Location: `ui/features/notifications/actions.ts`
+
+All actions follow the thin wrapper pattern:
+
+```
+validate input (Zod) -> get authenticated client -> call service -> map to ActionResult -> revalidatePath
+```
+
+### Actions list
+
+| Action | Schema | Service function | Sentry area |
+|--------|--------|-----------------|-------------|
+| `listNotificationsAction` | `notificationsQuerySchema` | `listNotifications` | `notifications` |
+| `getUnreadCountAction` | — | `getUnreadCount` | `notifications` |
+| `markAsReadAction` | `markAsReadSchema` | `markAsRead` | `notifications` |
+| `markAllAsReadAction` | `markAllAsReadSchema` | `markAllAsRead` | `notifications` |
+| `getPreferencesAction` | — | `getPreferences` | `notifications` |
+| `updatePreferencesAction` | `updatePreferencesSchema` | `updatePreferences` | `notifications` |
+
+### Sentry instrumentation
+
+Every action wraps its body with `Sentry.withServerActionInstrumentation`. Non-validation errors call `captureActionError` with:
+- `actionName`: the action function name
+- `area`: `"notifications"`
+- `tenantId`, `userId`, `userRole` from auth context
+- `inputShape`: `Object.keys(parsed.data)` — NEVER values
+- `errorCode`: from `ServiceResult.code`
+
+---
+
+## Sentry area registration
+
+Add `notifications` to the `SentryArea` union in `ui/lib/sentry.ts`:
+
+```typescript
+export type SentryArea = "auth" | "billing" | "dashboard" | "notifications" | "resources" | "settings" | "team" | "webhook";
+```
+
+---
+
+## Email adapter
+
+### Interface
+
+Location: `packages/core/src/services/ports/notification-email-port.ts`
+
+```typescript
+export interface NotificationEmailPort {
+  sendNotificationEmail(params: {
+    to: string;
+    subject: string;
+    title: string;
+    body: string;
+    ctaUrl?: string;
+    ctaLabel?: string;
+  }): Promise<{ success: boolean; error?: string }>;
+}
+```
+
+### Implementations
+
+| Adapter | Location | Behavior | Selection |
+|---------|----------|----------|-----------|
+| `ConsoleNotificationEmailAdapter` | `packages/core/src/services/adapters/console-notification-email.ts` | Logs email content to `console.info` | Default when `RESEND_API_KEY` is not set |
+| `ResendNotificationEmailAdapter` | `packages/core/src/services/adapters/resend-notification-email.ts` | Sends via Resend API using a generic notification template | When `RESEND_API_KEY` is set |
+
+### Adapter factory
+
+```typescript
+// packages/core/src/services/adapters/notification-email-adapter-factory.ts
+
+export function createNotificationEmailAdapter(): NotificationEmailPort {
+  const resendKey = process.env["RESEND_API_KEY"];
+  if (resendKey) {
+    return new ResendNotificationEmailAdapter(resendKey);
+  }
+  return new ConsoleNotificationEmailAdapter();
+}
+```
+
+Selection is based on env var presence, NOT `NODE_ENV`.
+
+---
+
+## Realtime integration
+
+### Unread badge subscription
+
+The notification bell component subscribes to Supabase Realtime on the `notifications` table to receive live unread count updates.
+
+```typescript
+// ui/features/notifications/hooks/use-unread-count.ts
+
+// Subscribe to INSERT events on notifications table
+// Filter: user_id = current user, tenant_id = current tenant
+// On INSERT event: increment local unread count
+// On component unmount: unsubscribe
+
+const channel = supabase
+  .channel("notifications-badge")
+  .on(
+    "postgres_changes",
+    {
+      event: "INSERT",
+      schema: "public",
+      table: "notifications",
+      filter: `user_id=eq.${userId}`,
+    },
+    (payload) => {
+      setUnreadCount((prev) => prev + 1);
+    },
+  )
+  .subscribe();
+```
+
+### Realtime scope
+
+| Feature | Realtime | Polling | Rationale |
+|---------|----------|---------|-----------|
+| Unread badge count | Yes (INSERT events) | No | Immediate feedback on new notifications |
+| Notification list page | No | Manual refresh / revalidate | Pagination complexity; Realtime full-feed is follow-up |
+| Preference changes | No | N/A | Preference saves trigger server-side revalidation |
+
+### Realtime RLS
+
+Supabase Realtime respects RLS policies. The subscription only receives events for rows where the user's JWT satisfies the `notifications_select` policy. No additional filtering is needed beyond the channel filter.
+
+---
+
+## UI routes and components
+
+### Routes
+
+| Route | Component | Auth | Description |
+|-------|-----------|------|-------------|
+| `/notifications` | `NotificationsPage` | Required, owner/admin/member | Notification center with filters and pagination |
+| `/settings/notifications` | `NotificationPreferencesPage` | Required, owner/admin/member | Per-category preference toggles |
+
+### Feature module structure
+
+```
+ui/features/notifications/
++-- actions.ts                              # Server Actions (thin wrappers)
++-- queries.ts                              # Server-side data fetching
++-- types.ts                                # Feature-local types
++-- components/
+|   +-- notification-bell.tsx               # Header bell icon with unread badge
+|   +-- notification-list.tsx               # Paginated notification list
+|   +-- notification-item.tsx               # Single notification row
+|   +-- notification-filters.tsx            # Category and read-state filter bar
+|   +-- notification-empty-state.tsx        # Empty state illustrations
+|   +-- notification-preferences-form.tsx   # Per-category toggle grid
+|   +-- mark-all-read-button.tsx            # Bulk action button
++-- hooks/
+    +-- use-unread-count.ts                 # Supabase Realtime subscription hook
+```
+
+### App routes
+
+```
+ui/app/(protected)/notifications/
++-- page.tsx                                # Server Component — fetches data, passes to views
++-- error.tsx                               # Error boundary with Sentry
+
+ui/app/(protected)/settings/notifications/
++-- page.tsx                                # Server Component — preferences page
++-- error.tsx                               # Error boundary with Sentry
+```
+
+> Routes registered in `ui/lib/routes.ts`:
+> ```typescript
+> notifications: "/notifications",
+> notificationPreferences: "/settings/notifications",
+> ```
+
+---
+
+## Seed data
+
+Location: additions to `supabase/seed.sql`
+
+### Seed notifications
+
+```sql
+-- Unread team invitation notification for member user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000001',
+  '<demo_tenant_id>',
+  '<member_user_id>',
+  'team_invited', 'team',
+  'You were invited to join Demo Workspace',
+  'Admin User invited you as a member.',
+  '{"inviterId":"<admin_user_id>","role":"member"}',
+  false, 'tenant_member.invited', null,
+  now() - interval '2 hours'
+);
+
+-- Unread billing past_due notification for owner user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000002',
+  '<demo_tenant_id>',
+  '<owner_user_id>',
+  'billing_past_due', 'billing',
+  'Your subscription is past due',
+  'Update your payment method before the grace period ends.',
+  '{"graceEndsAt":"2026-06-15T00:00:00Z"}',
+  false, 'billing.subscription_past_due', null,
+  now() - interval '1 day'
+);
+
+-- Read billing upgrade notification for owner user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, read_at, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000003',
+  '<demo_tenant_id>',
+  '<owner_user_id>',
+  'billing_plan_upgraded', 'billing',
+  'Plan upgraded to Pro',
+  'Your plan has been upgraded from Free to Pro.',
+  '{"fromPlan":"free","toPlan":"pro"}',
+  true, now() - interval '2 days',
+  'billing.plan_upgraded', null,
+  now() - interval '3 days'
+);
+
+-- Read invitation accepted notification for admin user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, read_at, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000004',
+  '<demo_tenant_id>',
+  '<admin_user_id>',
+  'team_invitation_accepted', 'team',
+  'Member User accepted your invitation',
+  'Member User joined Demo Workspace as member.',
+  '{"acceptedByName":"Member User","role":"member"}',
+  true, now() - interval '5 days',
+  'tenant_invitation.accepted', null,
+  now() - interval '6 days'
+);
+
+-- Unread role changed notification for member user
+INSERT INTO public.notifications (
+  id, tenant_id, user_id, type, category,
+  title, body, metadata,
+  is_read, source_event, source_entity_id,
+  created_at
+) VALUES (
+  'c0000001-0000-0000-0000-000000000005',
+  '<demo_tenant_id>',
+  '<member_user_id>',
+  'team_role_changed', 'team',
+  'Your role was changed to admin',
+  'Owner User updated your role from member to admin.',
+  '{"previousRole":"member","newRole":"admin","changedBy":"<owner_user_id>"}',
+  false, 'tenant_member.role_changed', null,
+  now() - interval '12 hours'
+);
+```
+
+### Seed notification preferences
+
+```sql
+-- Member user has billing email disabled
+INSERT INTO public.notification_preferences (
+  id, user_id, tenant_id, category,
+  in_app_enabled, email_enabled,
+  created_at, updated_at
+) VALUES (
+  'c0000002-0000-0000-0000-000000000001',
+  '<member_user_id>',
+  '<demo_tenant_id>',
+  'billing',
+  true, false,
+  now(), now()
+);
+```
+
+> **Note**: `<demo_tenant_id>`, `<owner_user_id>`, `<admin_user_id>`, and `<member_user_id>` reference existing deterministic seed IDs from `seed.sql`.
+
+---
+
+## Testing strategy
+
+### Unit tests
+
+Location: `packages/core/src/services/__tests__/notification-service.test.ts`
+
+| Test | What it verifies |
+|------|------------------|
+| `listNotifications` returns user's notifications | Correct tenant+user scoping, pagination, ordering |
+| `listNotifications` with category filter | Only matching category returned |
+| `listNotifications` with isRead filter | Only read or unread returned |
+| `getUnreadCount` with mixed notifications | Correct count of unread only |
+| `getUnreadCount` with no notifications | Returns 0 |
+| `markAsRead` success | Sets `is_read = true`, `read_at` to now |
+| `markAsRead` already read | No-op, returns success |
+| `markAsRead` wrong user | Returns permission error |
+| `markAllAsRead` success | Updates all unread for user+tenant |
+| `markAllAsRead` no unread | Returns success with `updated: 0` |
+| `createNotification` non-critical, preferences allow | Creates notification in DB |
+| `createNotification` non-critical, in-app disabled | Does NOT create in-app notification |
+| `createNotification` critical type | Creates notification regardless of preferences |
+| `createNotification` with email channel | Calls email adapter |
+| `createNotification` email adapter fails | Notification still created; error logged to Sentry |
+| `createBulkNotifications` multiple recipients | Creates one notification per recipient |
+| `getPreferences` with existing rows | Returns saved preferences |
+| `getPreferences` with no rows | Returns defaults (all enabled) |
+| `updatePreferences` success | Upserts preference rows |
+
+### Contract tests
+
+Location: `packages/contracts/src/__tests__/notifications.test.ts`
+
+Test all schemas for valid input, boundary values, and rejection of invalid input.
+
+### E2E tests
+
+Location: `ui/e2e/notifications/notifications.spec.ts`
+
+| Test | Tag | Flow |
+|------|-----|------|
+| User sees notification bell with badge | `@critical` | Login as member -> verify bell shows unread count |
+| User opens notification center | `@critical` | Login as member -> click bell -> verify notification list |
+| User marks notification as read | `@critical` | Login as member -> click notification -> verify read state |
+| User marks all as read | | Login as member -> click "Mark all as read" -> verify badge gone |
+| User filters by category | | Login as member -> select "Team" filter -> verify only team notifications |
+| User filters by unread | | Login as member -> select "Unread" -> verify only unread shown |
+| User configures preferences | | Login as member -> navigate to preferences -> toggle billing email -> save -> verify |
+| Guest cannot see bell | `@critical` | Login as guest -> verify no notification bell in header |
+| Guest redirected from /notifications | | Login as guest -> navigate -> verify redirect to /dashboard |
+| Empty state renders correctly | | Login as clean user -> verify "No notifications yet" message |
+| Owner sees billing notifications | | Login as owner -> verify billing notifications in list |
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Notification dispatch model | Direct service calls | Event-driven (pub/sub, message queue) | Simpler for MVP; no infrastructure dependency; event-driven is follow-up |
+| Metadata storage | JSON string (`text`) | JSONB column | Consistent with billing pattern; parsed at service layer |
+| Preference default behavior | Missing row = enabled | Explicit rows for all categories on user creation | Less data, simpler onboarding; explicit rows only created when user changes defaults |
+| Realtime scope | Badge count only | Full feed realtime | Badge is the highest-value use case; full feed adds pagination complexity |
+| Email template | Generic notification template | Per-type custom templates | Fewer templates to maintain in MVP; per-type templates are follow-up |
+| Notification delivery | Non-blocking (try/catch in callers) | Transactional (fail parent if notification fails) | Notification failures must not break billing or team operations |
+| Schema file | New `notifications.ts` | Add to `platform.ts` | Separation of concerns; notifications schema grows independently |
+| Guest access | No notifications | Limited read-only | Consistent with guest permission model across all features |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Notification table grows unbounded | 90-day retention defined; cleanup cron is follow-up |
+| Realtime subscription leak (not unsubscribed) | Hook cleanup in `useEffect` return; unsubscribe on logout |
+| Email adapter outage blocks critical alerts | Adapter failure is non-blocking; audit event logged; Sentry captures error |
+| Preference bypass for critical events not enforced | `isCritical()` check is centralized and unit-tested |
+| Cross-tenant notification leak | RLS policies enforce `user_id = auth.uid()` AND `tenant_id` match |
+| Race condition: notification created after user removed | Non-blocking; orphaned notifications are harmless (no user to see them) |
+| Supabase Realtime connection limit exhaustion | One channel per authenticated user; unsubscribe on unmount |
+
+---
+
+## Implementation phases
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Contracts: Zod schemas and types in `@enterprise/contracts` | None |
+| 2 | Data model: `notifications.ts` Drizzle schema, enums, RLS policies, migration | Phase 1 |
+| 3 | Email adapter: `NotificationEmailPort` interface + `ConsoleNotificationEmailAdapter` + `ResendNotificationEmailAdapter` | Phase 1 |
+| 4 | Services: `notification-service.ts` + unit tests | Phases 1-3 |
+| 5 | Integration: wire `createNotification()` calls into `billing-service.ts` and `tenant-team-service.ts` | Phase 4 |
+| 6 | Server Actions + Sentry area registration | Phase 4 |
+| 7 | UI: notification center page, bell component, preferences page, route registration | Phase 6 |
+| 8 | Realtime: unread badge subscription hook + header integration | Phase 7 |
+| 9 | Seed data + E2E tests | Phase 7 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| New schema file or add to `platform.ts`? | New `notifications.ts` file | Separation of concerns; notification schema grows independently |
+| `metadata` as JSON string or JSONB? | JSON string (`text`) | Consistent with billing pattern (features, limits); parsed at service layer |
+| Direct dispatch or event-driven? | Direct service calls | No message queue dependency; event-driven is architectural follow-up |
+| Notification retention policy? | 90 days defined, no auto-cleanup in MVP | Sets expectation; cleanup cron job is follow-up |
+| Critical event handling? | Bypass preferences entirely | User safety: billing alerts and access changes must always reach the user |
+| Realtime for badge or full feed? | Badge count only | Highest value for lowest complexity; full feed Realtime is follow-up |
+| Guest notification access? | No access | Consistent with limited guest model; guests see no bell, no page |
+| Per-tenant or global preferences? | Per-tenant | User may work in multiple tenants with different notification needs |
+| Email template strategy? | Generic template | Fewer templates; per-type customization is follow-up |
+| Notification immutability? | Only `is_read` and `read_at` are mutable | Audit trail integrity; notifications are an immutable event log |
+| Preference default? | Missing row = all enabled | Reduces initial data; users only create preference rows when they customize |
+| Notification failure impact? | Non-blocking — parent operation succeeds | Billing upgrade should not fail because notification dispatch failed |
+
+---
+
+*Last updated: 2026-05-29*

--- a/packages/contracts/src/__tests__/notifications.test.ts
+++ b/packages/contracts/src/__tests__/notifications.test.ts
@@ -1,0 +1,443 @@
+import { describe, expect, it } from "vitest";
+import {
+  createNotificationSchema,
+  markAllAsReadSchema,
+  markAsReadSchema,
+  NOTIFICATION_CATEGORY,
+  NOTIFICATION_TYPE,
+  notificationCategorySchema,
+  notificationPreferenceSchema,
+  notificationSchema,
+  notificationsQuerySchema,
+  notificationTypeSchema,
+  unreadCountSchema,
+  updatePreferencesSchema,
+} from "../dto/notifications";
+
+// ============================================================================
+// notificationTypeSchema
+// ============================================================================
+
+describe("notificationTypeSchema", () => {
+  it("accepts all 9 valid notification types", () => {
+    const types = [
+      "team_invited",
+      "team_invitation_accepted",
+      "team_role_changed",
+      "team_removed",
+      "billing_past_due",
+      "billing_plan_upgraded",
+      "billing_plan_downgraded",
+      "billing_canceled",
+      "billing_activated",
+    ];
+
+    for (const type of types) {
+      const result = notificationTypeSchema.safeParse(type);
+      expect(result.success, `Expected ${type} to be valid`).toBe(true);
+    }
+  });
+
+  it("rejects an invalid type", () => {
+    const result = notificationTypeSchema.safeParse("sms_alert");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    const result = notificationTypeSchema.safeParse("");
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes all values via NOTIFICATION_TYPE const", () => {
+    expect(NOTIFICATION_TYPE.TEAM_INVITED).toBe("team_invited");
+    expect(NOTIFICATION_TYPE.TEAM_REMOVED).toBe("team_removed");
+    expect(NOTIFICATION_TYPE.BILLING_PAST_DUE).toBe("billing_past_due");
+    expect(NOTIFICATION_TYPE.BILLING_CANCELED).toBe("billing_canceled");
+    expect(NOTIFICATION_TYPE.BILLING_ACTIVATED).toBe("billing_activated");
+  });
+});
+
+// ============================================================================
+// notificationCategorySchema
+// ============================================================================
+
+describe("notificationCategorySchema", () => {
+  it("accepts 'team'", () => {
+    expect(notificationCategorySchema.safeParse("team").success).toBe(true);
+  });
+
+  it("accepts 'billing'", () => {
+    expect(notificationCategorySchema.safeParse("billing").success).toBe(true);
+  });
+
+  it("accepts 'system'", () => {
+    expect(notificationCategorySchema.safeParse("system").success).toBe(true);
+  });
+
+  it("rejects 'notifications'", () => {
+    expect(notificationCategorySchema.safeParse("notifications").success).toBe(false);
+  });
+
+  it("exposes all values via NOTIFICATION_CATEGORY const", () => {
+    expect(NOTIFICATION_CATEGORY.TEAM).toBe("team");
+    expect(NOTIFICATION_CATEGORY.BILLING).toBe("billing");
+    expect(NOTIFICATION_CATEGORY.SYSTEM).toBe("system");
+  });
+});
+
+// ============================================================================
+// notificationSchema
+// ============================================================================
+
+describe("notificationSchema", () => {
+  const validNotification = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    tenantId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    userId: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+    type: "team_invited" as const,
+    category: "team" as const,
+    title: "You were invited to join Acme",
+    body: "Admin invited you as a member.",
+    metadata: null,
+    isRead: false,
+    readAt: null,
+    sourceEvent: "tenant_member.invited",
+    sourceEntityId: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid notification", () => {
+    const result = notificationSchema.safeParse(validNotification);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null metadata", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, metadata: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts string metadata (JSON string)", () => {
+    const result = notificationSchema.safeParse({
+      ...validNotification,
+      metadata: '{"role":"member"}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null readAt", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, readAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null sourceEvent", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, sourceEvent: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null sourceEntityId", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, sourceEntityId: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid UUID for sourceEntityId", () => {
+    const result = notificationSchema.safeParse({
+      ...validNotification,
+      sourceEntityId: "d3eebc99-9c0b-4ef8-bb6d-6bb9bd380a44",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid UUID for id", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, id: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid type", () => {
+    const result = notificationSchema.safeParse({ ...validNotification, type: "unknown_event" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field 'title'", () => {
+    const { title: _title, ...withoutTitle } = validNotification;
+    const result = notificationSchema.safeParse(withoutTitle);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// notificationPreferenceSchema
+// ============================================================================
+
+describe("notificationPreferenceSchema", () => {
+  const validPreference = {
+    id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    userId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    tenantId: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+    category: "billing" as const,
+    inAppEnabled: true,
+    emailEnabled: false,
+  };
+
+  it("accepts a valid preference", () => {
+    const result = notificationPreferenceSchema.safeParse(validPreference);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid category", () => {
+    const result = notificationPreferenceSchema.safeParse({ ...validPreference, category: "sms" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-boolean inAppEnabled", () => {
+    const result = notificationPreferenceSchema.safeParse({
+      ...validPreference,
+      inAppEnabled: "true",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// unreadCountSchema
+// ============================================================================
+
+describe("unreadCountSchema", () => {
+  it("accepts count = 0", () => {
+    const result = unreadCountSchema.safeParse({ count: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts positive count", () => {
+    const result = unreadCountSchema.safeParse({ count: 42 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative count", () => {
+    const result = unreadCountSchema.safeParse({ count: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects float count", () => {
+    const result = unreadCountSchema.safeParse({ count: 1.5 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects string count", () => {
+    const result = unreadCountSchema.safeParse({ count: "5" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// markAsReadSchema
+// ============================================================================
+
+describe("markAsReadSchema", () => {
+  it("accepts a valid UUID notificationId", () => {
+    const result = markAsReadSchema.safeParse({
+      notificationId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-UUID notificationId", () => {
+    const result = markAsReadSchema.safeParse({ notificationId: "some-string" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing notificationId", () => {
+    const result = markAsReadSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// markAllAsReadSchema
+// ============================================================================
+
+describe("markAllAsReadSchema", () => {
+  it("accepts an empty object", () => {
+    const result = markAllAsReadSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts extra keys (strips them)", () => {
+    const result = markAllAsReadSchema.safeParse({ extra: "value" });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// updatePreferencesSchema
+// ============================================================================
+
+describe("updatePreferencesSchema", () => {
+  it("accepts a valid preferences array", () => {
+    const result = updatePreferencesSchema.safeParse({
+      preferences: [
+        { category: "billing", inAppEnabled: true, emailEnabled: false },
+        { category: "team", inAppEnabled: true, emailEnabled: true },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty preferences array", () => {
+    const result = updatePreferencesSchema.safeParse({ preferences: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects preferences with invalid category", () => {
+    const result = updatePreferencesSchema.safeParse({
+      preferences: [{ category: "push", inAppEnabled: true, emailEnabled: false }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing preferences field", () => {
+    const result = updatePreferencesSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// notificationsQuerySchema
+// ============================================================================
+
+describe("notificationsQuerySchema", () => {
+  it("applies default limit = 20 when not provided", () => {
+    const result = notificationsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it("applies default offset = 0 when not provided", () => {
+    const result = notificationsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it("accepts optional category filter", () => {
+    const result = notificationsQuerySchema.safeParse({ category: "billing" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.category).toBe("billing");
+    }
+  });
+
+  it("accepts optional isRead filter", () => {
+    const result = notificationsQuerySchema.safeParse({ isRead: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isRead).toBe(false);
+    }
+  });
+
+  it("accepts limit at boundary max (100)", () => {
+    const result = notificationsQuerySchema.safeParse({ limit: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects limit > 100", () => {
+    const result = notificationsQuerySchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit < 1", () => {
+    const result = notificationsQuerySchema.safeParse({ limit: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative offset", () => {
+    const result = notificationsQuerySchema.safeParse({ offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid category value", () => {
+    const result = notificationsQuerySchema.safeParse({ category: "email" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// createNotificationSchema
+// ============================================================================
+
+describe("createNotificationSchema", () => {
+  const validInput = {
+    tenantId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+    userId: "b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22",
+    type: "billing_past_due" as const,
+    category: "billing" as const,
+    title: "Payment past due",
+    body: "Please update your payment method.",
+    metadata: null,
+    sourceEvent: "billing.subscription_past_due",
+    sourceEntityId: null,
+  };
+
+  it("accepts a valid create notification input", () => {
+    const result = createNotificationSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional metadata as JSON string", () => {
+    const result = createNotificationSchema.safeParse({
+      ...validInput,
+      metadata: '{"graceEndsAt":"2026-06-15T00:00:00Z"}',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional sourceEntityId as UUID", () => {
+    const result = createNotificationSchema.safeParse({
+      ...validInput,
+      sourceEntityId: "c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a33",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects title shorter than 1 char", () => {
+    const result = createNotificationSchema.safeParse({ ...validInput, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects title longer than 200 chars", () => {
+    const result = createNotificationSchema.safeParse({
+      ...validInput,
+      title: "x".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects body longer than 1000 chars", () => {
+    const result = createNotificationSchema.safeParse({
+      ...validInput,
+      body: "x".repeat(1001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid type", () => {
+    const result = createNotificationSchema.safeParse({ ...validInput, type: "push_alert" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for sourceEntityId", () => {
+    const result = createNotificationSchema.safeParse({
+      ...validInput,
+      sourceEntityId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts input without optional fields", () => {
+    const { metadata: _m, sourceEvent: _se, sourceEntityId: _sei, ...minimal } = validInput;
+    const result = createNotificationSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/dto/notifications.ts
+++ b/packages/contracts/src/dto/notifications.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+// ============================================================================
+// Notification Type & Category — const objects + z.enum (contracts pattern)
+// ============================================================================
+
+export const NOTIFICATION_TYPE = {
+  TEAM_INVITED: "team_invited",
+  TEAM_INVITATION_ACCEPTED: "team_invitation_accepted",
+  TEAM_ROLE_CHANGED: "team_role_changed",
+  TEAM_REMOVED: "team_removed",
+  BILLING_PAST_DUE: "billing_past_due",
+  BILLING_PLAN_UPGRADED: "billing_plan_upgraded",
+  BILLING_PLAN_DOWNGRADED: "billing_plan_downgraded",
+  BILLING_CANCELED: "billing_canceled",
+  BILLING_ACTIVATED: "billing_activated",
+} as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPE)[keyof typeof NOTIFICATION_TYPE];
+
+export const notificationTypeSchema = z.enum([
+  "team_invited",
+  "team_invitation_accepted",
+  "team_role_changed",
+  "team_removed",
+  "billing_past_due",
+  "billing_plan_upgraded",
+  "billing_plan_downgraded",
+  "billing_canceled",
+  "billing_activated",
+]);
+
+export const NOTIFICATION_CATEGORY = {
+  TEAM: "team",
+  BILLING: "billing",
+  SYSTEM: "system",
+} as const;
+
+export type NotificationCategory =
+  (typeof NOTIFICATION_CATEGORY)[keyof typeof NOTIFICATION_CATEGORY];
+
+export const notificationCategorySchema = z.enum(["team", "billing", "system"]);
+
+// ============================================================================
+// Output Schemas
+// ============================================================================
+
+/** Notification display shape */
+export const notificationSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: notificationTypeSchema,
+  category: notificationCategorySchema,
+  title: z.string(),
+  body: z.string(),
+  metadata: z.string().nullable(),
+  isRead: z.boolean(),
+  readAt: z.string().datetime().nullable(),
+  sourceEvent: z.string().nullable(),
+  sourceEntityId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type NotificationDto = z.infer<typeof notificationSchema>;
+
+/** Notification preference display shape */
+export const notificationPreferenceSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  category: notificationCategorySchema,
+  inAppEnabled: z.boolean(),
+  emailEnabled: z.boolean(),
+});
+
+export type NotificationPreferenceDto = z.infer<typeof notificationPreferenceSchema>;
+
+/** Unread count shape */
+export const unreadCountSchema = z.object({
+  count: z.number().int().min(0),
+});
+
+export type UnreadCountDto = z.infer<typeof unreadCountSchema>;
+
+// ============================================================================
+// Input Schemas
+// ============================================================================
+
+/** Mark single notification as read */
+export const markAsReadSchema = z.object({
+  notificationId: z.string().uuid(),
+});
+
+export type MarkAsReadDto = z.infer<typeof markAsReadSchema>;
+
+/** Mark all as read (no input — uses auth context) */
+export const markAllAsReadSchema = z.object({});
+
+export type MarkAllAsReadDto = z.infer<typeof markAllAsReadSchema>;
+
+/** Update preferences */
+export const updatePreferencesSchema = z.object({
+  preferences: z.array(
+    z.object({
+      category: notificationCategorySchema,
+      inAppEnabled: z.boolean(),
+      emailEnabled: z.boolean(),
+    }),
+  ),
+});
+
+export type UpdatePreferencesDto = z.infer<typeof updatePreferencesSchema>;
+
+/** List notifications query */
+export const notificationsQuerySchema = z.object({
+  category: notificationCategorySchema.optional(),
+  isRead: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+export type NotificationsQueryDto = z.infer<typeof notificationsQuerySchema>;
+
+/** Create notification (internal — used by services, not exposed as Server Action) */
+export const createNotificationSchema = z.object({
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: notificationTypeSchema,
+  category: notificationCategorySchema,
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(1000),
+  metadata: z.string().nullable().optional(),
+  sourceEvent: z.string().nullable().optional(),
+  sourceEntityId: z.string().uuid().nullable().optional(),
+});
+
+export type CreateNotificationDto = z.infer<typeof createNotificationSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@
 // Re-export Zod for convenience
 export { z } from "zod";
 export * from "./dto/billing";
+export * from "./dto/notifications";
 // DTOs
 export * from "./dto/platform";
 export * from "./dto/resources";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "./services": "./src/services/index.ts",
     "./services/auth-service": "./src/services/auth-service.ts",
     "./services/billing-service": "./src/services/billing-service.ts",
+    "./services/notification-service": "./src/services/notification-service.ts",
     "./services/ports/payment-provider-port": "./src/services/ports/payment-provider-port.ts",
     "./services/adapters/payment-adapter-factory": "./src/services/adapters/payment-adapter-factory.ts"
   },

--- a/packages/core/src/services/__tests__/notification-service.test.ts
+++ b/packages/core/src/services/__tests__/notification-service.test.ts
@@ -1,0 +1,716 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBulkNotifications,
+  createNotification,
+  getPreferences,
+  getUnreadCount,
+  isCritical,
+  listNotifications,
+  markAllAsRead,
+  markAsRead,
+  updatePreferences,
+} from "../notification-service";
+import type { NotificationEmailPort } from "../ports/notification-email-port";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TENANT_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const USER_ID = "bbbbbbbb-0000-4000-8000-000000000001";
+const OTHER_USER_ID = "bbbbbbbb-0000-4000-8000-000000000099";
+const NOTIFICATION_ID = "cccccccc-0000-4000-8000-000000000001";
+
+const TEAM_NOTIFICATION_ROW = {
+  id: NOTIFICATION_ID,
+  tenant_id: TENANT_ID,
+  user_id: USER_ID,
+  type: "team_invited",
+  category: "team",
+  title: "You were invited",
+  body: "Admin invited you as a member.",
+  metadata: null,
+  is_read: false,
+  read_at: null,
+  source_event: "tenant_member.invited",
+  source_entity_id: null,
+  created_at: "2024-01-01T00:00:00.000Z",
+};
+
+const BILLING_NOTIFICATION_ROW = {
+  id: "cccccccc-0000-4000-8000-000000000002",
+  tenant_id: TENANT_ID,
+  user_id: USER_ID,
+  type: "billing_past_due",
+  category: "billing",
+  title: "Payment past due",
+  body: "Update your payment method.",
+  metadata: null,
+  is_read: false,
+  read_at: null,
+  source_event: "billing.subscription_past_due",
+  source_entity_id: null,
+  created_at: "2024-01-02T00:00:00.000Z",
+};
+
+const READ_NOTIFICATION_ROW = {
+  ...TEAM_NOTIFICATION_ROW,
+  id: "cccccccc-0000-4000-8000-000000000003",
+  is_read: true,
+  read_at: "2024-01-01T12:00:00.000Z",
+};
+
+const PREFERENCE_ROW = {
+  id: "dddddddd-0000-4000-8000-000000000001",
+  user_id: USER_ID,
+  tenant_id: TENANT_ID,
+  category: "team",
+  in_app_enabled: true,
+  email_enabled: false,
+};
+
+// ─── Mock Builder ─────────────────────────────────────────────────────────────
+
+function buildMockClientWithSequence(responses: Array<{ data: unknown; error: unknown }>): {
+  client: SupabaseClient;
+  callCount: () => number;
+} {
+  let idx = 0;
+  const getResponse = () => responses[Math.min(idx++, responses.length - 1)];
+
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    single: vi.fn().mockImplementation(() => Promise.resolve(getResponse())),
+    maybeSingle: vi.fn().mockImplementation(() => Promise.resolve(getResponse())),
+  };
+
+  const client = {
+    from: vi.fn().mockReturnValue(chain),
+    _chain: chain,
+  } as unknown as SupabaseClient;
+
+  return { client, callCount: () => idx };
+}
+
+function buildMockAdapter(result: { success: boolean; error?: string }): NotificationEmailPort {
+  return {
+    sendNotificationEmail: vi.fn().mockResolvedValue(result),
+  };
+}
+
+// ─── isCritical ───────────────────────────────────────────────────────────────
+
+describe("isCritical", () => {
+  it("returns true for billing_past_due", () => {
+    expect(isCritical("billing_past_due")).toBe(true);
+  });
+
+  it("returns true for billing_canceled", () => {
+    expect(isCritical("billing_canceled")).toBe(true);
+  });
+
+  it("returns true for team_invited", () => {
+    expect(isCritical("team_invited")).toBe(true);
+  });
+
+  it("returns true for team_removed", () => {
+    expect(isCritical("team_removed")).toBe(true);
+  });
+
+  it("returns false for billing_plan_upgraded", () => {
+    expect(isCritical("billing_plan_upgraded")).toBe(false);
+  });
+
+  it("returns false for team_role_changed", () => {
+    expect(isCritical("team_role_changed")).toBe(false);
+  });
+});
+
+// ─── listNotifications mock ───────────────────────────────────────────────────
+
+/**
+ * Build a mock for listNotifications which uses .select().eq().eq().order().range()
+ * The last method in the chain is range() which must return the promise.
+ */
+function buildListMockClient(resolveWith: { data: unknown; error: unknown }): SupabaseClient {
+  // listNotifications uses: .select().eq().eq()[.eq()][.eq()].order().range()
+  // All chainable methods must return the same object, and range() returns the promise
+  const chain: Record<string, unknown> = {};
+  chain["select"] = vi.fn().mockReturnValue(chain);
+  chain["eq"] = vi.fn().mockReturnValue(chain);
+  chain["order"] = vi.fn().mockReturnValue(chain);
+  chain["range"] = vi.fn().mockResolvedValue(resolveWith);
+  return { from: vi.fn().mockReturnValue(chain) } as unknown as SupabaseClient;
+}
+
+// ─── listNotifications ────────────────────────────────────────────────────────
+
+describe("listNotifications", () => {
+  it("returns user notifications scoped to tenant (basic pagination)", async () => {
+    const rows = [TEAM_NOTIFICATION_ROW, BILLING_NOTIFICATION_ROW];
+    const client = buildListMockClient({ data: rows, error: null });
+
+    const result = await listNotifications(client, TENANT_ID, USER_ID, {
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]?.tenantId).toBe(TENANT_ID);
+    expect(result.data[0]?.userId).toBe(USER_ID);
+  });
+
+  it("returns only billing category when category filter is applied", async () => {
+    const rows = [BILLING_NOTIFICATION_ROW];
+    const client = buildListMockClient({ data: rows, error: null });
+
+    const result = await listNotifications(client, TENANT_ID, USER_ID, {
+      limit: 20,
+      offset: 0,
+      category: "billing",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.category).toBe("billing");
+  });
+
+  it("returns only unread when isRead=false filter is applied", async () => {
+    const rows = [TEAM_NOTIFICATION_ROW, BILLING_NOTIFICATION_ROW];
+    const client = buildListMockClient({ data: rows, error: null });
+
+    const result = await listNotifications(client, TENANT_ID, USER_ID, {
+      limit: 20,
+      offset: 0,
+      isRead: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.every((n) => !n.isRead)).toBe(true);
+  });
+
+  it("returns error when query fails", async () => {
+    const client = buildListMockClient({ data: null, error: { message: "DB error" } });
+
+    const result = await listNotifications(client, TENANT_ID, USER_ID, {
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe("NOTIFICATIONS_LIST_FAILED");
+  });
+});
+
+// ─── getUnreadCount mock helper ───────────────────────────────────────────────
+
+/**
+ * Build a mock for getUnreadCount which uses .select("*", {count:"exact",head:true}).eq().eq().eq()
+ * The third eq() is the last — returns the promise with { count, error }.
+ */
+function buildCountMockClient(count: number | null): SupabaseClient {
+  let eqCalls = 0;
+  const chain: Record<string, unknown> = {};
+  chain["select"] = vi.fn().mockReturnValue(chain);
+  chain["eq"] = vi.fn().mockImplementation(() => {
+    eqCalls++;
+    if (eqCalls >= 3) {
+      return Promise.resolve({ count, error: null });
+    }
+    return chain;
+  });
+  return { from: vi.fn().mockReturnValue(chain) } as unknown as SupabaseClient;
+}
+
+// ─── getUnreadCount ───────────────────────────────────────────────────────────
+
+describe("getUnreadCount", () => {
+  it("returns correct count of unread notifications", async () => {
+    const client = buildCountMockClient(3);
+
+    const result = await getUnreadCount(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.count).toBe(3);
+  });
+
+  it("returns count = 0 when no unread notifications exist", async () => {
+    const client = buildCountMockClient(0);
+
+    const result = await getUnreadCount(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.count).toBe(0);
+  });
+});
+
+// ─── markAsRead ───────────────────────────────────────────────────────────────
+
+describe("markAsRead", () => {
+  it("marks a notification as read successfully", async () => {
+    const { client } = buildMockClientWithSequence([
+      { data: TEAM_NOTIFICATION_ROW, error: null }, // fetch check
+      { data: null, error: null }, // update
+    ]);
+
+    const result = await markAsRead(client, TENANT_ID, USER_ID, NOTIFICATION_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toBeNull();
+  });
+
+  it("returns success (no-op) when notification is already read", async () => {
+    const { client } = buildMockClientWithSequence([
+      { data: READ_NOTIFICATION_ROW, error: null }, // already read
+    ]);
+
+    const result = await markAsRead(client, TENANT_ID, USER_ID, NOTIFICATION_ID);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns error when notification belongs to another user", async () => {
+    const { client } = buildMockClientWithSequence([
+      { data: null, error: null }, // not found for this user
+    ]);
+
+    const result = await markAsRead(client, TENANT_ID, OTHER_USER_ID, NOTIFICATION_ID);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe("NOTIFICATION_NOT_FOUND");
+  });
+});
+
+// ─── markAllAsRead ────────────────────────────────────────────────────────────
+
+describe("markAllAsRead", () => {
+  it("marks all unread notifications and returns updated count", async () => {
+    const rows = [TEAM_NOTIFICATION_ROW, BILLING_NOTIFICATION_ROW];
+    const chain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    };
+
+    const client = {
+      from: vi.fn().mockReturnValue(chain),
+    } as unknown as SupabaseClient;
+
+    const result = await markAllAsRead(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.updated).toBe(2);
+  });
+
+  it("returns updated = 0 when no unread notifications exist", async () => {
+    const chain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+
+    const client = {
+      from: vi.fn().mockReturnValue(chain),
+    } as unknown as SupabaseClient;
+
+    const result = await markAllAsRead(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.updated).toBe(0);
+  });
+});
+
+// ─── createNotification ───────────────────────────────────────────────────────
+
+describe("createNotification", () => {
+  const baseInput = {
+    tenantId: TENANT_ID,
+    userId: USER_ID,
+    type: "billing_plan_upgraded" as const,
+    category: "billing" as const,
+    title: "Plan upgraded",
+    body: "Your plan was upgraded to Pro.",
+    metadata: null,
+  };
+
+  it("creates notification when non-critical and preferences allow in-app", async () => {
+    // Sequence: getPreferenceForCategory (maybeSingle → null = default enabled), then insert
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      maybeSingle: vi
+        .fn()
+        .mockResolvedValueOnce({ data: null, error: null }) // pref check: no row = default enabled
+        .mockResolvedValueOnce({ data: BILLING_NOTIFICATION_ROW, error: null }), // audit_log
+    };
+    chain.select.mockReturnThis();
+    chain.insert.mockReturnThis();
+
+    // For insert().select().single()
+    const insertChain = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: BILLING_NOTIFICATION_ROW, error: null }),
+    };
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // notification_preferences query
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      if (callIndex === 2) {
+        // notifications insert
+        return {
+          insert: vi.fn().mockReturnValue(insertChain),
+        };
+      }
+      // audit_log
+      return {
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createNotification(adminClient, baseInput);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("does NOT create in-app notification when preferences disable in_app", async () => {
+    const disabledPref = { in_app_enabled: false, email_enabled: false };
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // preference check → in_app disabled
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: disabledPref, error: null }),
+        };
+      }
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createNotification(adminClient, baseInput);
+
+    // Returns success but with empty id (no DB row)
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.id).toBe("");
+    // Should not have called insert (callIndex would only be 1 from pref check)
+    expect(callIndex).toBe(1);
+  });
+
+  it("creates notification for critical type regardless of preferences", async () => {
+    const criticalInput = {
+      ...baseInput,
+      type: "billing_past_due" as const,
+      category: "billing" as const,
+    };
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // notifications insert
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: BILLING_NOTIFICATION_ROW, error: null }),
+          }),
+        };
+      }
+      // audit_log
+      return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createNotification(adminClient, criticalInput);
+
+    expect(result.success).toBe(true);
+    // No preference check should have happened (critical bypass)
+    // First call goes straight to notifications insert, not preference lookup
+    expect(callIndex).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls email adapter when notification type requires email", async () => {
+    const emailAdapter = buildMockAdapter({ success: true });
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // preference check (for in-app)
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      if (callIndex === 2) {
+        // insert notification
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: BILLING_NOTIFICATION_ROW, error: null }),
+          }),
+        };
+      }
+      // audit_log or email preference check
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createNotification(
+      adminClient,
+      baseInput,
+      emailAdapter,
+      "user@example.com",
+    );
+
+    expect(result.success).toBe(true);
+    // Email adapter should have been called (it's non-blocking, so we need to wait)
+    await new Promise((r) => setTimeout(r, 10));
+    expect(emailAdapter.sendNotificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user@example.com",
+        subject: baseInput.title,
+      }),
+    );
+  });
+
+  it("creates notification even when email adapter fails", async () => {
+    const emailAdapter = buildMockAdapter({ success: false, error: "SMTP timeout" });
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      if (callIndex === 2) {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: BILLING_NOTIFICATION_ROW, error: null }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createNotification(
+      adminClient,
+      baseInput,
+      emailAdapter,
+      "user@example.com",
+    );
+
+    // Notification must be created even if email fails
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── createBulkNotifications ──────────────────────────────────────────────────
+
+describe("createBulkNotifications", () => {
+  it("creates one notification per recipient", async () => {
+    const inputs = [
+      {
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        type: "billing_past_due" as const,
+        category: "billing" as const,
+        title: "Payment past due",
+        body: "Update your payment method.",
+        metadata: null,
+      },
+      {
+        tenantId: TENANT_ID,
+        userId: OTHER_USER_ID,
+        type: "billing_past_due" as const,
+        category: "billing" as const,
+        title: "Payment past due",
+        body: "Update your payment method.",
+        metadata: null,
+      },
+    ];
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      // For critical types, no pref check — go straight to insert
+      if (callIndex % 2 === 1) {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: BILLING_NOTIFICATION_ROW, error: null }),
+          }),
+        };
+      }
+      // audit_log
+      return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+
+    const adminClient = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await createBulkNotifications(adminClient, inputs);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(2);
+  });
+});
+
+// ─── getPreferences mock helper ───────────────────────────────────────────────
+
+/**
+ * Build a mock for getPreferences which uses .select().eq(tenant).eq(user).
+ * The second eq() call returns the awaitable result.
+ */
+function buildPrefMockClient(resolveWith: { data: unknown; error: unknown }): SupabaseClient {
+  let eqCalls = 0;
+  const chain: Record<string, unknown> = {};
+  chain["select"] = vi.fn().mockReturnValue(chain);
+  chain["eq"] = vi.fn().mockImplementation(() => {
+    eqCalls++;
+    // The second eq call is the last one — return the promise
+    if (eqCalls >= 2) {
+      return Promise.resolve(resolveWith);
+    }
+    return chain;
+  });
+  return { from: vi.fn().mockReturnValue(chain) } as unknown as SupabaseClient;
+}
+
+// ─── getPreferences ───────────────────────────────────────────────────────────
+
+describe("getPreferences", () => {
+  it("returns saved preferences when rows exist", async () => {
+    const client = buildPrefMockClient({ data: [PREFERENCE_ROW], error: null });
+
+    const result = await getPreferences(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // At least the one saved row + defaults for missing categories
+    expect(result.data.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns defaults (all enabled) when no preference rows exist", async () => {
+    const client = buildPrefMockClient({ data: [], error: null });
+
+    const result = await getPreferences(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // All 3 categories with defaults
+    expect(result.data).toHaveLength(3);
+    expect(result.data.every((p) => p.inAppEnabled && p.emailEnabled)).toBe(true);
+  });
+});
+
+// ─── updatePreferences ────────────────────────────────────────────────────────
+
+describe("updatePreferences", () => {
+  it("upserts preference rows and returns updated preferences", async () => {
+    const updatedRows = [{ ...PREFERENCE_ROW, in_app_enabled: true, email_enabled: false }];
+
+    let callIndex = 0;
+    const fromMock = vi.fn().mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // upsert notification_preferences
+        return {
+          upsert: vi.fn().mockReturnValue({
+            select: vi.fn().mockResolvedValue({ data: updatedRows, error: null }),
+          }),
+        };
+      }
+      // audit_log
+      return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+
+    const client = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await updatePreferences(client, TENANT_ID, USER_ID, {
+      preferences: [{ category: "team", inAppEnabled: true, emailEnabled: false }],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.category).toBe("team");
+  });
+
+  it("returns error when upsert fails", async () => {
+    const fromMock = vi.fn().mockReturnValue({
+      upsert: vi.fn().mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ data: null, error: { message: "Constraint violation" } }),
+      }),
+    });
+
+    const client = { from: fromMock } as unknown as SupabaseClient;
+
+    const result = await updatePreferences(client, TENANT_ID, USER_ID, {
+      preferences: [{ category: "billing", inAppEnabled: false, emailEnabled: false }],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.code).toBe("PREFERENCES_UPDATE_FAILED");
+  });
+});

--- a/packages/core/src/services/adapters/console-notification-email.ts
+++ b/packages/core/src/services/adapters/console-notification-email.ts
@@ -1,0 +1,31 @@
+// Console adapter for notification emails (development use)
+// Logs notification email details to stdout — no external HTTP calls made
+
+import type {
+  NotificationEmailParams,
+  NotificationEmailPort,
+} from "../ports/notification-email-port";
+
+export class ConsoleNotificationEmailAdapter implements NotificationEmailPort {
+  async sendNotificationEmail(
+    params: NotificationEmailParams,
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      console.info("[ConsoleNotificationEmailAdapter] Notification email:");
+      console.info(`  To:      ${params.to}`);
+      console.info(`  Subject: ${params.subject}`);
+      console.info(`  Title:   ${params.title}`);
+      console.info(`  Body:    ${params.body}`);
+      if (params.ctaUrl) {
+        console.info(`  CTA URL: ${params.ctaUrl}`);
+      }
+      if (params.ctaLabel) {
+        console.info(`  CTA Label: ${params.ctaLabel}`);
+      }
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return { success: false, error: message };
+    }
+  }
+}

--- a/packages/core/src/services/adapters/notification-email-adapter-factory.ts
+++ b/packages/core/src/services/adapters/notification-email-adapter-factory.ts
@@ -1,0 +1,26 @@
+// Notification email adapter factory — selects the correct adapter based on env var presence
+// RESEND_API_KEY present → ResendNotificationEmailAdapter; absent → ConsoleNotificationEmailAdapter
+// Adapter is singleton-cached per process (serverless-safe — each cold start gets fresh selection)
+
+import type { NotificationEmailPort } from "../ports/notification-email-port";
+import { ConsoleNotificationEmailAdapter } from "./console-notification-email";
+import { ResendNotificationEmailAdapter } from "./resend-notification-email";
+
+let cachedAdapter: NotificationEmailPort | null = null;
+
+/**
+ * Returns the appropriate notification email adapter based on env var presence.
+ * Selection is based on RESEND_API_KEY, NOT NODE_ENV.
+ * Cached per process — multiple calls return the same instance.
+ */
+export function createNotificationEmailAdapter(): NotificationEmailPort {
+  if (cachedAdapter) return cachedAdapter;
+
+  const resendKey = process.env["RESEND_API_KEY"];
+
+  cachedAdapter = resendKey
+    ? new ResendNotificationEmailAdapter(resendKey)
+    : new ConsoleNotificationEmailAdapter();
+
+  return cachedAdapter;
+}

--- a/packages/core/src/services/adapters/resend-notification-email.ts
+++ b/packages/core/src/services/adapters/resend-notification-email.ts
@@ -1,0 +1,78 @@
+// Resend adapter for notification emails (production use)
+// Requires RESEND_API_KEY and RESEND_FROM_EMAIL env vars
+
+import type {
+  NotificationEmailParams,
+  NotificationEmailPort,
+} from "../ports/notification-email-port";
+
+export class ResendNotificationEmailAdapter implements NotificationEmailPort {
+  private readonly apiKey: string;
+  private readonly fromEmail: string;
+
+  constructor(apiKey?: string, fromEmail?: string) {
+    this.apiKey = apiKey ?? process.env["RESEND_API_KEY"] ?? "";
+    this.fromEmail = fromEmail ?? process.env["RESEND_FROM_EMAIL"] ?? "noreply@example.com";
+  }
+
+  async sendNotificationEmail(
+    params: NotificationEmailParams,
+  ): Promise<{ success: boolean; error?: string }> {
+    if (!this.apiKey) {
+      return { success: false, error: "RESEND_API_KEY is not configured" };
+    }
+
+    try {
+      const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: this.fromEmail,
+          to: params.to,
+          subject: params.subject,
+          html: buildNotificationEmailHtml(params),
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        return { success: false, error: `Resend API error ${response.status}: ${body}` };
+      }
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return { success: false, error: message };
+    }
+  }
+}
+
+function buildNotificationEmailHtml(params: NotificationEmailParams): string {
+  const ctaSection = params.ctaUrl
+    ? `
+    <p style="margin: 24px 0;">
+      <a href="${params.ctaUrl}"
+         style="background: #0f172a; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+        ${params.ctaLabel ?? "View Details"}
+      </a>
+    </p>`
+    : "";
+
+  return `
+<!DOCTYPE html>
+<html>
+  <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 24px;">
+    <h2>${params.title}</h2>
+    <p>${params.body}</p>
+    ${ctaSection}
+    <p style="color: #64748b; font-size: 14px;">
+      You are receiving this notification because you have notifications enabled for this category.
+      You can manage your notification preferences in your account settings.
+    </p>
+  </body>
+</html>
+  `.trim();
+}

--- a/packages/core/src/services/billing-service.ts
+++ b/packages/core/src/services/billing-service.ts
@@ -9,7 +9,9 @@ import type {
   ChangePlanDto,
 } from "@enterprise/contracts";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createNotificationEmailAdapter } from "./adapters/notification-email-adapter-factory";
 import type { ServiceResult } from "./auth-service";
+import { createBulkNotifications, createNotification } from "./notification-service";
 import type { PaymentProviderPort } from "./ports/payment-provider-port";
 
 // ─── Service-Layer Types ──────────────────────────────────────────────────────
@@ -397,6 +399,28 @@ export async function changePlan(
     initiatedBy: userId,
   });
 
+  // 9. Dispatch notification (non-blocking)
+  const notificationType = isUpgrade ? "billing_plan_upgraded" : "billing_plan_downgraded";
+  createNotification(
+    adminClient,
+    {
+      tenantId,
+      userId,
+      type: notificationType,
+      category: "billing",
+      title: isUpgrade ? "Plan upgraded" : "Plan downgraded",
+      body: isUpgrade
+        ? "Your subscription plan has been upgraded."
+        : "Your subscription plan has been downgraded.",
+      metadata: JSON.stringify({ fromPlanId: oldPlanId, toPlanId: input.planId }),
+      sourceEvent: auditEvent,
+      sourceEntityId: sub["id"] as string,
+    },
+    createNotificationEmailAdapter(),
+  ).catch((notifError) => {
+    console.error("[billing] changePlan: notification dispatch failed:", notifError);
+  });
+
   return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
 }
 
@@ -503,6 +527,44 @@ export async function cancelSubscription(
     },
   );
 
+  // 7. Dispatch notification to owner + admins (non-blocking)
+  try {
+    const { data: recipients } = await adminClient
+      .from("profiles")
+      .select("id, email")
+      .eq("tenant_id", tenantId)
+      .in("role", ["owner", "admin"]);
+
+    const recipientRows = (recipients ?? []) as Array<Record<string, unknown>>;
+    const inputs = recipientRows.map((r) => ({
+      tenantId,
+      userId: r["id"] as string,
+      type: "billing_canceled" as const,
+      category: "billing" as const,
+      title: "Subscription canceled",
+      body: "Your subscription has been canceled.",
+      sourceEvent: "billing.subscription_canceled",
+      sourceEntityId: sub["id"] as string,
+    }));
+    const emailMap: Record<string, string> = {};
+    for (const r of recipientRows) {
+      emailMap[r["id"] as string] = r["email"] as string;
+    }
+
+    if (inputs.length > 0) {
+      createBulkNotifications(
+        adminClient,
+        inputs,
+        createNotificationEmailAdapter(),
+        emailMap,
+      ).catch((notifError) => {
+        console.error("[billing] cancelSubscription: notification dispatch failed:", notifError);
+      });
+    }
+  } catch (notifError) {
+    console.error("[billing] cancelSubscription: notification dispatch failed:", notifError);
+  }
+
   return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
 }
 
@@ -593,6 +655,44 @@ export async function resumeSubscription(
       initiatedBy: userId,
     },
   );
+
+  // 6. Dispatch notification to owner + admins (non-blocking)
+  try {
+    const { data: recipients } = await adminClient
+      .from("profiles")
+      .select("id, email")
+      .eq("tenant_id", tenantId)
+      .in("role", ["owner", "admin"]);
+
+    const recipientRows = (recipients ?? []) as Array<Record<string, unknown>>;
+    const inputs = recipientRows.map((r) => ({
+      tenantId,
+      userId: r["id"] as string,
+      type: "billing_activated" as const,
+      category: "billing" as const,
+      title: "Subscription reactivated",
+      body: "Your subscription has been reactivated.",
+      sourceEvent: "billing.subscription_reactivated",
+      sourceEntityId: sub["id"] as string,
+    }));
+    const emailMap: Record<string, string> = {};
+    for (const r of recipientRows) {
+      emailMap[r["id"] as string] = r["email"] as string;
+    }
+
+    if (inputs.length > 0) {
+      createBulkNotifications(
+        adminClient,
+        inputs,
+        createNotificationEmailAdapter(),
+        emailMap,
+      ).catch((notifError) => {
+        console.error("[billing] resumeSubscription: notification dispatch failed:", notifError);
+      });
+    }
+  } catch (notifError) {
+    console.error("[billing] resumeSubscription: notification dispatch failed:", notifError);
+  }
 
   return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };
 }
@@ -779,6 +879,93 @@ async function syncSubscriptionState(
   const auditEvent = data.status ? statusAuditMap[data.status] : undefined;
   if (auditEvent) {
     void writeAuditLog(adminClient, tenantId, systemUserId, auditEvent, updatedSub["id"] as string);
+  }
+
+  // Dispatch notifications based on status transition (non-blocking)
+  if (data.status === "past_due" || data.status === "active" || data.status === "canceled") {
+    try {
+      const { data: recipients } = await adminClient
+        .from("profiles")
+        .select("id, email, role")
+        .eq("tenant_id", tenantId)
+        .in("role", ["owner", "admin"]);
+
+      const recipientRows = (recipients ?? []) as Array<Record<string, unknown>>;
+      const emailMap: Record<string, string> = {};
+      for (const r of recipientRows) {
+        emailMap[r["id"] as string] = r["email"] as string;
+      }
+
+      let notifInputs: Array<{
+        tenantId: string;
+        userId: string;
+        type: "billing_past_due" | "billing_activated" | "billing_canceled";
+        category: "billing";
+        title: string;
+        body: string;
+        sourceEvent: string;
+        sourceEntityId?: string;
+      }> = [];
+
+      if (data.status === "past_due") {
+        // All owners + admins
+        notifInputs = recipientRows.map((r) => ({
+          tenantId,
+          userId: r["id"] as string,
+          type: "billing_past_due" as const,
+          category: "billing" as const,
+          title: "Payment past due",
+          body: "Your subscription payment is past due. Please update your payment method.",
+          sourceEvent: "billing.subscription_past_due",
+          sourceEntityId: updatedSub["id"] as string,
+        }));
+      } else if (data.status === "active") {
+        // Owner only (first owner found)
+        const owner = recipientRows.find((r) => r["role"] === "owner");
+        if (owner) {
+          notifInputs = [
+            {
+              tenantId,
+              userId: owner["id"] as string,
+              type: "billing_activated" as const,
+              category: "billing" as const,
+              title: "Subscription activated",
+              body: "Your subscription is now active.",
+              sourceEvent: "billing.subscription_activated",
+              sourceEntityId: updatedSub["id"] as string,
+            },
+          ];
+        }
+      } else if (data.status === "canceled") {
+        // All owners + admins
+        notifInputs = recipientRows.map((r) => ({
+          tenantId,
+          userId: r["id"] as string,
+          type: "billing_canceled" as const,
+          category: "billing" as const,
+          title: "Subscription canceled",
+          body: "Your subscription has been canceled.",
+          sourceEvent: "billing.subscription_expired",
+          sourceEntityId: updatedSub["id"] as string,
+        }));
+      }
+
+      if (notifInputs.length > 0) {
+        createBulkNotifications(
+          adminClient,
+          notifInputs,
+          createNotificationEmailAdapter(),
+          emailMap,
+        ).catch((notifError) => {
+          console.error(
+            "[billing] syncSubscriptionState: notification dispatch failed:",
+            notifError,
+          );
+        });
+      }
+    } catch (notifError) {
+      console.error("[billing] syncSubscriptionState: notification dispatch failed:", notifError);
+    }
   }
 
   return { success: true, data: mapSubscriptionRow(updatedSub as SubscriptionRow) };

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -5,6 +5,7 @@ export { ConsoleInvitationEmailAdapter } from "./adapters/console-invitation-ema
 export { ResendInvitationEmailAdapter } from "./adapters/resend-invitation-email-adapter";
 export * from "./auth-service";
 export * from "./billing-service";
+export * from "./notification-service";
 export type { InvitationEmailParams, InvitationEmailPort } from "./ports/invitation-email-port";
 export * from "./resource-service";
 export * from "./tenant-team-service";

--- a/packages/core/src/services/notification-service.ts
+++ b/packages/core/src/services/notification-service.ts
@@ -1,0 +1,584 @@
+// Notification Service
+// Handles in-app notification creation, listing, mark-as-read, and preference management
+// Reads use authenticated client (RLS scoped); INSERTs use adminClient (service_role)
+
+import type {
+  CreateNotificationDto,
+  NotificationsQueryDto,
+  NotificationType,
+  UpdatePreferencesDto,
+} from "@enterprise/contracts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ServiceResult } from "./auth-service";
+import type { NotificationEmailPort } from "./ports/notification-email-port";
+
+// ─── Service-Layer Types ──────────────────────────────────────────────────────
+// ISO string timestamps (matching Supabase JS client response format)
+
+export interface NotificationRecord {
+  id: string;
+  tenantId: string;
+  userId: string;
+  type: NotificationType;
+  category: "team" | "billing" | "system";
+  title: string;
+  body: string;
+  metadata: string | null;
+  isRead: boolean;
+  readAt: string | null;
+  sourceEvent: string | null;
+  sourceEntityId: string | null;
+  createdAt: string;
+}
+
+export interface NotificationPreferenceRecord {
+  id: string;
+  userId: string;
+  tenantId: string;
+  category: "team" | "billing" | "system";
+  inAppEnabled: boolean;
+  emailEnabled: boolean;
+}
+
+// ─── Critical Types ───────────────────────────────────────────────────────────
+
+/** Critical event types bypass user preferences and always deliver to all channels */
+const CRITICAL_TYPES: NotificationType[] = [
+  "billing_past_due",
+  "billing_canceled",
+  "team_invited",
+  "team_removed",
+];
+
+export function isCritical(type: NotificationType): boolean {
+  return CRITICAL_TYPES.includes(type);
+}
+
+// ─── Email Channel Strategy ───────────────────────────────────────────────────
+
+/** Notification types that trigger email delivery (in addition to in-app) */
+const EMAIL_TYPES: NotificationType[] = [
+  "team_invited",
+  "team_removed",
+  "billing_past_due",
+  "billing_canceled",
+  "billing_plan_upgraded",
+  "billing_plan_downgraded",
+  "billing_activated",
+  "team_invitation_accepted",
+  "team_role_changed",
+];
+
+function requiresEmail(type: NotificationType): boolean {
+  return EMAIL_TYPES.includes(type);
+}
+
+// ─── Row Mapper ───────────────────────────────────────────────────────────────
+
+type NotificationRow = Record<string, unknown>;
+type PreferenceRow = Record<string, unknown>;
+
+function mapNotificationRow(row: NotificationRow): NotificationRecord {
+  return {
+    id: row["id"] as string,
+    tenantId: row["tenant_id"] as string,
+    userId: row["user_id"] as string,
+    type: row["type"] as NotificationType,
+    category: row["category"] as NotificationRecord["category"],
+    title: row["title"] as string,
+    body: row["body"] as string,
+    metadata: (row["metadata"] as string | null) ?? null,
+    isRead: row["is_read"] as boolean,
+    readAt: (row["read_at"] as string | null) ?? null,
+    sourceEvent: (row["source_event"] as string | null) ?? null,
+    sourceEntityId: (row["source_entity_id"] as string | null) ?? null,
+    createdAt: row["created_at"] as string,
+  };
+}
+
+function mapPreferenceRow(row: PreferenceRow): NotificationPreferenceRecord {
+  return {
+    id: row["id"] as string,
+    userId: row["user_id"] as string,
+    tenantId: row["tenant_id"] as string,
+    category: row["category"] as NotificationPreferenceRecord["category"],
+    inAppEnabled: row["in_app_enabled"] as boolean,
+    emailEnabled: row["email_enabled"] as boolean,
+  };
+}
+
+// ─── Default Preference Helper ────────────────────────────────────────────────
+
+const ALL_CATEGORIES: NotificationPreferenceRecord["category"][] = ["team", "billing", "system"];
+
+function buildDefaultPreferences(userId: string, tenantId: string): NotificationPreferenceRecord[] {
+  return ALL_CATEGORIES.map((category) => ({
+    id: `default-${category}`,
+    userId,
+    tenantId,
+    category,
+    inAppEnabled: true,
+    emailEnabled: true,
+  }));
+}
+
+// ─── Audit Helper ─────────────────────────────────────────────────────────────
+
+async function writeAuditLog(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  event: string,
+  resourceId?: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const { error } = await client.from("audit_log").insert({
+    tenant_id: tenantId,
+    user_id: userId,
+    action: "create",
+    resource: "notification",
+    resource_id: resourceId ?? null,
+    metadata: JSON.stringify({ event, ...(metadata ?? {}) }),
+    ip_address: null,
+    user_agent: null,
+  });
+
+  if (error) {
+    console.error(`[audit_log] Failed to write [${event}]:`, error);
+  }
+}
+
+// ─── Service Functions ────────────────────────────────────────────────────────
+
+/**
+ * List notifications for a user in a tenant.
+ * Supports pagination and optional category/isRead filters.
+ * Ordered by created_at DESC.
+ */
+export async function listNotifications(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  query: NotificationsQueryDto,
+): Promise<ServiceResult<NotificationRecord[]>> {
+  const { limit, offset, category, isRead } = query;
+
+  // Build base query — add optional filters BEFORE pagination to keep the chain valid
+  let queryBuilder = client
+    .from("notifications")
+    .select(
+      "id, tenant_id, user_id, type, category, title, body, metadata, is_read, read_at, source_event, source_entity_id, created_at",
+    )
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId);
+
+  if (category !== undefined) {
+    queryBuilder = queryBuilder.eq("category", category);
+  }
+
+  if (isRead !== undefined) {
+    queryBuilder = queryBuilder.eq("is_read", isRead);
+  }
+
+  const { data, error } = await queryBuilder
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return { success: false, error: error.message, code: "NOTIFICATIONS_LIST_FAILED" };
+  }
+
+  return {
+    success: true,
+    data: ((data ?? []) as NotificationRow[]).map(mapNotificationRow),
+  };
+}
+
+/**
+ * Get unread notification count for a user in a tenant.
+ * Used for the header bell badge.
+ */
+export async function getUnreadCount(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<ServiceResult<{ count: number }>> {
+  const { count, error } = await client
+    .from("notifications")
+    .select("*", { count: "exact", head: true })
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId)
+    .eq("is_read", false);
+
+  if (error) {
+    return { success: false, error: error.message, code: "UNREAD_COUNT_FAILED" };
+  }
+
+  return { success: true, data: { count: count ?? 0 } };
+}
+
+/**
+ * Mark a single notification as read.
+ * Sets is_read = true and read_at = now().
+ * Idempotent — no error if already read.
+ */
+export async function markAsRead(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  notificationId: string,
+): Promise<ServiceResult<null>> {
+  // Verify the notification belongs to this user
+  const { data: existing, error: fetchError } = await client
+    .from("notifications")
+    .select("id, user_id, tenant_id, is_read")
+    .eq("id", notificationId)
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (fetchError) {
+    return { success: false, error: fetchError.message, code: "NOTIFICATION_FETCH_FAILED" };
+  }
+
+  if (!existing) {
+    return {
+      success: false,
+      error: "Notification not found or access denied",
+      code: "NOTIFICATION_NOT_FOUND",
+    };
+  }
+
+  const row = existing as NotificationRow;
+
+  // Idempotent: already read
+  if (row["is_read"] === true) {
+    return { success: true, data: null };
+  }
+
+  const { error: updateError } = await client
+    .from("notifications")
+    .update({
+      is_read: true,
+      read_at: new Date().toISOString(),
+    })
+    .eq("id", notificationId)
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId);
+
+  if (updateError) {
+    return { success: false, error: updateError.message, code: "MARK_READ_FAILED" };
+  }
+
+  return { success: true, data: null };
+}
+
+/**
+ * Mark all unread notifications as read for a user in a tenant.
+ * Returns the count of updated rows.
+ */
+export async function markAllAsRead(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<ServiceResult<{ updated: number }>> {
+  const { data, error } = await client
+    .from("notifications")
+    .update({
+      is_read: true,
+      read_at: new Date().toISOString(),
+    })
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId)
+    .eq("is_read", false)
+    .select("id");
+
+  if (error) {
+    return { success: false, error: error.message, code: "MARK_ALL_READ_FAILED" };
+  }
+
+  return { success: true, data: { updated: (data ?? []).length } };
+}
+
+/**
+ * Create a single in-app notification.
+ * Checks user preferences (unless critical) before inserting.
+ * Dispatches email via adapter if the notification type requires it.
+ * Email dispatch is NON-BLOCKING — failures do not prevent notification creation.
+ */
+export async function createNotification(
+  adminClient: SupabaseClient,
+  input: CreateNotificationDto,
+  emailAdapter?: NotificationEmailPort,
+  recipientEmail?: string,
+): Promise<ServiceResult<NotificationRecord>> {
+  const critical = isCritical(input.type);
+
+  // Check in-app preference (skip if critical)
+  let inAppAllowed = true;
+  if (!critical) {
+    const prefResult = await getPreferenceForCategory(
+      adminClient,
+      input.tenantId,
+      input.userId,
+      input.category,
+    );
+    inAppAllowed = prefResult.inAppEnabled;
+  }
+
+  let notificationRecord: NotificationRecord | null = null;
+
+  // Create in-app notification if allowed
+  if (inAppAllowed) {
+    const { data, error } = await adminClient
+      .from("notifications")
+      .insert({
+        tenant_id: input.tenantId,
+        user_id: input.userId,
+        type: input.type,
+        category: input.category,
+        title: input.title,
+        body: input.body,
+        metadata: input.metadata ?? null,
+        source_event: input.sourceEvent ?? null,
+        source_entity_id: input.sourceEntityId ?? null,
+      })
+      .select(
+        "id, tenant_id, user_id, type, category, title, body, metadata, is_read, read_at, source_event, source_entity_id, created_at",
+      )
+      .single();
+
+    if (error) {
+      return { success: false, error: error.message, code: "NOTIFICATION_CREATE_FAILED" };
+    }
+
+    notificationRecord = mapNotificationRow(data as NotificationRow);
+
+    // Audit: notification created
+    void writeAuditLog(
+      adminClient,
+      input.tenantId,
+      input.userId,
+      "notification.created",
+      notificationRecord.id,
+      { type: input.type, category: input.category },
+    );
+  }
+
+  // Dispatch email if applicable
+  if (emailAdapter && recipientEmail && requiresEmail(input.type)) {
+    let emailAllowed = critical;
+
+    if (!emailAllowed) {
+      const prefResult = await getPreferenceForCategory(
+        adminClient,
+        input.tenantId,
+        input.userId,
+        input.category,
+      );
+      emailAllowed = prefResult.emailEnabled;
+    }
+
+    if (emailAllowed) {
+      // Non-blocking email dispatch
+      emailAdapter
+        .sendNotificationEmail({
+          to: recipientEmail,
+          subject: input.title,
+          title: input.title,
+          body: input.body,
+        })
+        .then((emailResult) => {
+          const auditEvent = emailResult.success
+            ? "notification.email_sent"
+            : "notification.email_failed";
+
+          void writeAuditLog(adminClient, input.tenantId, input.userId, auditEvent, undefined, {
+            type: input.type,
+            error: emailResult.success ? undefined : emailResult.error,
+          });
+        })
+        .catch((err) => {
+          console.error("[notification-service] Email dispatch error:", err);
+          void writeAuditLog(
+            adminClient,
+            input.tenantId,
+            input.userId,
+            "notification.email_failed",
+            undefined,
+            { type: input.type, error: err instanceof Error ? err.message : "Unknown error" },
+          );
+        });
+    }
+  }
+
+  // If in-app was disabled and no notification was created, return a synthetic record
+  if (!notificationRecord) {
+    // Return a synthetic representation when in-app was disabled by preference
+    return {
+      success: true,
+      data: {
+        id: "",
+        tenantId: input.tenantId,
+        userId: input.userId,
+        type: input.type,
+        category: input.category,
+        title: input.title,
+        body: input.body,
+        metadata: input.metadata ?? null,
+        isRead: false,
+        readAt: null,
+        sourceEvent: input.sourceEvent ?? null,
+        sourceEntityId: input.sourceEntityId ?? null,
+        createdAt: new Date().toISOString(),
+      },
+    };
+  }
+
+  return { success: true, data: notificationRecord };
+}
+
+/**
+ * Create notifications for multiple recipients.
+ * Used for broadcasting events (e.g. billing_past_due → owner + admins).
+ * Non-blocking: individual failures are logged but do not abort the batch.
+ */
+export async function createBulkNotifications(
+  adminClient: SupabaseClient,
+  inputs: CreateNotificationDto[],
+  emailAdapter?: NotificationEmailPort,
+  recipientEmails?: Record<string, string>,
+): Promise<ServiceResult<NotificationRecord[]>> {
+  if (inputs.length === 0) {
+    return { success: true, data: [] };
+  }
+
+  const results: NotificationRecord[] = [];
+  const errors: string[] = [];
+
+  for (const input of inputs) {
+    const recipientEmail = recipientEmails?.[input.userId];
+    const result = await createNotification(adminClient, input, emailAdapter, recipientEmail);
+
+    if (result.success) {
+      results.push(result.data);
+    } else {
+      errors.push(`${input.userId}: ${result.error}`);
+      console.error(
+        "[notification-service] createBulkNotifications partial failure:",
+        result.error,
+      );
+    }
+  }
+
+  if (errors.length > 0 && results.length === 0) {
+    return {
+      success: false,
+      error: `All ${errors.length} notifications failed`,
+      code: "BULK_CREATE_FAILED",
+    };
+  }
+
+  return { success: true, data: results };
+}
+
+/**
+ * Get notification preferences for a user in a tenant.
+ * Returns all 3 categories; missing rows use default (all enabled).
+ */
+export async function getPreferences(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+): Promise<ServiceResult<NotificationPreferenceRecord[]>> {
+  const { data, error } = await client
+    .from("notification_preferences")
+    .select("id, user_id, tenant_id, category, in_app_enabled, email_enabled")
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId);
+
+  if (error) {
+    return { success: false, error: error.message, code: "PREFERENCES_FETCH_FAILED" };
+  }
+
+  const rows = ((data ?? []) as PreferenceRow[]).map(mapPreferenceRow);
+
+  // Fill in missing categories with defaults
+  const existing = new Set(rows.map((r) => r.category));
+  const defaults = buildDefaultPreferences(userId, tenantId).filter(
+    (d) => !existing.has(d.category),
+  );
+
+  return { success: true, data: [...rows, ...defaults] };
+}
+
+/**
+ * Upsert notification preferences for a user in a tenant.
+ * Writes audit log for the change.
+ */
+export async function updatePreferences(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  input: UpdatePreferencesDto,
+): Promise<ServiceResult<NotificationPreferenceRecord[]>> {
+  const upsertRows = input.preferences.map((pref) => ({
+    user_id: userId,
+    tenant_id: tenantId,
+    category: pref.category,
+    in_app_enabled: pref.inAppEnabled,
+    email_enabled: pref.emailEnabled,
+    updated_at: new Date().toISOString(),
+  }));
+
+  const { data, error } = await client
+    .from("notification_preferences")
+    .upsert(upsertRows, { onConflict: "user_id,tenant_id,category" })
+    .select("id, user_id, tenant_id, category, in_app_enabled, email_enabled");
+
+  if (error) {
+    return { success: false, error: error.message, code: "PREFERENCES_UPDATE_FAILED" };
+  }
+
+  // Audit: preferences changed
+  void writeAuditLog(client, tenantId, userId, "notification.preferences_updated", undefined, {
+    categories: input.preferences.map((p) => p.category),
+  });
+
+  return {
+    success: true,
+    data: ((data ?? []) as PreferenceRow[]).map(mapPreferenceRow),
+  };
+}
+
+// ─── Internal Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Fetch preference for a specific category.
+ * Falls back to defaults (all enabled) if no row exists.
+ */
+async function getPreferenceForCategory(
+  client: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  category: "team" | "billing" | "system",
+): Promise<{ inAppEnabled: boolean; emailEnabled: boolean }> {
+  const { data } = await client
+    .from("notification_preferences")
+    .select("in_app_enabled, email_enabled")
+    .eq("tenant_id", tenantId)
+    .eq("user_id", userId)
+    .eq("category", category)
+    .maybeSingle();
+
+  if (!data) {
+    // Missing row = all enabled (preference default)
+    return { inAppEnabled: true, emailEnabled: true };
+  }
+
+  const row = data as PreferenceRow;
+  return {
+    inAppEnabled: row["in_app_enabled"] as boolean,
+    emailEnabled: row["email_enabled"] as boolean,
+  };
+}

--- a/packages/core/src/services/ports/notification-email-port.ts
+++ b/packages/core/src/services/ports/notification-email-port.ts
@@ -1,0 +1,17 @@
+// Email port interface for notification delivery
+// Implement this interface to swap email adapters per environment
+
+export interface NotificationEmailParams {
+  to: string;
+  subject: string;
+  title: string;
+  body: string;
+  ctaUrl?: string;
+  ctaLabel?: string;
+}
+
+export interface NotificationEmailPort {
+  sendNotificationEmail(
+    params: NotificationEmailParams,
+  ): Promise<{ success: boolean; error?: string }>;
+}

--- a/packages/core/src/services/tenant-team-service.ts
+++ b/packages/core/src/services/tenant-team-service.ts
@@ -12,7 +12,9 @@ import type {
   TenantMemberOutput,
 } from "@enterprise/contracts";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createNotificationEmailAdapter } from "./adapters/notification-email-adapter-factory";
 import type { ServiceResult } from "./auth-service";
+import { createNotification } from "./notification-service";
 import type { InvitationEmailPort } from "./ports/invitation-email-port";
 
 // ─── Token Utilities ───────────────────────────────────────────────────────────
@@ -159,6 +161,7 @@ export async function inviteTenantMember(
   input: InviteMemberDto,
   emailPort: InvitationEmailPort,
   opts?: { appUrl?: string; tenantName?: string; inviterName?: string },
+  adminClient?: SupabaseClient,
 ): Promise<ServiceResult<TenantInvitationOutput>> {
   // Guard: allow_admin_invites flag
   if (userRole === "admin") {
@@ -277,6 +280,43 @@ export async function inviteTenantMember(
         error: emailResult.error,
       },
     );
+  }
+
+  // Dispatch in-app notification if invited user already has an account (non-blocking)
+  if (adminClient) {
+    try {
+      // Check if the invited email already has an auth user via profiles lookup
+      const { data: existingUser } = await adminClient
+        .from("profiles")
+        .select("id")
+        .eq("email", input.email)
+        .maybeSingle();
+
+      if (existingUser) {
+        // Existing user: create in-app + email notification
+        const existingUserId = (existingUser as Record<string, unknown>)["id"] as string;
+        createNotification(
+          adminClient,
+          {
+            tenantId,
+            userId: existingUserId,
+            type: "team_invited",
+            category: "team",
+            title: "You have been invited to a team",
+            body: `You have been invited to join as ${input.role}.`,
+            sourceEvent: "member.invited",
+            sourceEntityId: invitationRow["id"] as string,
+          },
+          createNotificationEmailAdapter(),
+          input.email,
+        ).catch((notifError) => {
+          console.error("[team] inviteTenantMember: notification dispatch failed:", notifError);
+        });
+      }
+      // No account yet: invitation email already sent above via emailPort — no in-app row
+    } catch (notifError) {
+      console.error("[team] inviteTenantMember: notification dispatch failed:", notifError);
+    }
   }
 
   return { success: true, data: mapInvitationRow(invitationRow) };
@@ -415,6 +455,26 @@ export async function acceptTenantInvitation(
     role,
   });
 
+  // Dispatch notification to the inviter (non-blocking)
+  const invitedByUserId = inv["invited_by"] as string;
+  createNotification(
+    adminClient,
+    {
+      tenantId,
+      userId: invitedByUserId,
+      type: "team_invitation_accepted",
+      category: "team",
+      title: "Invitation accepted",
+      body: `Your invitation has been accepted. The new member joined as ${role}.`,
+      metadata: JSON.stringify({ acceptedByEmail: email, role }),
+      sourceEvent: "member.joined",
+      sourceEntityId: invitationId,
+    },
+    createNotificationEmailAdapter(),
+  ).catch((notifError) => {
+    console.error("[team] acceptTenantInvitation: notification dispatch failed:", notifError);
+  });
+
   return { success: true, data: undefined };
 }
 
@@ -513,6 +573,29 @@ export async function changeTenantMemberRole(
     to: input.role,
   });
 
+  // Dispatch notification to the affected member (non-blocking)
+  createNotification(
+    adminClient,
+    {
+      tenantId,
+      userId: input.userId,
+      type: "team_role_changed",
+      category: "team",
+      title: "Your role has changed",
+      body: `Your role has been updated to ${input.role}.`,
+      metadata: JSON.stringify({
+        previousRole: target["role"],
+        newRole: input.role,
+        changedBy: requesterId,
+      }),
+      sourceEvent: "member.role_changed",
+      sourceEntityId: input.userId,
+    },
+    createNotificationEmailAdapter(),
+  ).catch((notifError) => {
+    console.error("[team] changeTenantMemberRole: notification dispatch failed:", notifError);
+  });
+
   return { success: true, data: mapProfileToMember(updated as Record<string, unknown>) };
 }
 
@@ -603,6 +686,22 @@ export async function removeTenantMember(
     email: target["email"],
     role: target["role"],
   });
+
+  // Dispatch email-only notification (no in-app row — user is losing access) (non-blocking)
+  const removedEmail = target["email"] as string | null;
+  if (removedEmail) {
+    try {
+      const emailAdapter = createNotificationEmailAdapter();
+      void emailAdapter.sendNotificationEmail({
+        to: removedEmail,
+        subject: "You have been removed from the team",
+        title: "Removed from team",
+        body: "Your access to the workspace has been revoked.",
+      });
+    } catch (notifError) {
+      console.error("[team] removeTenantMember: email notification failed:", notifError);
+    }
+  }
 
   return { success: true, data: undefined };
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,6 +5,7 @@ export type { PgTable } from "drizzle-orm/pg-core";
 // Re-export drizzle utilities
 export { drizzle } from "drizzle-orm/postgres-js";
 export * from "./schema/billing.js";
+export * from "./schema/notifications.js";
 // Re-export new types explicitly for consumers
 export type { NewTenantInvitation, TenantInvitation } from "./schema/platform.js";
 export * from "./schema/platform.js";

--- a/packages/db/src/schema/notifications.ts
+++ b/packages/db/src/schema/notifications.ts
@@ -1,0 +1,184 @@
+// Notifications schema — in-app notification feed and user preferences
+// INSERT is service_role only; SELECT/UPDATE are authenticated (user_id = auth.uid())
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  pgEnum,
+  pgPolicy,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { authenticatedRole, serviceRole } from "drizzle-orm/supabase";
+import { tenants } from "./platform.js";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/** Notification type — identifies the triggering event */
+export const notificationTypeEnum = pgEnum("notification_type", [
+  "team_invited",
+  "team_invitation_accepted",
+  "team_role_changed",
+  "team_removed",
+  "billing_past_due",
+  "billing_plan_upgraded",
+  "billing_plan_downgraded",
+  "billing_canceled",
+  "billing_activated",
+]);
+
+/** Notification category — groups notifications for filtering and preference controls */
+export const notificationCategoryEnum = pgEnum("notification_category", [
+  "team",
+  "billing",
+  "system",
+]);
+
+// ============================================================================
+// RLS Helpers
+// ============================================================================
+
+/** Matches the user_id column against the authenticated user's JWT sub */
+const userIdMatchesUid = sql`(user_id = auth.uid())`;
+
+/** Matches the tenant_id column against the JWT app_metadata tenant_id claim */
+const tenantClaimMatchesColumn = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+
+/** Combined user + tenant scope check (used on both tables) */
+const userAndTenantMatch = sql`(${userIdMatchesUid} AND ${tenantClaimMatchesColumn})`;
+
+// ============================================================================
+// Notifications Table
+// ============================================================================
+
+/**
+ * notifications — immutable event log per user per tenant.
+ * Only is_read and read_at are mutable after creation.
+ * INSERT is service_role only — notifications are created by service-layer code
+ * that may not have the recipient's JWT context (e.g. billing webhooks).
+ */
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    /** Recipient — references auth.users.id (no FK enforced; users may be removed) */
+    userId: uuid("user_id").notNull(),
+    type: notificationTypeEnum("type").notNull(),
+    category: notificationCategoryEnum("category").notNull(),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    /** JSON string — parsed at service layer. Consistent with billing features/limits pattern. */
+    metadata: text("metadata"),
+    isRead: boolean("is_read").notNull().default(false),
+    readAt: timestamp("read_at", { withTimezone: true }),
+    /** Original triggering event name (e.g. 'tenant_member.invited') */
+    sourceEvent: text("source_event"),
+    /** ID of the entity that triggered this notification */
+    sourceEntityId: uuid("source_entity_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("notifications_user_tenant_idx").on(table.userId, table.tenantId),
+    index("notifications_user_unread_idx").on(table.userId, table.tenantId, table.isRead),
+    index("notifications_category_idx").on(table.category),
+    index("notifications_created_at_idx").on(table.createdAt),
+    index("notifications_source_event_idx").on(table.sourceEvent),
+    // SELECT: user sees only their own notifications in their tenant
+    pgPolicy("notifications_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: userAndTenantMatch,
+    }),
+    // INSERT: service_role only — no recipient JWT available at create time
+    pgPolicy("notifications_insert", {
+      as: "permissive",
+      for: "insert",
+      to: serviceRole,
+      withCheck: sql`true`,
+    }),
+    // UPDATE: user can mark their own notifications as read
+    pgPolicy("notifications_update", {
+      as: "permissive",
+      for: "update",
+      to: authenticatedRole,
+      using: userAndTenantMatch,
+      withCheck: userAndTenantMatch,
+    }),
+    // No DELETE policy — retention cleanup is a follow-up (90-day cron job)
+  ],
+).enableRLS();
+
+// ============================================================================
+// Notification Preferences Table
+// ============================================================================
+
+/**
+ * notification_preferences — per-user, per-tenant, per-category toggles.
+ * Missing row means all channels enabled (preference default = enabled).
+ * UNIQUE constraint prevents duplicate rows per (user, tenant, category).
+ */
+export const notificationPreferences = pgTable(
+  "notification_preferences",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    /** Owner of the preference — references auth.users.id */
+    userId: uuid("user_id").notNull(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    category: notificationCategoryEnum("category").notNull(),
+    inAppEnabled: boolean("in_app_enabled").notNull().default(true),
+    emailEnabled: boolean("email_enabled").notNull().default(true),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("preferences_user_tenant_idx").on(table.userId, table.tenantId),
+    // One preference row per user per tenant per category
+    unique("preferences_user_tenant_category_unique").on(
+      table.userId,
+      table.tenantId,
+      table.category,
+    ),
+    pgPolicy("preferences_select", {
+      as: "permissive",
+      for: "select",
+      to: authenticatedRole,
+      using: userAndTenantMatch,
+    }),
+    pgPolicy("preferences_insert", {
+      as: "permissive",
+      for: "insert",
+      to: authenticatedRole,
+      withCheck: userAndTenantMatch,
+    }),
+    pgPolicy("preferences_update", {
+      as: "permissive",
+      for: "update",
+      to: authenticatedRole,
+      using: userAndTenantMatch,
+      withCheck: userAndTenantMatch,
+    }),
+    // No DELETE policy — preferences are updated, not removed
+  ],
+).enableRLS();
+
+// ============================================================================
+// Type Exports (for use in services)
+// ============================================================================
+
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+
+export type NotificationPreference = typeof notificationPreferences.$inferSelect;
+export type NewNotificationPreference = typeof notificationPreferences.$inferInsert;

--- a/supabase/migrations/20260529000001_notifications_schema.sql
+++ b/supabase/migrations/20260529000001_notifications_schema.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."notification_category" AS ENUM('team', 'billing', 'system');--> statement-breakpoint
+CREATE TYPE "public"."notification_type" AS ENUM('team_invited', 'team_invitation_accepted', 'team_role_changed', 'team_removed', 'billing_past_due', 'billing_plan_upgraded', 'billing_plan_downgraded', 'billing_canceled', 'billing_activated');--> statement-breakpoint
+CREATE TABLE "notification_preferences" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"category" "notification_category" NOT NULL,
+	"in_app_enabled" boolean DEFAULT true NOT NULL,
+	"email_enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "preferences_user_tenant_category_unique" UNIQUE("user_id","tenant_id","category")
+);
+--> statement-breakpoint
+ALTER TABLE "notification_preferences" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"type" "notification_type" NOT NULL,
+	"category" "notification_category" NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"metadata" text,
+	"is_read" boolean DEFAULT false NOT NULL,
+	"read_at" timestamp with time zone,
+	"source_event" text,
+	"source_entity_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "notifications" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "notification_preferences" ADD CONSTRAINT "notification_preferences_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "preferences_user_tenant_idx" ON "notification_preferences" USING btree ("user_id","tenant_id");--> statement-breakpoint
+CREATE INDEX "notifications_user_tenant_idx" ON "notifications" USING btree ("user_id","tenant_id");--> statement-breakpoint
+CREATE INDEX "notifications_user_unread_idx" ON "notifications" USING btree ("user_id","tenant_id","is_read");--> statement-breakpoint
+CREATE INDEX "notifications_category_idx" ON "notifications" USING btree ("category");--> statement-breakpoint
+CREATE INDEX "notifications_created_at_idx" ON "notifications" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "notifications_source_event_idx" ON "notifications" USING btree ("source_event");--> statement-breakpoint
+CREATE POLICY "preferences_select" ON "notification_preferences" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)));--> statement-breakpoint
+CREATE POLICY "preferences_insert" ON "notification_preferences" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)));--> statement-breakpoint
+CREATE POLICY "preferences_update" ON "notification_preferences" AS PERMISSIVE FOR UPDATE TO "authenticated" USING (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))) WITH CHECK (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)));--> statement-breakpoint
+CREATE POLICY "notifications_select" ON "notifications" AS PERMISSIVE FOR SELECT TO "authenticated" USING (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)));--> statement-breakpoint
+CREATE POLICY "notifications_insert" ON "notifications" AS PERMISSIVE FOR INSERT TO "service_role" WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "notifications_update" ON "notifications" AS PERMISSIVE FOR UPDATE TO "authenticated" USING (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))) WITH CHECK (((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)));

--- a/supabase/migrations/meta/0002_snapshot.json
+++ b/supabase/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2004 @@
+{
+  "id": "585017cc-3da8-431c-b1e7-c28e3426c2c8",
+  "prevId": "979c4b2c-50d8-490e-9e38-5d3a39bb2d8b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_events_tenant_idx": {
+          "name": "billing_events_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_external_event_idx": {
+          "name": "billing_events_external_event_idx",
+          "columns": [
+            {
+              "expression": "external_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_events_subscription_idx": {
+          "name": "billing_events_subscription_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_events_tenant_id_tenants_id_fk": {
+          "name": "billing_events_tenant_id_tenants_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "billing_events_subscription_id_tenant_subscriptions_id_fk": {
+          "name": "billing_events_subscription_id_tenant_subscriptions_id_fk",
+          "tableFrom": "billing_events",
+          "tableTo": "tenant_subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_external_event_id_unique": {
+          "name": "billing_events_external_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_event_id"
+          ]
+        }
+      },
+      "policies": {
+        "billing_events_select": {
+          "name": "billing_events_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "billing_events_insert_sr": {
+          "name": "billing_events_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_monthly": {
+          "name": "price_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_yearly": {
+          "name": "price_yearly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "features": {
+          "name": "features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limits": {
+          "name": "limits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trial_days": {
+          "name": "trial_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plans_slug_idx": {
+          "name": "plans_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "plans_active_order_idx": {
+          "name": "plans_active_order_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plans_slug_unique": {
+          "name": "plans_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "plans_select": {
+          "name": "plans_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "plans_insert": {
+          "name": "plans_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "plans_update": {
+          "name": "plans_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        },
+        "plans_delete": {
+          "name": "plans_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_subscriptions": {
+      "name": "tenant_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_cycle": {
+          "name": "billing_cycle",
+          "type": "billing_cycle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subscription_id": {
+          "name": "external_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_customer_id": {
+          "name": "external_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_external_id_idx": {
+          "name": "subscriptions_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_subscriptions_tenant_id_tenants_id_fk": {
+          "name": "tenant_subscriptions_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tenant_subscriptions_plan_id_plans_id_fk": {
+          "name": "tenant_subscriptions_plan_id_plans_id_fk",
+          "tableFrom": "tenant_subscriptions",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenant_subscriptions_tenant_id_unique": {
+          "name": "tenant_subscriptions_tenant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id"
+          ]
+        },
+        "tenant_subscriptions_external_subscription_id_unique": {
+          "name": "tenant_subscriptions_external_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_subscription_id"
+          ]
+        }
+      },
+      "policies": {
+        "subscriptions_select": {
+          "name": "subscriptions_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "subscriptions_insert_sr": {
+          "name": "subscriptions_insert_sr",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "subscriptions_update_sr": {
+          "name": "subscriptions_update_sr",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "notification_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_app_enabled": {
+          "name": "in_app_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "preferences_user_tenant_idx": {
+          "name": "preferences_user_tenant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_tenant_id_tenants_id_fk": {
+          "name": "notification_preferences_tenant_id_tenants_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preferences_user_tenant_category_unique": {
+          "name": "preferences_user_tenant_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "tenant_id",
+            "category"
+          ]
+        }
+      },
+      "policies": {
+        "preferences_select": {
+          "name": "preferences_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "preferences_insert": {
+          "name": "preferences_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "preferences_update": {
+          "name": "preferences_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))",
+          "withCheck": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "notification_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event": {
+          "name": "source_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_entity_id": {
+          "name": "source_entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_tenant_idx": {
+          "name": "notifications_user_tenant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_source_event_idx": {
+          "name": "notifications_source_event_idx",
+          "columns": [
+            {
+              "expression": "source_event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_tenant_id_tenants_id_fk": {
+          "name": "notifications_tenant_id_tenants_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "notifications_select": {
+          "name": "notifications_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "notifications_insert": {
+          "name": "notifications_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "notifications_update": {
+          "name": "notifications_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))",
+          "withCheck": "((user_id = auth.uid()) AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_tenant_idx": {
+          "name": "audit_log_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_user_idx": {
+          "name": "audit_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_resource_idx": {
+          "name": "audit_log_resource_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_idx": {
+          "name": "audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "audit_log_select": {
+          "name": "audit_log_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "audit_log_insert": {
+          "name": "audit_log_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND auth.uid() = user_id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_tenant_idx": {
+          "name": "profiles_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "profiles_email_idx": {
+          "name": "profiles_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "profiles_select": {
+          "name": "profiles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "profiles_insert": {
+          "name": "profiles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid() = id AND ((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id))"
+        },
+        "profiles_update": {
+          "name": "profiles_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "profiles_delete": {
+          "name": "profiles_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenant_invitations": {
+      "name": "tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_tenant_idx": {
+          "name": "invitations_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_token_hash_idx": {
+          "name": "invitations_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_invitations_tenant_id_tenants_id_fk": {
+          "name": "tenant_invitations_tenant_id_tenants_id_fk",
+          "tableFrom": "tenant_invitations",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "invitations_select": {
+          "name": "invitations_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_insert": {
+          "name": "invitations_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_update": {
+          "name": "invitations_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "invitations_delete": {
+          "name": "invitations_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tenant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_path": {
+          "name": "logo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en-US'"
+        },
+        "allow_admin_invites": {
+          "name": "allow_admin_invites",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_slug_idx": {
+          "name": "tenants_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenants_status_idx": {
+          "name": "tenants_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_slug_unique": {
+          "name": "tenants_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {
+        "tenants_select": {
+          "name": "tenants_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = id)"
+        },
+        "tenants_insert": {
+          "name": "tenants_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "service_role"
+          ],
+          "withCheck": "true"
+        },
+        "tenants_update": {
+          "name": "tenants_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "service_role"
+          ],
+          "using": "true",
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_roles_user_tenant_idx": {
+          "name": "user_roles_user_tenant_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "user_roles_select": {
+          "name": "user_roles_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "user_roles_insert": {
+          "name": "user_roles_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_tenant_idx": {
+          "name": "resources_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_status_idx": {
+          "name": "resources_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_type_idx": {
+          "name": "resources_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resources_created_by_idx": {
+          "name": "resources_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "resources_select": {
+          "name": "resources_select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)"
+        },
+        "resources_insert": {
+          "name": "resources_insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_update": {
+          "name": "resources_update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))",
+          "withCheck": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        },
+        "resources_delete": {
+          "name": "resources_delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id) AND (auth.jwt()->'app_metadata'->>'role' IN ('owner', 'admin')))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.billing_cycle": {
+      "name": "billing_cycle",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "yearly"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid"
+      ]
+    },
+    "public.notification_category": {
+      "name": "notification_category",
+      "schema": "public",
+      "values": [
+        "team",
+        "billing",
+        "system"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "team_invited",
+        "team_invitation_accepted",
+        "team_role_changed",
+        "team_removed",
+        "billing_past_due",
+        "billing_plan_upgraded",
+        "billing_plan_downgraded",
+        "billing_canceled",
+        "billing_activated"
+      ]
+    },
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "create",
+        "read",
+        "update",
+        "delete",
+        "login",
+        "logout",
+        "custom"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.tenant_status": {
+      "name": "tenant_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "suspended"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "guest"
+      ]
+    },
+    "public.resource_status": {
+      "name": "resource_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "draft",
+        "archived",
+        "suspended"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "product",
+        "service",
+        "asset",
+        "document",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779396142849,
       "tag": "0001_happy_the_renegades",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780099326005,
+      "tag": "0002_rapid_stingray",
+      "breakpoints": true
     }
   ]
 }

--- a/ui/app/(protected)/layout.tsx
+++ b/ui/app/(protected)/layout.tsx
@@ -1,11 +1,19 @@
 import { DashboardShell } from "@/components/layout/dashboard-shell";
 import { requireAuth } from "@/features/auth/queries";
+import { getNotificationUnreadCount } from "@/features/notifications/queries";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await requireAuth();
+  const initialUnreadCount = user.role !== "guest" ? await getNotificationUnreadCount() : 0;
 
   return (
-    <DashboardShell userRole={user.role} userLabel={user.name ?? user.email}>
+    <DashboardShell
+      userRole={user.role}
+      userLabel={user.name ?? user.email}
+      userId={user.id}
+      tenantId={user.tenantId}
+      initialUnreadCount={initialUnreadCount}
+    >
       {children}
     </DashboardShell>
   );

--- a/ui/app/(protected)/notifications/error.tsx
+++ b/ui/app/(protected)/notifications/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ErrorState } from "@enterprise/ui/components/error-state";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function NotificationsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <ErrorState
+      message="An error occurred while loading notifications. Please try again."
+      onReset={reset}
+    />
+  );
+}

--- a/ui/app/(protected)/notifications/page.tsx
+++ b/ui/app/(protected)/notifications/page.tsx
@@ -1,0 +1,55 @@
+import { PageHeader } from "@enterprise/ui/components/page-header";
+import { redirect } from "next/navigation";
+import { requireAuth } from "@/features/auth/queries";
+import { MarkAllReadButton } from "@/features/notifications/components/mark-all-read-button";
+import { NotificationFilters } from "@/features/notifications/components/notification-filters";
+import { NotificationList } from "@/features/notifications/components/notification-list";
+import { getNotifications, getNotificationUnreadCount } from "@/features/notifications/queries";
+import type { NotificationCategory } from "@/features/notifications/types";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata = { title: "Notifications" };
+
+interface NotificationsPageProps {
+  searchParams: Promise<{ tab?: string; category?: string }>;
+}
+
+export default async function NotificationsPage({ searchParams }: NotificationsPageProps) {
+  const user = await requireAuth();
+
+  // Guests cannot access notifications
+  if (user.role === "guest") {
+    redirect(ROUTES.dashboard);
+  }
+
+  const params = await searchParams;
+  const tab = params.tab;
+  const category = params.category as NotificationCategory | undefined;
+  const isReadFilter = tab === "unread" ? false : undefined;
+
+  const [notifications, unreadCount] = await Promise.all([
+    getNotifications({
+      category,
+      isRead: isReadFilter,
+      limit: 20,
+      offset: 0,
+    }),
+    getNotificationUnreadCount(),
+  ]);
+
+  const hasFilter = Boolean(tab === "unread" || category);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Notifications"
+        subtitle="Stay updated on team and billing"
+        action={<MarkAllReadButton unreadCount={unreadCount} />}
+      />
+
+      <NotificationFilters />
+
+      <NotificationList initialItems={notifications} hasFilter={hasFilter} />
+    </div>
+  );
+}

--- a/ui/app/(protected)/settings/notifications/error.tsx
+++ b/ui/app/(protected)/settings/notifications/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ErrorState } from "@enterprise/ui/components/error-state";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function NotificationPreferencesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <ErrorState
+      message="An error occurred while loading notification preferences. Please try again."
+      onReset={reset}
+    />
+  );
+}

--- a/ui/app/(protected)/settings/notifications/page.tsx
+++ b/ui/app/(protected)/settings/notifications/page.tsx
@@ -1,0 +1,30 @@
+import { PageHeader } from "@enterprise/ui/components/page-header";
+import { redirect } from "next/navigation";
+import { requireAuth } from "@/features/auth/queries";
+import { NotificationPreferencesForm } from "@/features/notifications/components/notification-preferences-form";
+import { getNotificationPreferences } from "@/features/notifications/queries";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata = { title: "Notification preferences" };
+
+export default async function NotificationPreferencesPage() {
+  const user = await requireAuth();
+
+  // Guests cannot access notification preferences
+  if (user.role === "guest") {
+    redirect(ROUTES.dashboard);
+  }
+
+  const preferences = await getNotificationPreferences();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Notification preferences"
+        subtitle="Choose which notifications you receive"
+      />
+
+      <NotificationPreferencesForm preferences={preferences} />
+    </div>
+  );
+}

--- a/ui/components/layout/dashboard-shell.tsx
+++ b/ui/components/layout/dashboard-shell.tsx
@@ -9,14 +9,30 @@ interface DashboardShellProps {
   children: React.ReactNode;
   userRole: UserRole;
   userLabel: string;
+  userId: string;
+  tenantId: string;
+  initialUnreadCount: number;
 }
 
-export function DashboardShell({ children, userRole, userLabel }: DashboardShellProps) {
+export function DashboardShell({
+  children,
+  userRole,
+  userLabel,
+  userId,
+  tenantId,
+  initialUnreadCount,
+}: DashboardShellProps) {
   return (
     <div className="min-h-screen lg:h-screen">
       <Sidebar userRole={userRole} userLabel={userLabel} />
       <div className="flex min-h-screen flex-1 flex-col lg:ml-[var(--sidebar-width)] lg:h-screen lg:overflow-hidden">
-        <Header userRole={userRole} userLabel={userLabel} />
+        <Header
+          userRole={userRole}
+          userLabel={userLabel}
+          userId={userId}
+          tenantId={tenantId}
+          initialUnreadCount={initialUnreadCount}
+        />
         <main className="flex-1 overflow-y-auto p-6 pb-20 lg:pb-6">{children}</main>
       </div>
       <BottomTabBar userRole={userRole} userLabel={userLabel} />

--- a/ui/components/layout/header.tsx
+++ b/ui/components/layout/header.tsx
@@ -15,12 +15,16 @@ import { LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "@/features/auth/actions";
+import { NotificationBell } from "@/features/notifications/components/notification-bell";
 import { ROUTES } from "@/lib/routes";
 import { MobileNav } from "./mobile-nav";
 
 interface HeaderProps {
   userRole: UserRole;
   userLabel: string;
+  userId: string;
+  tenantId: string;
+  initialUnreadCount: number;
 }
 
 const ROUTE_TITLES = [
@@ -28,9 +32,10 @@ const ROUTE_TITLES = [
   { prefix: ROUTES.team, title: "Team" },
   { prefix: ROUTES.billing, title: "Billing" },
   { prefix: ROUTES.resources.root, title: "Resources" },
+  { prefix: ROUTES.notifications, title: "Notifications" },
 ] as const;
 
-export function Header({ userRole, userLabel }: HeaderProps) {
+export function Header({ userRole, userLabel, userId, tenantId, initialUnreadCount }: HeaderProps) {
   const avatarLabel = userLabel.trim().charAt(0).toUpperCase() || "U";
   const pathname = usePathname();
 
@@ -45,6 +50,9 @@ export function Header({ userRole, userLabel }: HeaderProps) {
 
       <div className="ml-auto flex items-center gap-2">
         <ThemeToggle />
+        {userRole !== "guest" && (
+          <NotificationBell initialCount={initialUnreadCount} userId={userId} tenantId={tenantId} />
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" className="rounded-full">

--- a/ui/features/notifications/actions.ts
+++ b/ui/features/notifications/actions.ts
@@ -1,0 +1,414 @@
+"use server";
+
+import type { ActionResult, NotificationsQueryDto } from "@enterprise/contracts";
+import {
+  markAsReadSchema,
+  notificationsQuerySchema,
+  updatePreferencesSchema,
+} from "@enterprise/contracts";
+import type {
+  NotificationPreferenceRecord,
+  NotificationRecord,
+} from "@enterprise/core/services/notification-service";
+import {
+  getPreferences,
+  getUnreadCount,
+  listNotifications,
+  markAllAsRead,
+  markAsRead,
+  updatePreferences,
+} from "@enterprise/core/services/notification-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { revalidatePath } from "next/cache";
+import { ROUTES } from "@/lib/routes";
+import { captureActionError } from "@/lib/sentry";
+
+// ─── Auth Context ─────────────────────────────────────────────────────────────
+
+async function getAuthContext(supabase: Awaited<ReturnType<typeof getServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+  const role = (user.app_metadata?.["role"] as string | undefined) ?? null;
+
+  if (!tenantId) {
+    return null;
+  }
+
+  return { userId: user.id, tenantId, role };
+}
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+/**
+ * List notifications for the authenticated user.
+ * Accepts an optional query object (category, isRead, limit, offset).
+ */
+export async function listNotificationsAction(
+  input: Partial<NotificationsQueryDto> = {},
+): Promise<ActionResult<NotificationRecord[]>> {
+  const parsed = notificationsQuerySchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid query parameters",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await listNotifications(supabase, auth.tenantId, auth.userId, parsed.data);
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "listNotificationsAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+        inputShape: Object.keys(parsed.data),
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "LIST_NOTIFICATIONS_FAILED", message: result.error },
+      };
+    }
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "listNotificationsAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Get the unread notification count for the authenticated user.
+ * No input — uses auth context for tenant+user scoping.
+ */
+export async function getUnreadCountAction(): Promise<ActionResult<{ count: number }>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await getUnreadCount(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "getUnreadCountAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "UNREAD_COUNT_FAILED", message: result.error },
+      };
+    }
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "getUnreadCountAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Mark a single notification as read.
+ * Validates notificationId UUID, then calls markAsRead service.
+ */
+export async function markAsReadAction(
+  input: Record<string, unknown>,
+): Promise<ActionResult<null>> {
+  const parsed = markAsReadSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await markAsRead(
+      supabase,
+      auth.tenantId,
+      auth.userId,
+      parsed.data.notificationId,
+    );
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "markAsReadAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+        inputShape: Object.keys(parsed.data),
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "MARK_READ_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.notifications);
+    return { success: true, data: null };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "markAsReadAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Mark all notifications as read for the authenticated user.
+ * No meaningful input — uses auth context for tenant+user scoping.
+ */
+export async function markAllAsReadAction(): Promise<ActionResult<{ updated: number }>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await markAllAsRead(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "markAllAsReadAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "MARK_ALL_READ_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.notifications);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "markAllAsReadAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Get notification preferences for the authenticated user.
+ * No input — uses auth context. Returns all 3 categories (missing rows = defaults).
+ */
+export async function getPreferencesAction(): Promise<
+  ActionResult<NotificationPreferenceRecord[]>
+> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await getPreferences(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "getPreferencesAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "PREFERENCES_FETCH_FAILED", message: result.error },
+      };
+    }
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "getPreferencesAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Update notification preferences for the authenticated user.
+ * Upserts per-category settings; revalidates the preferences page.
+ */
+export async function updatePreferencesAction(
+  input: Record<string, unknown>,
+): Promise<ActionResult<NotificationPreferenceRecord[]>> {
+  const parsed = updatePreferencesSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid preferences input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  try {
+    const result = await updatePreferences(supabase, auth.tenantId, auth.userId, parsed.data);
+
+    if (!result.success) {
+      captureActionError(new Error(result.error), {
+        actionName: "updatePreferencesAction",
+        area: "notifications",
+        errorCode: result.code,
+        tenantId: auth.tenantId,
+        userId: auth.userId,
+        userRole: auth.role ?? undefined,
+        inputShape: ["preferences"],
+      });
+
+      return {
+        success: false,
+        error: { code: result.code ?? "PREFERENCES_UPDATE_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.notificationPreferences);
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "updatePreferencesAction",
+      area: "notifications",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      userRole: auth.role ?? undefined,
+      inputShape: ["preferences"],
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}

--- a/ui/features/notifications/components/mark-all-read-button.tsx
+++ b/ui/features/notifications/components/mark-all-read-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import { CheckCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { markAllAsReadAction } from "@/features/notifications/actions";
+
+interface MarkAllReadButtonProps {
+  unreadCount: number;
+}
+
+export function MarkAllReadButton({ unreadCount }: MarkAllReadButtonProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleClick() {
+    if (unreadCount === 0) return;
+    setIsLoading(true);
+    try {
+      await markAllAsReadAction();
+      router.refresh();
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={unreadCount === 0 || isLoading}
+      onClick={handleClick}
+      className="gap-2"
+    >
+      <CheckCheck className="size-4" aria-hidden="true" />
+      {unreadCount > 0 ? `Mark ${unreadCount} as read` : "Mark all as read"}
+    </Button>
+  );
+}

--- a/ui/features/notifications/components/notification-bell.tsx
+++ b/ui/features/notifications/components/notification-bell.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import { cn } from "@enterprise/ui/lib/utils";
+import { Bell } from "lucide-react";
+import Link from "next/link";
+import { useUnreadCount } from "@/features/notifications/hooks/use-unread-count";
+import type { NotificationBellProps } from "@/features/notifications/types";
+import { ROUTES } from "@/lib/routes";
+
+function formatBadgeCount(count: number): string {
+  if (count > 99) return "99+";
+  return String(count);
+}
+
+export function NotificationBell({ initialCount, userId, tenantId }: NotificationBellProps) {
+  const { count } = useUnreadCount({ initialCount, userId, tenantId });
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      asChild
+      className="relative"
+      aria-label={count > 0 ? `Notifications — ${count} unread` : "Notifications"}
+    >
+      <Link href={ROUTES.notifications}>
+        <Bell className="size-4" aria-hidden="true" />
+
+        {count > 0 && (
+          <span
+            className={cn(
+              "absolute -right-0.5 -top-0.5 flex items-center justify-center rounded-full bg-destructive text-destructive-foreground font-medium leading-none",
+              count <= 9
+                ? "size-2 text-[0px]" // red dot for 1–9
+                : "min-w-4 h-4 px-1 text-[10px]", // numeric for 10+
+            )}
+            aria-hidden="true"
+          >
+            {count >= 10 ? formatBadgeCount(count) : null}
+          </span>
+        )}
+      </Link>
+    </Button>
+  );
+}

--- a/ui/features/notifications/components/notification-empty-state.tsx
+++ b/ui/features/notifications/components/notification-empty-state.tsx
@@ -1,0 +1,26 @@
+import { EmptyState } from "@enterprise/ui/components/empty-state";
+import { Bell } from "lucide-react";
+
+interface NotificationEmptyStateProps {
+  hasFilter?: boolean;
+}
+
+export function NotificationEmptyState({ hasFilter = false }: NotificationEmptyStateProps) {
+  if (hasFilter) {
+    return (
+      <EmptyState
+        icon={Bell}
+        title="You're all caught up"
+        description="No notifications match the current filter."
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      icon={Bell}
+      title="No notifications yet"
+      description="We'll let you know when something happens."
+    />
+  );
+}

--- a/ui/features/notifications/components/notification-filters.tsx
+++ b/ui/features/notifications/components/notification-filters.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@enterprise/ui/components/select";
+import { cn } from "@enterprise/ui/lib/utils";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import { ROUTES } from "@/lib/routes";
+
+const CATEGORY_OPTIONS = [
+  { value: "all", label: "All categories" },
+  { value: "team", label: "Team" },
+  { value: "billing", label: "Billing" },
+] as const;
+
+export function NotificationFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const currentTab = searchParams.get("tab") ?? "all";
+  const currentCategory = searchParams.get("category") ?? "all";
+
+  function updateParams(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "all") {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    startTransition(() => {
+      router.push(`${ROUTES.notifications}?${params.toString()}`);
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Read state toggle */}
+      <div className="flex items-center rounded-lg bg-muted p-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          onClick={() => updateParams("tab", "all")}
+          className={cn(
+            "h-7 rounded-md px-3 text-xs transition-colors",
+            currentTab === "all" && "bg-background shadow-sm",
+          )}
+        >
+          All
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isPending}
+          onClick={() => updateParams("tab", "unread")}
+          className={cn(
+            "h-7 rounded-md px-3 text-xs transition-colors",
+            currentTab === "unread" && "bg-background shadow-sm",
+          )}
+        >
+          Unread
+        </Button>
+      </div>
+
+      {/* Category dropdown */}
+      <Select
+        value={currentCategory}
+        onValueChange={(value) => updateParams("category", value)}
+        disabled={isPending}
+      >
+        <SelectTrigger className="h-8 w-40 text-xs">
+          <SelectValue placeholder="Category" />
+        </SelectTrigger>
+        <SelectContent>
+          {CATEGORY_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value} className="text-xs">
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/ui/features/notifications/components/notification-item.tsx
+++ b/ui/features/notifications/components/notification-item.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { cn } from "@enterprise/ui/lib/utils";
+import { CreditCard, Users } from "lucide-react";
+import type { NotificationItemProps } from "@/features/notifications/types";
+
+function formatRelativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffMs = now - then;
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return "just now";
+  if (diffMins < 60) return `${diffMins} minute${diffMins === 1 ? "" : "s"} ago`;
+  if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
+  if (diffDays < 30) return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+interface NotificationItemClickableProps extends NotificationItemProps {
+  onClick?: () => void;
+  isLoading?: boolean;
+}
+
+export function NotificationItem({
+  notification,
+  onClick,
+  isLoading,
+}: NotificationItemClickableProps) {
+  const CategoryIcon = notification.category === "billing" ? CreditCard : Users;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-lg p-3 text-left transition-colors",
+        notification.isRead
+          ? "bg-surface-container-low hover:bg-surface-container-high"
+          : "bg-primary/5 hover:bg-primary/10",
+        isLoading && "opacity-50 cursor-wait",
+      )}
+    >
+      {/* Unread dot */}
+      <div className="flex shrink-0 flex-col items-center pt-1">
+        <span
+          className={cn(
+            "size-2 rounded-full",
+            notification.isRead ? "bg-transparent" : "bg-primary",
+          )}
+          role={notification.isRead ? undefined : "status"}
+        />
+      </div>
+
+      {/* Category icon */}
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted">
+        <CategoryIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+      </div>
+
+      {/* Content */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p
+          className={cn(
+            "text-sm leading-tight",
+            notification.isRead ? "font-normal text-foreground" : "font-medium text-foreground",
+          )}
+        >
+          {notification.title}
+        </p>
+        <p className="line-clamp-2 text-xs text-muted-foreground">{notification.body}</p>
+        <p className="text-xs text-muted-foreground/70">
+          {formatRelativeTime(notification.createdAt)}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/ui/features/notifications/components/notification-list.tsx
+++ b/ui/features/notifications/components/notification-list.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { markAsReadAction } from "@/features/notifications/actions";
+import type { NotificationDto } from "@/features/notifications/types";
+import { NotificationEmptyState } from "./notification-empty-state";
+import { NotificationItem } from "./notification-item";
+
+const PAGE_SIZE = 20;
+
+interface NotificationListProps {
+  initialItems: NotificationDto[];
+  hasFilter: boolean;
+}
+
+export function NotificationList({ initialItems, hasFilter }: NotificationListProps) {
+  const router = useRouter();
+  const [items, setItems] = useState(initialItems);
+  const [offset, setOffset] = useState(0);
+  const [markingId, setMarkingId] = useState<string | null>(null);
+
+  const hasPrev = offset > 0;
+  const hasNext = items.length === PAGE_SIZE;
+
+  async function handleMarkAsRead(notificationId: string) {
+    setMarkingId(notificationId);
+    try {
+      await markAsReadAction({ notificationId });
+      // Optimistically update the item in place
+      setItems((prev) =>
+        prev.map((n) =>
+          n.id === notificationId ? { ...n, isRead: true, readAt: new Date().toISOString() } : n,
+        ),
+      );
+      router.refresh();
+    } finally {
+      setMarkingId(null);
+    }
+  }
+
+  if (items.length === 0) {
+    return <NotificationEmptyState hasFilter={hasFilter} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {items.map((notification) => (
+        <NotificationItem
+          key={notification.id}
+          notification={notification}
+          onClick={notification.isRead ? undefined : () => handleMarkAsRead(notification.id)}
+          isLoading={markingId === notification.id}
+        />
+      ))}
+
+      {(hasPrev || hasNext) && (
+        <div className="flex items-center justify-center gap-2 pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!hasPrev}
+            onClick={() => setOffset((prev) => prev - PAGE_SIZE)}
+          >
+            Previous
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Page {Math.floor(offset / PAGE_SIZE) + 1}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!hasNext}
+            onClick={() => setOffset((prev) => prev + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/features/notifications/components/notification-preferences-form.tsx
+++ b/ui/features/notifications/components/notification-preferences-form.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import { Separator } from "@enterprise/ui/components/separator";
+import { Switch } from "@enterprise/ui/components/switch";
+import { cn } from "@enterprise/ui/lib/utils";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { updatePreferencesAction } from "@/features/notifications/actions";
+import type {
+  NotificationCategory,
+  NotificationPreferencesFormProps,
+} from "@/features/notifications/types";
+
+// Critical types that cannot be opted out of
+const CRITICAL_NOTE_BY_CATEGORY: Record<NotificationCategory, string | null> = {
+  team: "Invitation and removal notices are always sent",
+  billing: "Past due and cancellation alerts are always sent",
+  system: null,
+};
+
+const CATEGORY_LABELS: Record<NotificationCategory, string> = {
+  team: "Team notifications",
+  billing: "Billing notifications",
+  system: "System notifications",
+};
+
+// Non-critical notification types per category (what can be toggled)
+const TOGGLEABLE_BY_CATEGORY: Record<NotificationCategory, string[]> = {
+  team: ["Invitation accepted", "Role changes"],
+  billing: ["Plan upgrades", "Plan downgrades", "Subscription activated"],
+  system: [],
+};
+
+interface PreferenceState {
+  category: NotificationCategory;
+  inAppEnabled: boolean;
+  emailEnabled: boolean;
+}
+
+export function NotificationPreferencesForm({ preferences }: NotificationPreferencesFormProps) {
+  const router = useRouter();
+  const [isSaving, setIsSaving] = useState(false);
+  const [savedOk, setSavedOk] = useState(false);
+
+  // Build initial state from props (fill missing categories with defaults)
+  const [prefState, setPrefState] = useState<PreferenceState[]>(() => {
+    const categories: NotificationCategory[] = ["team", "billing"];
+    return categories.map((cat) => {
+      const existing = preferences.find((p) => p.category === cat);
+      return {
+        category: cat,
+        inAppEnabled: existing?.inAppEnabled ?? true,
+        emailEnabled: existing?.emailEnabled ?? true,
+      };
+    });
+  });
+
+  function updatePref(
+    category: NotificationCategory,
+    field: "inAppEnabled" | "emailEnabled",
+    value: boolean,
+  ) {
+    setPrefState((prev) =>
+      prev.map((p) => (p.category === category ? { ...p, [field]: value } : p)),
+    );
+    setSavedOk(false);
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    setSavedOk(false);
+    try {
+      const result = await updatePreferencesAction({
+        preferences: prefState.map((p) => ({
+          category: p.category,
+          inAppEnabled: p.inAppEnabled,
+          emailEnabled: p.emailEnabled,
+        })),
+      });
+      if (result.success) {
+        setSavedOk(true);
+        router.refresh();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const displayCategories = prefState.filter((p) => TOGGLEABLE_BY_CATEGORY[p.category].length > 0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {displayCategories.map((pref, idx) => {
+        const note = CRITICAL_NOTE_BY_CATEGORY[pref.category];
+        const toggleable = TOGGLEABLE_BY_CATEGORY[pref.category];
+
+        return (
+          <div key={pref.category} className="flex flex-col gap-4">
+            {idx > 0 && <Separator />}
+
+            <h2 className="text-base font-semibold">{CATEGORY_LABELS[pref.category]}</h2>
+
+            {/* Toggleable rows */}
+            <div className="flex flex-col gap-3">
+              {toggleable.map((label) => (
+                <div key={label} className="flex items-center justify-between gap-4">
+                  <span className="text-sm text-foreground">{label}</span>
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">In-app</span>
+                      <Switch
+                        checked={pref.inAppEnabled}
+                        onCheckedChange={(checked) =>
+                          updatePref(pref.category, "inAppEnabled", checked)
+                        }
+                        aria-label={`${label} in-app notifications`}
+                        disabled={isSaving}
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">Email</span>
+                      <Switch
+                        checked={pref.emailEnabled}
+                        onCheckedChange={(checked) =>
+                          updatePref(pref.category, "emailEnabled", checked)
+                        }
+                        aria-label={`${label} email notifications`}
+                        disabled={isSaving}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Critical events note */}
+            {note && (
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium">Note:</span> {note}
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex items-center justify-end gap-3 pt-2">
+        {savedOk && (
+          <span className="text-sm text-muted-foreground">Notification preferences updated</span>
+        )}
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving}
+          className={cn(isSaving && "opacity-70")}
+        >
+          {isSaving ? "Saving..." : "Save changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/features/notifications/hooks/use-unread-count.ts
+++ b/ui/features/notifications/hooks/use-unread-count.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { getBrowserClient } from "@enterprise/core/supabase/client";
+import { useEffect, useRef, useState } from "react";
+
+interface UseUnreadCountOptions {
+  initialCount: number;
+  userId: string;
+  tenantId: string;
+}
+
+/**
+ * Manages the notification bell unread count.
+ * - Starts from the SSR-fetched initial count.
+ * - Subscribes to Supabase Realtime INSERT events on the `notifications` table
+ *   filtered by `user_id` to increment on new notifications.
+ * - Exposes decrement (markAsRead) and reset (markAllAsRead) to let UI optimistically update.
+ */
+export function useUnreadCount({ initialCount, userId, tenantId }: UseUnreadCountOptions) {
+  const [count, setCount] = useState(initialCount);
+  // Keep tenantId in a ref for closure safety inside the Realtime callback
+  const tenantIdRef = useRef(tenantId);
+
+  useEffect(() => {
+    tenantIdRef.current = tenantId;
+  }, [tenantId]);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    let isMounted = true;
+    const supabase = getBrowserClient();
+
+    const channel = supabase
+      .channel(`notifications-badge-${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "notifications",
+          filter: `user_id=eq.${userId}`,
+        },
+        (payload: { new: Record<string, unknown> }) => {
+          if (!isMounted) return;
+          // Only increment for the current tenant
+          const row = payload.new;
+          if (row["tenant_id"] === tenantIdRef.current && row["is_read"] === false) {
+            setCount((prev) => prev + 1);
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      isMounted = false;
+      supabase.removeChannel(channel);
+    };
+  }, [userId]);
+
+  function decrement() {
+    setCount((prev) => Math.max(0, prev - 1));
+  }
+
+  function reset() {
+    setCount(0);
+  }
+
+  return { count, decrement, reset };
+}

--- a/ui/features/notifications/queries.ts
+++ b/ui/features/notifications/queries.ts
@@ -1,0 +1,98 @@
+// Server-side data fetching for notification Server Components.
+// These are NOT Server Actions — they are async functions called directly from page.tsx.
+// They use the authenticated Supabase client (RLS-scoped).
+
+import type { NotificationsQueryDto } from "@enterprise/contracts";
+import { notificationsQuerySchema } from "@enterprise/contracts";
+import {
+  getPreferences,
+  getUnreadCount,
+  listNotifications,
+} from "@enterprise/core/services/notification-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+
+// ─── Auth Context Helper ──────────────────────────────────────────────────────
+
+async function getNotificationAuthContext() {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+
+  if (!tenantId) {
+    return null;
+  }
+
+  return { supabase, userId: user.id, tenantId };
+}
+
+// ─── Query Functions ──────────────────────────────────────────────────────────
+
+/**
+ * Fetch paginated notifications for the authenticated user.
+ * Used by the notifications page Server Component.
+ */
+export async function getNotifications(query?: Partial<NotificationsQueryDto>) {
+  const ctx = await getNotificationAuthContext();
+
+  if (!ctx) {
+    return [];
+  }
+
+  const parsed = notificationsQuerySchema.safeParse(query ?? {});
+  const resolvedQuery = parsed.success ? parsed.data : notificationsQuerySchema.parse({});
+
+  const result = await listNotifications(ctx.supabase, ctx.tenantId, ctx.userId, resolvedQuery);
+
+  if (!result.success) {
+    return [];
+  }
+
+  return result.data;
+}
+
+/**
+ * Fetch the unread notification count for the authenticated user.
+ * Used to seed the notification bell's initial count (SSR).
+ */
+export async function getNotificationUnreadCount(): Promise<number> {
+  const ctx = await getNotificationAuthContext();
+
+  if (!ctx) {
+    return 0;
+  }
+
+  const result = await getUnreadCount(ctx.supabase, ctx.tenantId, ctx.userId);
+
+  if (!result.success) {
+    return 0;
+  }
+
+  return result.data.count;
+}
+
+/**
+ * Fetch notification preferences for the authenticated user.
+ * Used by the preferences page Server Component.
+ */
+export async function getNotificationPreferences() {
+  const ctx = await getNotificationAuthContext();
+
+  if (!ctx) {
+    return [];
+  }
+
+  const result = await getPreferences(ctx.supabase, ctx.tenantId, ctx.userId);
+
+  if (!result.success) {
+    return [];
+  }
+
+  return result.data;
+}

--- a/ui/features/notifications/types.ts
+++ b/ui/features/notifications/types.ts
@@ -1,0 +1,50 @@
+// Feature-local type re-exports and UI state types for the notifications feature.
+// Consumers in this feature should import from here, not directly from @enterprise/contracts.
+
+import type {
+  NotificationCategory,
+  NotificationDto,
+  NotificationPreferenceDto,
+} from "@enterprise/contracts";
+
+export type {
+  NotificationCategory,
+  NotificationDto,
+  NotificationPreferenceDto,
+  NotificationType,
+  NotificationsQueryDto,
+  UnreadCountDto,
+  UpdatePreferencesDto,
+} from "@enterprise/contracts";
+
+// ─── UI State Types ───────────────────────────────────────────────────────────
+
+/** Filter state used by notification-filters component and page URL params */
+export interface NotificationFilters {
+  category?: NotificationCategory;
+  isRead?: boolean;
+}
+
+/** Props passed from the notifications page to the notification list component */
+export interface NotificationListProps {
+  initialItems: NotificationDto[];
+  totalUnread: number;
+  filters: NotificationFilters;
+}
+
+/** Props for a single notification item row */
+export interface NotificationItemProps {
+  notification: NotificationDto;
+}
+
+/** Props for the notification preferences form */
+export interface NotificationPreferencesFormProps {
+  preferences: NotificationPreferenceDto[];
+}
+
+/** Bell component props (initial server-fetched count; realtime hook takes over) */
+export interface NotificationBellProps {
+  initialCount: number;
+  userId: string;
+  tenantId: string;
+}

--- a/ui/lib/routes.ts
+++ b/ui/lib/routes.ts
@@ -2,6 +2,8 @@ export const ROUTES = {
   home: "/",
   dashboard: "/dashboard",
   billing: "/billing",
+  notifications: "/notifications",
+  notificationPreferences: "/settings/notifications",
   settings: "/settings",
   team: "/team",
   resources: {

--- a/ui/lib/sentry.ts
+++ b/ui/lib/sentry.ts
@@ -7,6 +7,7 @@ export type SentryArea =
   | "auth"
   | "billing"
   | "dashboard"
+  | "notifications"
   | "resources"
   | "settings"
   | "team"


### PR DESCRIPTION
## Summary

- Full notification UI: center page, preferences page, header bell with Realtime badge
- First Supabase Realtime subscription in the codebase

## Changes

| File | Change |
|------|--------|
| `ui/features/notifications/components/notification-bell.tsx` | Header bell with unread badge (red dot / numeric / 99+) |
| `ui/features/notifications/components/notification-list.tsx` | Paginated list with optimistic mark-as-read |
| `ui/features/notifications/components/notification-item.tsx` | Category icon, title, body, timestamp, unread dot |
| `ui/features/notifications/components/notification-filters.tsx` | All/Unread toggle + category filter via URL params |
| `ui/features/notifications/components/notification-empty-state.tsx` | Empty state variants |
| `ui/features/notifications/components/notification-preferences-form.tsx` | Per-category toggle grid with critical event notes |
| `ui/features/notifications/components/mark-all-read-button.tsx` | Bulk action with count label |
| `ui/features/notifications/hooks/use-unread-count.ts` | Supabase Realtime INSERT subscription for badge |
| `ui/app/(protected)/notifications/page.tsx` | Server Component with guest redirect and parallel fetch |
| `ui/app/(protected)/settings/notifications/page.tsx` | Server Component for preferences |
| `ui/components/layout/header.tsx` | NotificationBell between ThemeToggle and avatar |
| `ui/components/layout/dashboard-shell.tsx` | Thread userId/tenantId/initialUnreadCount to Header |
| `ui/app/(protected)/layout.tsx` | Fetch initialUnreadCount for SSR |

### UI Verification
- [x] All UI states handled (loading, empty, error)
- [x] Guest guard on bell and pages
- [x] Realtime subscription with cleanup on unmount

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

**PR 5 of 6** in the notifications feature chain (stacked-to-main).