### PR TITLE
feat(brand): add brand config schema, provider, and layout integration

### DIFF
--- a/openspec/changes/brand-and-decoupling/tasks.md
+++ b/openspec/changes/brand-and-decoupling/tasks.md
@@ -1,0 +1,204 @@
+# Tasks: Brand Abstraction Layer + Backend Provider Decoupling
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2600 (A: ~5, B: ~1000, C: ~1600) |
+| 800-line budget risk | High (total), mitigated by 5-PR split |
+| Chained PRs recommended | Yes |
+| Suggested split | PR-A → PR-B1 → PR-B2 (B-track) \| PR-C1 → PR-C2 → PR-C3 (C-track) |
+| Delivery strategy | auto-forecast |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Est. Lines | Notes |
+|------|------|-----------|------------|-------|
+| A | Roadmap fix | PR-A | ~5 | Merge to main independently; trivial |
+| B1 | Brand contracts + module + provider + layout | PR-B1 | ~600 | Base: main; typecheck must pass standalone |
+| B2 | BrandLogo + BrandFooter + subpath exports + E2E | PR-B2 | ~400 | Base: PR-B1 branch |
+| C1 | Port interfaces + adapters + factory (additive) | PR-C1 | ~500 | Base: main; no behavior change |
+| C2 | auth-service + actions + middleware migration | PR-C2 | ~600 | Base: PR-C1 branch; invasive |
+| C3 | Test rewrite to port mocks + env docs + migration guide | PR-C3 | ~500 | Base: PR-C2 branch |
+
+B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
+
+---
+
+## PR-A: Roadmap Fix
+
+### Phase 1: Roadmap Update
+
+- [ ] A.1.1 Edit `docs/features/roadmap.md`: change Notifications (#10) status from `"Planned"` to `"Done"`
+- [ ] A.1.2 Verify: grep roadmap.md confirms `"Done"` on the Notifications row
+
+---
+
+## PR-B1: Brand Contracts + Module + Provider + Layout
+
+### Phase 1: Schema (RED → GREEN)
+
+- [x] B1.1.1 RED: Write `packages/contracts/src/schemas/__tests__/brand.test.ts` — 6 scenarios: valid full config passes, minimal config passes, invalid slug rejected at path `["slug"]`, missing nested field rejected, features non-boolean rejected, social.twitter invalid URL rejected
+- [x] B1.1.2 GREEN: Create `packages/contracts/src/schemas/brand.ts` — `brandLogoVariantSchema`, `brandLogoSchema`, `brandMetadataSchema`, `brandLegalSchema`, `brandSocialSchema`, `brandConfigSchema`; export types `BrandConfig`, `BrandLogoVariant`, `BrandLogo`, `BrandMetadata`, `BrandLegal`, `BrandSocial`
+- [x] B1.1.3 Export all brand schemas + types from `packages/contracts/src/index.ts`
+- [x] B1.1.4 Run vitest — all schema tests GREEN
+
+### Phase 2: Brand Registry (RED → GREEN)
+
+- [x] B1.2.1 RED: Write `packages/ui/src/brand/__tests__/registry.test.ts` — scenarios: duplicate slug throws, no brands throws on `getDefaultBrand()`, `getDefaultBrand()` returns `isDefault=true` brand, falls back to `"enterprise"` slug
+- [x] B1.2.2 GREEN: Create `packages/ui/src/brands/enterprise.brand.ts` — default enterprise brand config satisfying `brandConfigSchema`
+- [x] B1.2.3 GREEN: Create `packages/ui/src/brand/registry.ts` — `buildRegistry()`, `getAllBrands()`, `getBrandBySlug()`, `getDefaultBrand()`; pure helpers + lazy singleton; throws on duplicate slug or missing default
+- [x] B1.2.4 Run vitest — all registry tests GREEN
+
+### Phase 3: Brand Resolution (RED → GREEN)
+
+- [x] B1.3.1 RED: Write `packages/ui/src/brand/__tests__/resolve.test.ts` — scenarios: `BRAND_SLUG` forces brand, unknown `BRAND_SLUG` throws with available slugs, subdomain resolves, unrecognized subdomain warns+falls back, path prefix resolves, static asset paths produce no spurious warn
+- [x] B1.3.2 GREEN: Create `packages/ui/src/brand/resolve.ts` — `resolveBrand()` server-only function + `resolveBrandFromRegistry()` pure testable variant; priority chain: env → subdomain → path prefix → `getDefaultBrand()`; `console.warn` on unrecognized fallback
+- [x] B1.3.3 Run vitest — all resolve tests GREEN
+
+### Phase 4: BrandProvider + useBrand() (RED → GREEN)
+
+- [x] B1.4.1 RED: Write `packages/ui/src/brand/__tests__/provider.test.ts` — scenarios: `useBrand()` returns brand inside provider, `useBrand()` throws outside provider with `<BrandProvider>` guidance, ThemeProvider receives derived `defaultMode` from `themeRef`
+- [x] B1.4.2 GREEN: Create `packages/ui/src/brand/context.ts` — `BrandContext = createContext<BrandContextValue | null>(null)`
+- [x] B1.4.3 GREEN: Create `packages/ui/src/brand/provider.tsx` — `"use client"`, `BrandProvider` wraps `ThemeProvider` deriving mode from `themeRef`, `useBrand()` hook
+- [x] B1.4.4 Run vitest — all provider tests GREEN
+
+### Phase 5: generateBrandMetadata() (RED → GREEN)
+
+- [x] B1.5.1 RED: Write `packages/ui/src/brand/__tests__/metadata.test.ts` — scenario: all fields mapped correctly; `openGraph.images = []` when `ogImage` falsy
+- [x] B1.5.2 GREEN: Create `packages/ui/src/brand/metadata.ts` — `generateBrandMetadata(brand: BrandConfig): Metadata`; returns `title.template`, `title.default`, `description`, `icons.icon`, `openGraph.images`
+- [x] B1.5.3 Run vitest — metadata test GREEN
+
+### Phase 6: Layout Integration
+
+- [x] B1.6.1 Modify `ui/app/layout.tsx`: convert static `metadata` export to `async generateMetadata()` calling `resolveBrand()` + `generateBrandMetadata()`
+- [x] B1.6.2 Wrap `children` with `<BrandProvider brand={brand}>` in `RootLayout`; preserve font `className` on `<html>`, preserve `<Toaster>` as sibling (not inside BrandProvider)
+- [x] B1.6.3 Run `pnpm typecheck` from root — no errors
+
+### Phase 7: Barrel Export (packages/ui)
+
+- [x] B1.7.1 Create `packages/ui/src/brand/index.ts` — re-exports `BrandProvider`, `useBrand`, `BrandContext`
+- [x] B1.7.2 Add subpath exports to `packages/ui/package.json`: `"./brand/provider"`, `"./brand/context"`, `"./brand/resolve"`, `"./brand/registry"`, `"./brand/metadata"`
+- [x] B1.7.3 Add brand barrel to `packages/ui/src/index.ts` (or existing barrel entry point)
+- [x] B1.7.4 Run `pnpm typecheck` + `pnpm lint` — clean
+
+---
+
+## PR-B2: BrandLogo + BrandFooter + E2E (base: PR-B1)
+
+### Phase 1: BrandLogo (RED → GREEN)
+
+- [ ] B2.1.1 RED: Write `packages/ui/src/brand/__tests__/logo.test.tsx` — scenarios: correct variant rendered by mode (`light`/`dark`), empty `src` renders `<span>` with `displayName`
+- [ ] B2.1.2 GREEN: Create `packages/ui/src/brand/logo.tsx` — `"use client"`, reads `useBrand().logo` + `useTheme()`, renders `<img>` with variant src+alt, falls back to `<span>` when src empty, forwards `className`
+- [ ] B2.1.3 Run vitest — logo tests GREEN
+
+### Phase 2: BrandFooter (RED → GREEN)
+
+- [ ] B2.2.1 RED: Write `packages/ui/src/brand/__tests__/footer.test.tsx` — scenarios: legal links rendered when non-empty, omitted when empty string, social links when `brand.social` present, "Powered by" when `features?.showPoweredBy === true`
+- [ ] B2.2.2 GREEN: Create `packages/ui/src/brand/footer.tsx` — `"use client"`, `© year displayName`, conditional legal `<a>` links, conditional social links, conditional "Powered by"
+- [ ] B2.2.3 Run vitest — footer tests GREEN
+
+### Phase 3: Subpath Exports + Barrel (finish)
+
+- [ ] B2.3.1 Add `BrandLogo`, `BrandFooter` to `packages/ui/src/brand/index.ts`
+- [ ] B2.3.2 Add subpath exports for `./brand/logo` and `./brand/footer` to `packages/ui/package.json`
+- [ ] B2.3.3 Run `pnpm typecheck` — clean
+
+### Phase 4: E2E Tests
+
+- [ ] B2.4.1 Write `ui/e2e/brand/brand.spec.ts` — scenarios: default brand renders (logo visible), `BRAND_SLUG` env override resolves correct brand, existing auth E2E suite passes unchanged
+- [ ] B2.4.2 Run `pnpm e2e` — brand suite GREEN
+
+---
+
+## PR-C1: Port Interfaces + Adapters + Factory (base: main)
+
+### Phase 1: Port Interfaces (RED → GREEN)
+
+- [ ] C1.1.1 RED: Write `packages/core/src/services/ports/__tests__/auth-port.test.ts` — scenarios: mock satisfies `AuthPort` interface without SDK import; `getUser` mock returns `null` (not error) for anonymous
+- [ ] C1.1.2 GREEN: Create `packages/core/src/services/ports/auth-port.ts` — `AuthPort` interface; 7 methods with correct `ServiceResult<T>` return types; no SDK imports
+- [ ] C1.1.3 RED: Write `packages/core/src/services/ports/__tests__/storage-port.test.ts` — scenarios: mock satisfies `StoragePort` interface; delete accepts multiple paths
+- [ ] C1.1.4 GREEN: Create `packages/core/src/services/ports/storage-port.ts` — `StoragePort` interface; 6 methods + supporting types exported (`StorageUploadResult`, `StorageSignedUrlResult`, `StoragePublicUrlResult`, `StorageFileEntry`)
+- [ ] C1.1.5 GREEN: Create `packages/core/src/services/ports/session-port.ts` — `SessionPort` interface; single `refreshSession(request: NextRequest): Promise<NextResponse>`
+- [ ] C1.1.6 Run vitest — all port tests GREEN
+
+### Phase 2: Supabase Adapters (RED → GREEN)
+
+- [ ] C1.2.1 RED: Write `packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts` — scenarios: `signInWithPassword` maps Supabase error to `INVALID_CREDENTIALS`; `getUserRole` ignores `PGRST116` and returns `{ role: "guest" }`
+- [ ] C1.2.2 GREEN: Create `packages/core/src/services/adapters/supabase-auth-adapter.ts` — `SupabaseAuthAdapter implements AuthPort`; constructor `(client: SupabaseClient)`; maps all 7 methods; all error codes listed in spec
+- [ ] C1.2.3 RED: Write `packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts` — scenarios: `upload` returns `path+fullPath`; `getPublicUrl` always succeeds (no error path)
+- [ ] C1.2.4 GREEN: Create `packages/core/src/services/adapters/supabase-storage-adapter.ts` — `SupabaseStorageAdapter implements StoragePort`; constructor `(client: SupabaseClient)`
+- [ ] C1.2.5 GREEN: Create `packages/core/src/services/adapters/supabase-session-adapter.ts` — `SupabaseSessionAdapter implements SessionPort`; delegates `refreshSession()` to `updateSession()`; constructor `(supabaseUrl, supabaseAnonKey)`
+- [ ] C1.2.6 Run vitest — all adapter tests GREEN
+
+### Phase 3: Factory (RED → GREEN)
+
+- [ ] C1.3.1 RED: Write `packages/core/src/services/__tests__/backend-adapters.test.ts` — scenarios: default returns Supabase adapters; unknown provider throws with guidance; missing `NEXT_PUBLIC_SUPABASE_URL` throws descriptive error
+- [ ] C1.3.2 GREEN: Create `packages/core/src/services/backend-adapters.ts` — `createBackendAdapters()` returning `{ auth: (client) => AuthPort, storage: (client) => StoragePort, session: SessionPort }`; reads `BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- [ ] C1.3.3 Run vitest — factory tests GREEN
+
+### Phase 4: Exports
+
+- [ ] C1.4.1 Export `AuthPort`, `StoragePort`, `SessionPort` from `packages/core/src/services/index.ts` (subpath export)
+- [ ] C1.4.2 Export `createBackendAdapters` from `packages/core/src/services/index.ts`
+- [ ] C1.4.3 Run `pnpm typecheck` + `pnpm lint` — clean
+
+---
+
+## PR-C2: Service Migration + Actions + Middleware (base: PR-C1)
+
+### Phase 1: auth-service Migration
+
+- [ ] C2.1.1 Modify `packages/core/src/services/auth-service.ts`: change all 7 function signatures — first param `SupabaseClient` → `AuthPort`; bodies become thin delegations `return auth.method(input)`; remove all `@supabase/supabase-js` SDK calls from service functions
+- [ ] C2.1.2 Run `pnpm typecheck` — verify no SDK imports remain in service functions
+
+### Phase 2: Server Actions Migration
+
+- [ ] C2.2.1 Modify `ui/features/auth/actions.ts`: add `createBackendAdapters()` at module level; add per-request `authFactory(client)` call inside each action; replace `client` → `auth` (AuthPort) in service function calls for all 6 Server Actions
+- [ ] C2.2.2 Run `pnpm typecheck` — actions file clean
+
+### Phase 3: Middleware Migration
+
+- [ ] C2.3.1 Modify `ui/middleware.ts`: import `createBackendAdapters`; call at module level to get `sessionPort`; replace `updateSession(request)` call with `sessionPort.refreshSession(request)`; retain `createMiddlewareClient` for `getUserRoleService` DB query; add comment `// TODO: DatabasePort — see brand-and-decoupling migration guide`
+- [ ] C2.3.2 Run `pnpm typecheck` + `pnpm lint` — middleware clean
+
+### Phase 4: Integration Verify
+
+- [ ] C2.4.1 Run full `pnpm test` — all existing auth tests pass (may be failing until C3 rewrite — acceptable at this PR stage; document in PR description)
+- [ ] C2.4.2 Run `pnpm typecheck` from root — zero errors
+
+---
+
+## PR-C3: Test Rewrite + Env Docs + Migration Guide (base: PR-C2)
+
+### Phase 1: Port Mock Helpers (RED → GREEN)
+
+- [ ] C3.1.1 Create `packages/core/src/services/__tests__/mocks/auth-port.mock.ts` — `createMockAuthPort()` returning object with 7 `vi.fn()` stubs; zero `@supabase/supabase-js` imports
+- [ ] C3.1.2 Create `packages/core/src/services/__tests__/mocks/storage-port.mock.ts` — `createMockStoragePort()` returning object with 6 `vi.fn()` stubs
+
+### Phase 2: auth-service Test Rewrite (RED → GREEN)
+
+- [ ] C3.2.1 Rewrite `packages/core/src/services/__tests__/auth-service.test.ts`: use `createMockAuthPort()` in all test cases; no `@supabase/supabase-js` import in test file; verify `signInWithPasswordService` delegates to `auth.signInWithPassword`; verify all 7 functions delegate correctly
+- [ ] C3.2.2 Run vitest — all auth-service tests GREEN
+
+### Phase 3: Env Docs
+
+- [ ] C3.3.1 Add to `.env.example`: `BRAND_SLUG=` (optional, with comment), `BACKEND_AUTH_PROVIDER=supabase` (with comment), `BACKEND_STORAGE_PROVIDER=supabase` (with comment)
+- [ ] C3.3.2 Update `AGENTS.md` or `packages/core/AGENTS.md` to document the port pattern for new services
+
+### Phase 4: Migration Guide
+
+- [ ] C3.4.1 Create `docs/migrations/brand-and-decoupling-migration-guide.md` — covers: auth-service signature breaking change (SupabaseClient → AuthPort), adapter injection pattern for Server Actions, implementing a custom AuthPort, implementing a custom StoragePort, test setup with `createMockAuthPort()`
+
+### Phase 5: Final Verification
+
+- [ ] C3.5.1 Run `pnpm typecheck` from root — zero errors
+- [ ] C3.5.2 Run `pnpm lint` from root — zero errors  
+- [ ] C3.5.3 Run `pnpm test` — all unit tests GREEN (auth-service + adapters + factory + brand schema + registry + resolve)
+- [ ] C3.5.4 Run `pnpm e2e` — brand suite + auth suite GREEN

--- a/packages/contracts/src/__tests__/brand.test.ts
+++ b/packages/contracts/src/__tests__/brand.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  brandConfigSchema,
+  brandLegalSchema,
+  brandLogoSchema,
+  brandLogoVariantSchema,
+  brandMetadataSchema,
+  brandSocialSchema,
+} from "../schemas/brand";
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+const validLogoVariant = {
+  src: "/images/enterprise/logo-light.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+} as const;
+
+const validLogo = {
+  light: validLogoVariant,
+  dark: { ...validLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+} as const;
+
+const validMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+} as const;
+
+const validLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+} as const;
+
+const validSocial = {
+  github: "https://github.com/your-org",
+  twitter: "https://twitter.com/your-org",
+  linkedin: "https://linkedin.com/company/your-org",
+} as const;
+
+const validFullConfig = {
+  slug: "enterprise",
+  name: "enterprise",
+  displayName: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  logo: validLogo,
+  favicon: "/images/enterprise/favicon.svg",
+  metadata: validMetadata,
+  legal: validLegal,
+  social: validSocial,
+  themeRef: "light",
+  features: { showPoweredBy: true },
+  isDefault: true,
+} as const;
+
+const validMinimalConfig = {
+  slug: "enterprise",
+  name: "enterprise",
+  displayName: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  logo: validLogo,
+  favicon: "/images/enterprise/favicon.svg",
+  metadata: validMetadata,
+  legal: validLegal,
+  themeRef: "light",
+} as const;
+
+// ============================================================================
+// brandLogoVariantSchema
+// ============================================================================
+
+describe("brandLogoVariantSchema", () => {
+  it("accepts a valid logo variant", () => {
+    expect(brandLogoVariantSchema.safeParse(validLogoVariant).success).toBe(true);
+  });
+
+  it("accepts empty src (text fallback)", () => {
+    expect(brandLogoVariantSchema.safeParse({ src: "", alt: "Logo" }).success).toBe(true);
+  });
+
+  it("rejects missing alt text", () => {
+    const result = brandLogoVariantSchema.safeParse({ src: "/logo.svg", alt: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative width", () => {
+    const result = brandLogoVariantSchema.safeParse({ src: "/logo.svg", alt: "Logo", width: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// brandLogoSchema
+// ============================================================================
+
+describe("brandLogoSchema", () => {
+  it("accepts valid light + dark variants", () => {
+    expect(brandLogoSchema.safeParse(validLogo).success).toBe(true);
+  });
+
+  it("rejects missing dark variant", () => {
+    const result = brandLogoSchema.safeParse({ light: validLogoVariant });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// brandMetadataSchema
+// ============================================================================
+
+describe("brandMetadataSchema", () => {
+  it("accepts valid metadata", () => {
+    expect(brandMetadataSchema.safeParse(validMetadata).success).toBe(true);
+  });
+
+  it("rejects empty titleTemplate", () => {
+    const result = brandMetadataSchema.safeParse({ ...validMetadata, titleTemplate: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty defaultTitle", () => {
+    const result = brandMetadataSchema.safeParse({ ...validMetadata, defaultTitle: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty ogImage (optional URL)", () => {
+    const result = brandMetadataSchema.safeParse({ ...validMetadata, ogImage: "" });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// brandLegalSchema
+// ============================================================================
+
+describe("brandLegalSchema", () => {
+  it("accepts valid legal URLs", () => {
+    expect(brandLegalSchema.safeParse(validLegal).success).toBe(true);
+  });
+
+  it("accepts empty strings (suppresses links)", () => {
+    const result = brandLegalSchema.safeParse({ privacyUrl: "", termsUrl: "" });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// brandSocialSchema
+// ============================================================================
+
+describe("brandSocialSchema", () => {
+  it("accepts valid social URLs", () => {
+    expect(brandSocialSchema.safeParse(validSocial).success).toBe(true);
+  });
+
+  it("accepts empty object (all optional)", () => {
+    expect(brandSocialSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects invalid twitter URL", () => {
+    const result = brandSocialSchema.safeParse({ twitter: "not-a-url" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("twitter");
+    }
+  });
+
+  it("rejects invalid linkedin URL", () => {
+    const result = brandSocialSchema.safeParse({ linkedin: "not-a-url" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// brandConfigSchema — full contract tests
+// ============================================================================
+
+describe("brandConfigSchema", () => {
+  it("accepts a valid full config", () => {
+    const result = brandConfigSchema.safeParse(validFullConfig);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a minimal config (only required fields)", () => {
+    const result = brandConfigSchema.safeParse(validMinimalConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.social).toBeUndefined();
+      expect(result.data.features).toBeUndefined();
+      expect(result.data.isDefault).toBeUndefined();
+    }
+  });
+
+  it("rejects invalid slug (spaces)", () => {
+    const result = brandConfigSchema.safeParse({ ...validMinimalConfig, slug: "My Brand" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("slug");
+    }
+  });
+
+  it("rejects invalid slug (uppercase)", () => {
+    const result = brandConfigSchema.safeParse({ ...validMinimalConfig, slug: "Enterprise" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty slug", () => {
+    const result = brandConfigSchema.safeParse({ ...validMinimalConfig, slug: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("slug");
+    }
+  });
+
+  it("rejects missing nested field logo.light.alt", () => {
+    const badLogo = {
+      light: { src: "/logo.svg", alt: "" },
+      dark: { src: "/logo-dark.svg", alt: "Logo" },
+    };
+    const result = brandConfigSchema.safeParse({ ...validMinimalConfig, logo: badLogo });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths.some((p) => p.includes("logo"))).toBe(true);
+    }
+  });
+
+  it("rejects features with non-boolean value", () => {
+    const result = brandConfigSchema.safeParse({
+      ...validMinimalConfig,
+      features: { enabled: 1 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects social.twitter with invalid URL", () => {
+    const result = brandConfigSchema.safeParse({
+      ...validMinimalConfig,
+      social: { twitter: "not-a-url" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths.some((p) => p.includes("twitter"))).toBe(true);
+    }
+  });
+
+  it("rejects empty themeRef", () => {
+    const result = brandConfigSchema.safeParse({ ...validMinimalConfig, themeRef: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty metadata.titleTemplate", () => {
+    const result = brandConfigSchema.safeParse({
+      ...validMinimalConfig,
+      metadata: { ...validMetadata, titleTemplate: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,7 +3,21 @@
 
 // Re-export Zod for convenience
 export { z } from "zod";
-
+export * from "./dto/billing";
+export * from "./dto/notifications";
+// DTOs
+export * from "./dto/platform";
+export * from "./dto/resources";
+export * from "./dto/tenant-team";
+export * from "./dto/workspace-admin";
+export type {
+  BrandConfig,
+  BrandLegal,
+  BrandLogo,
+  BrandLogoVariant,
+  BrandMetadata,
+  BrandSocial,
+} from "./schemas/brand";
 // Brand system — schemas and types
 export {
   brandConfigSchema,
@@ -13,21 +27,6 @@ export {
   brandMetadataSchema,
   brandSocialSchema,
 } from "./schemas/brand";
-export type {
-  BrandConfig,
-  BrandLegal,
-  BrandLogo,
-  BrandLogoVariant,
-  BrandMetadata,
-  BrandSocial,
-} from "./schemas/brand";
-export * from "./dto/billing";
-export * from "./dto/notifications";
-// DTOs
-export * from "./dto/platform";
-export * from "./dto/resources";
-export * from "./dto/tenant-team";
-export * from "./dto/workspace-admin";
 export type {
   InvitationMetadata,
   PaginationParams,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,24 @@
 
 // Re-export Zod for convenience
 export { z } from "zod";
+
+// Brand system — schemas and types
+export {
+  brandConfigSchema,
+  brandLegalSchema,
+  brandLogoSchema,
+  brandLogoVariantSchema,
+  brandMetadataSchema,
+  brandSocialSchema,
+} from "./schemas/brand";
+export type {
+  BrandConfig,
+  BrandLegal,
+  BrandLogo,
+  BrandLogoVariant,
+  BrandMetadata,
+  BrandSocial,
+} from "./schemas/brand";
 export * from "./dto/billing";
 export * from "./dto/notifications";
 // DTOs

--- a/packages/contracts/src/schemas/brand.ts
+++ b/packages/contracts/src/schemas/brand.ts
@@ -1,0 +1,166 @@
+// Brand system schemas — single source of truth for brand identity configuration
+
+import { z } from "zod";
+
+// ============================================================================
+// Logo variant — a single light or dark logo asset
+// ============================================================================
+
+export const brandLogoVariantSchema = z.object({
+  /** Absolute path or full CDN URL for the logo image. Empty string triggers text fallback. */
+  src: z.string(),
+  /** Alt text for the <img> element — required for accessibility. */
+  alt: z.string().min(1, "Logo alt text must not be empty"),
+  /** Optional explicit width in pixels. Used to prevent layout shift. */
+  width: z.number().int().positive().optional(),
+  /** Optional explicit height in pixels. */
+  height: z.number().int().positive().optional(),
+});
+
+// ============================================================================
+// Logo — light + dark variants
+// ============================================================================
+
+export const brandLogoSchema = z.object({
+  light: brandLogoVariantSchema,
+  dark: brandLogoVariantSchema,
+});
+
+// ============================================================================
+// Metadata — Open Graph and page title configuration
+// ============================================================================
+
+export const brandMetadataSchema = z.object({
+  /**
+   * Next.js title template. Use "%s" as the placeholder for the page title.
+   * Example: "%s | Acme Platform"
+   */
+  titleTemplate: z.string().min(1),
+  /**
+   * Default page title used when no per-page title is set.
+   * Also used for the home page <title> tag.
+   */
+  defaultTitle: z.string().min(1),
+  /**
+   * Default meta description. Used as og:description when no page-level
+   * description is provided.
+   */
+  description: z.string().min(1),
+  /**
+   * Absolute path or full URL for the Open Graph image.
+   * Used as og:image on all pages unless overridden per-page.
+   */
+  ogImage: z.string(),
+});
+
+// ============================================================================
+// Legal — privacy policy and terms of service URLs
+// ============================================================================
+
+export const brandLegalSchema = z.object({
+  /** Full URL to the privacy policy page. Empty string suppresses the link. */
+  privacyUrl: z.string(),
+  /** Full URL to the terms of service page. Empty string suppresses the link. */
+  termsUrl: z.string(),
+});
+
+// ============================================================================
+// Social links — optional external profile URLs
+// ============================================================================
+
+export const brandSocialSchema = z.object({
+  /** Twitter / X profile URL */
+  twitter: z.string().url().optional(),
+  /** LinkedIn company page URL */
+  linkedin: z.string().url().optional(),
+  /** GitHub organization or user profile URL */
+  github: z.string().url().optional(),
+});
+
+// ============================================================================
+// BrandConfig — top-level schema
+// ============================================================================
+
+export const brandConfigSchema = z.object({
+  /**
+   * URL-safe unique identifier. Must be lowercase, alphanumeric with hyphens.
+   * Used for subdomain matching, path prefix matching, and the BRAND_SLUG env var.
+   * Example: "enterprise", "acme", "acme-eu"
+   */
+  slug: z
+    .string()
+    .min(1)
+    .regex(
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+      'Slug must be lowercase alphanumeric with optional hyphens (e.g. "acme-eu")',
+    ),
+
+  /**
+   * Internal identifier used in audit events, Sentry tags, and log output.
+   * Human-readable but not shown to end users.
+   */
+  name: z.string().min(1),
+
+  /**
+   * Human-readable brand name shown in UI headings, footers, and browser tabs.
+   * Example: "Acme Platform", "Enterprise"
+   */
+  displayName: z.string().min(1),
+
+  /**
+   * Short description of the brand. Used in internal docs and meta tags
+   * when no page-level description is provided.
+   */
+  description: z.string().min(1),
+
+  /** Light and dark logo variants. */
+  logo: brandLogoSchema,
+
+  /**
+   * Path or URL to the favicon asset.
+   * Recommended: SVG or 32×32 ICO. Example: "/images/enterprise/favicon.svg"
+   */
+  favicon: z.string().min(1),
+
+  /** Open Graph and page title configuration. */
+  metadata: brandMetadataSchema,
+
+  /** Legal link URLs for privacy policy and terms of service. */
+  legal: brandLegalSchema,
+
+  /** Optional external social profile links. */
+  social: brandSocialSchema.optional(),
+
+  /**
+   * Key that references which theme JSON file to apply.
+   * Must match the "metadata.name" field of a theme JSON in packages/ui/src/themes/.
+   * Examples: "light", "dark", "acme-light"
+   * The brand layer does not embed token values — it declares which token set to use.
+   */
+  themeRef: z.string().min(1),
+
+  /**
+   * Optional brand-scoped feature toggles.
+   * Keys are feature names; values are boolean flags.
+   * Example: { "showPoweredBy": true, "enablePublicApi": false }
+   */
+  features: z.record(z.string(), z.boolean()).optional(),
+
+  /**
+   * When true, this brand is returned as the fallback when no slug matches.
+   * At most one brand in the registry should set this to true.
+   * If no brand has isDefault=true, the "enterprise" slug is used as the default.
+   */
+  isDefault: z.boolean().optional(),
+});
+
+// ============================================================================
+// Inferred TypeScript types
+// ============================================================================
+
+export type BrandConfig = z.infer<typeof brandConfigSchema>;
+export type BrandLogoVariant = z.infer<typeof brandLogoVariantSchema>;
+export type BrandLogo = z.infer<typeof brandLogoSchema>;
+export type BrandMetadata = z.infer<typeof brandMetadataSchema>;
+export type BrandLegal = z.infer<typeof brandLegalSchema>;
+export type BrandSocial = z.infer<typeof brandSocialSchema>;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,12 @@
     "./theme/context": "./src/theme/context.ts",
     "./theme/provider": "./src/theme/provider.tsx",
     "./theme/toggle": "./src/theme/toggle.tsx",
-    "./hooks/*": "./src/hooks/*.ts"
+    "./hooks/*": "./src/hooks/*.ts",
+    "./brand/context": "./src/brand/context.ts",
+    "./brand/provider": "./src/brand/provider.tsx",
+    "./brand/resolve": "./src/brand/resolve.ts",
+    "./brand/registry": "./src/brand/registry.ts",
+    "./brand/metadata": "./src/brand/metadata.ts"
   },
   "scripts": {
     "build:theme": "tsx scripts/build-theme.ts",
@@ -29,11 +34,13 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "next": "^15.5.18",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "zod": "^3.25.0"
   },
   "peerDependencies": {
+    "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0"

--- a/packages/ui/src/brand/__tests__/metadata.test.ts
+++ b/packages/ui/src/brand/__tests__/metadata.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+import { generateBrandMetadata } from "../metadata";
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const validMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: validMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("generateBrandMetadata", () => {
+  it("maps all fields correctly from a full BrandConfig", () => {
+    const brand = makeBrand();
+    const result = generateBrandMetadata(brand);
+
+    expect(result.title).toEqual({
+      template: "%s | Enterprise Platform",
+      default: "Enterprise Platform",
+    });
+    expect(result.description).toBe("The enterprise-grade SaaS platform template.");
+    expect(result.icons).toEqual({ icon: "/images/enterprise/favicon.svg" });
+    expect(result.openGraph).toMatchObject({
+      title: "Enterprise Platform",
+      description: "The enterprise-grade SaaS platform template.",
+      images: ["/images/enterprise/og-image.png"],
+    });
+  });
+
+  it("sets openGraph.images = [] when ogImage is empty string", () => {
+    const brand = makeBrand({
+      metadata: { ...validMetadata, ogImage: "" },
+    });
+    const result = generateBrandMetadata(brand);
+    expect(result.openGraph?.images).toEqual([]);
+  });
+
+  it("uses titleTemplate and defaultTitle for title object", () => {
+    const brand = makeBrand({
+      metadata: {
+        ...validMetadata,
+        titleTemplate: "%s | Acme",
+        defaultTitle: "Acme Platform",
+      },
+    });
+    const result = generateBrandMetadata(brand);
+    expect(result.title).toEqual({
+      template: "%s | Acme",
+      default: "Acme Platform",
+    });
+  });
+
+  it("uses brand favicon for icons.icon", () => {
+    const brand = makeBrand({ favicon: "/acme/favicon.ico" });
+    const result = generateBrandMetadata(brand);
+    expect(result.icons).toEqual({ icon: "/acme/favicon.ico" });
+  });
+});

--- a/packages/ui/src/brand/__tests__/metadata.test.ts
+++ b/packages/ui/src/brand/__tests__/metadata.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { BrandConfig } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
 import { generateBrandMetadata } from "../metadata";
 
 // ============================================================================

--- a/packages/ui/src/brand/__tests__/provider.test.ts
+++ b/packages/ui/src/brand/__tests__/provider.test.ts
@@ -8,10 +8,10 @@
  * - ThemeProvider receives the correct defaultMode derived from themeRef
  */
 
+import type { BrandConfig } from "@enterprise/contracts";
 import { act, createElement, useContext } from "react";
 import * as ReactDOM from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BrandConfig } from "@enterprise/contracts";
 
 // ============================================================================
 // Mock ThemeProvider to capture the defaultMode prop passed to it
@@ -140,6 +140,7 @@ describe("BrandProvider + useBrand", () => {
     let threwError = false;
     function OutsideConsumer() {
       try {
+        // biome-ignore lint/correctness/useHookAtTopLevel: deliberately calling the hook outside a provider to assert it throws
         useBrand();
       } catch {
         threwError = true;
@@ -148,7 +149,11 @@ describe("BrandProvider + useBrand", () => {
     }
 
     const contextValue = null;
-    const tree = createElement(BrandContext, { value: contextValue }, createElement(OutsideConsumer));
+    const tree = createElement(
+      BrandContext,
+      { value: contextValue },
+      createElement(OutsideConsumer),
+    );
     const { root } = renderTree(tree);
     cleanup.push(() => act(() => root.unmount()));
     expect(threwError).toBe(true);

--- a/packages/ui/src/brand/__tests__/provider.test.ts
+++ b/packages/ui/src/brand/__tests__/provider.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment happy-dom
+/**
+ * BrandProvider + useBrand() tests
+ *
+ * Tests cover:
+ * - useBrand() returns the brand config inside BrandProvider
+ * - useBrand() throws with guidance when called outside BrandProvider
+ * - ThemeProvider receives the correct defaultMode derived from themeRef
+ */
+
+import { act, createElement, useContext } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Mock ThemeProvider to capture the defaultMode prop passed to it
+// ============================================================================
+
+let capturedDefaultMode: string | undefined;
+
+vi.mock("../../theme/provider", () => ({
+  ThemeProvider: ({
+    children,
+    defaultMode,
+  }: {
+    children: React.ReactNode;
+    defaultMode?: string;
+  }) => {
+    capturedDefaultMode = defaultMode;
+    return children;
+  },
+}));
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "Enterprise Platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): { container: HTMLDivElement; root: ReactDOM.Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandProvider + useBrand", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    capturedDefaultMode = undefined;
+  });
+
+  it("useBrand() returns the brand config inside BrandProvider", async () => {
+    const { BrandProvider, useBrand } = await import("../provider");
+    const brand = makeBrand();
+    let captured: BrandConfig | null = null;
+
+    function Consumer() {
+      captured = useBrand();
+      return null;
+    }
+
+    const tree = createElement(BrandProvider, { brand }, createElement(Consumer));
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as BrandConfig).slug).toBe("enterprise");
+  });
+
+  it("useBrand() throws outside BrandProvider with guidance", async () => {
+    const { useBrand } = await import("../provider");
+
+    // Simulate what useBrand does: reads null context and throws
+    const ctx: BrandConfig | null = null;
+    expect(() => {
+      if (ctx === null) {
+        throw new Error(
+          "useBrand() must be called inside a <BrandProvider>. " +
+            "Ensure the root layout wraps its children with <BrandProvider brand={...}>.",
+        );
+      }
+    }).toThrow(/BrandProvider/);
+
+    // Also test the actual hook behavior by rendering outside a provider
+    const { BrandContext } = await import("../context");
+    let threwError = false;
+    function OutsideConsumer() {
+      try {
+        useBrand();
+      } catch {
+        threwError = true;
+      }
+      return null;
+    }
+
+    const contextValue = null;
+    const tree = createElement(BrandContext, { value: contextValue }, createElement(OutsideConsumer));
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+    expect(threwError).toBe(true);
+  });
+
+  it("ThemeProvider receives 'light' defaultMode when themeRef ends in 'light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "light" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("light");
+  });
+
+  it("ThemeProvider receives 'dark' defaultMode when themeRef does not end in 'light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "dark" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("dark");
+  });
+
+  it("ThemeProvider receives 'dark' for custom themeRef like 'acme-dark'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "acme-dark" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("dark");
+  });
+
+  it("ThemeProvider receives 'light' for custom themeRef like 'acme-light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "acme-light" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("light");
+  });
+});

--- a/packages/ui/src/brand/__tests__/registry.test.ts
+++ b/packages/ui/src/brand/__tests__/registry.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import type { BrandConfig } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
 
 // ============================================================================
 // Fixture brand configs

--- a/packages/ui/src/brand/__tests__/registry.test.ts
+++ b/packages/ui/src/brand/__tests__/registry.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Fixture brand configs
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests for buildRegistry() and related helpers
+// ============================================================================
+
+describe("buildRegistry", () => {
+  it("builds a registry with a single valid brand", async () => {
+    const { buildRegistry } = await import("../registry");
+    const brand = makeBrand();
+    const registry = buildRegistry([brand]);
+    expect(registry.size).toBe(1);
+    expect(registry.get("enterprise")).toEqual(brand);
+  });
+
+  it("builds a registry with multiple valid brands", async () => {
+    const { buildRegistry } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const enterprise = makeBrand();
+    const registry = buildRegistry([enterprise, acme]);
+    expect(registry.size).toBe(2);
+    expect(registry.has("acme")).toBe(true);
+  });
+
+  it("throws on duplicate slug", async () => {
+    const { buildRegistry } = await import("../registry");
+    const brand1 = makeBrand();
+    const brand2 = makeBrand({ name: "enterprise-copy" });
+    expect(() => buildRegistry([brand1, brand2])).toThrow(/duplicate/i);
+  });
+});
+
+describe("getDefaultBrand", () => {
+  it("returns the brand with isDefault=true", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const enterprise = makeBrand({ isDefault: true });
+    const registry = new Map<string, BrandConfig>([
+      ["acme", acme],
+      ["enterprise", enterprise],
+    ]);
+    expect(getDefaultBrand(registry).slug).toBe("enterprise");
+  });
+
+  it("falls back to 'enterprise' slug when no isDefault is declared", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const enterprise = makeBrand({ isDefault: undefined });
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+    expect(getDefaultBrand(registry).slug).toBe("enterprise");
+  });
+
+  it("throws when no brands are registered", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const empty = new Map<string, BrandConfig>();
+    expect(() => getDefaultBrand(empty)).toThrow();
+  });
+
+  it("throws when no isDefault and no 'enterprise' slug", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: undefined });
+    const registry = new Map<string, BrandConfig>([["acme", acme]]);
+    expect(() => getDefaultBrand(registry)).toThrow(/enterprise/i);
+  });
+});
+
+describe("getBrandBySlug", () => {
+  it("returns brand for matching slug", async () => {
+    const { getBrandBySlug } = await import("../registry");
+    const brand = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", brand]]);
+    expect(getBrandBySlug(registry, "enterprise")).toEqual(brand);
+  });
+
+  it("returns undefined for unknown slug", async () => {
+    const { getBrandBySlug } = await import("../registry");
+    const registry = new Map<string, BrandConfig>();
+    expect(getBrandBySlug(registry, "unknown")).toBeUndefined();
+  });
+});
+
+describe("getAllBrands", () => {
+  it("returns all registered brands as array", async () => {
+    const { getAllBrands } = await import("../registry");
+    const brand = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", brand],
+      ["acme", acme],
+    ]);
+    expect(getAllBrands(registry)).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/brand/__tests__/resolve.test.ts
+++ b/packages/ui/src/brand/__tests__/resolve.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Mock next/headers before importing resolve
+// ============================================================================
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture factories
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "Enterprise Platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests for resolveBrand()
+// ============================================================================
+
+describe("resolveBrand", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("BRAND_SLUG env var forces the matching brand", async () => {
+    process.env["BRAND_SLUG"] = "enterprise";
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/" });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("BRAND_SLUG env var overrides subdomain context", async () => {
+    process.env["BRAND_SLUG"] = "enterprise";
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    // even though host has acme subdomain, env var wins
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "acme.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("unknown BRAND_SLUG throws with available slugs listed", async () => {
+    process.env["BRAND_SLUG"] = "unknown-brand";
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    await expect(
+      resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/" }),
+    ).rejects.toThrow(/enterprise/);
+  });
+
+  it("subdomain resolves to matching brand", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "acme.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("acme");
+  });
+
+  it("unrecognized subdomain warns and falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "unknown.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("host with only 2 segments (no qualifying subdomain) falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("path prefix resolves to matching brand", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "localhost",
+      pathname: "/acme/dashboard",
+    });
+    expect(result.slug).toBe("acme");
+  });
+
+  it("static asset path /favicon.ico does not emit brand warning", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    await resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/favicon.ico" });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("unknown path prefix emits warn and falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "localhost",
+      pathname: "/unknown-brand/page",
+    });
+    expect(result.slug).toBe("enterprise");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown-brand"));
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/brand/__tests__/resolve.test.ts
+++ b/packages/ui/src/brand/__tests__/resolve.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrandConfig } from "@enterprise/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ============================================================================
 // Mock next/headers before importing resolve

--- a/packages/ui/src/brand/context.ts
+++ b/packages/ui/src/brand/context.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { createContext } from "react";
+
+export interface BrandContextValue {
+  brand: BrandConfig;
+}
+
+export const BrandContext = createContext<BrandContextValue | null>(null);

--- a/packages/ui/src/brand/index.ts
+++ b/packages/ui/src/brand/index.ts
@@ -1,0 +1,8 @@
+// Brand module barrel — re-exports for consumers that prefer the index import.
+// For server-only utilities (resolveBrand), import from the specific subpath.
+
+export type { BrandContextValue } from "./context";
+export { BrandContext } from "./context";
+export { generateBrandMetadata } from "./metadata";
+export type { BrandProviderProps } from "./provider";
+export { BrandProvider, useBrand } from "./provider";

--- a/packages/ui/src/brand/metadata.ts
+++ b/packages/ui/src/brand/metadata.ts
@@ -1,5 +1,5 @@
-import type { Metadata } from "next";
 import type { BrandConfig } from "@enterprise/contracts";
+import type { Metadata } from "next";
 
 /**
  * Generates a Next.js Metadata object from a resolved BrandConfig.

--- a/packages/ui/src/brand/metadata.ts
+++ b/packages/ui/src/brand/metadata.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import type { BrandConfig } from "@enterprise/contracts";
+
+/**
+ * Generates a Next.js Metadata object from a resolved BrandConfig.
+ * Call this from generateMetadata() in ui/app/layout.tsx.
+ *
+ * @example
+ * export async function generateMetadata() {
+ *   const brand = await resolveBrand();
+ *   return generateBrandMetadata(brand);
+ * }
+ */
+export function generateBrandMetadata(brand: BrandConfig): Metadata {
+  return {
+    title: {
+      template: brand.metadata.titleTemplate,
+      default: brand.metadata.defaultTitle,
+    },
+    description: brand.metadata.description,
+    icons: {
+      icon: brand.favicon,
+    },
+    openGraph: {
+      title: brand.metadata.defaultTitle,
+      description: brand.metadata.description,
+      images: brand.metadata.ogImage ? [brand.metadata.ogImage] : [],
+    },
+  };
+}

--- a/packages/ui/src/brand/provider.tsx
+++ b/packages/ui/src/brand/provider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { useContext } from "react";
+import { BrandContext } from "./context";
+import { ThemeProvider } from "../theme/provider";
+
+// ============================================================================
+// BrandProvider
+// ============================================================================
+
+export interface BrandProviderProps {
+  children?: React.ReactNode;
+  /**
+   * The resolved BrandConfig — provided by the server boundary (root layout).
+   * BrandProvider does NOT resolve the brand; resolution happens in resolveBrand().
+   */
+  brand: BrandConfig;
+  /**
+   * Initial theme mode before localStorage hydration.
+   * Derived from the brand's themeRef: "light" or "dark" suffix.
+   * Falls back to "dark" if themeRef does not end in "light".
+   */
+  defaultMode?: "light" | "dark";
+}
+
+export function BrandProvider({ children, brand, defaultMode }: BrandProviderProps) {
+  // Derive initial theme mode from themeRef if not explicitly provided
+  const resolvedDefaultMode: "light" | "dark" =
+    defaultMode ?? (brand.themeRef.endsWith("light") ? "light" : "dark");
+
+  return (
+    <BrandContext value={{ brand }}>
+      <ThemeProvider defaultMode={resolvedDefaultMode}>{children}</ThemeProvider>
+    </BrandContext>
+  );
+}
+
+// ============================================================================
+// useBrand hook
+// ============================================================================
+
+/**
+ * Returns the resolved BrandConfig from context.
+ * Must be called inside a BrandProvider — throws with actionable guidance otherwise.
+ */
+export function useBrand(): BrandConfig {
+  const ctx = useContext(BrandContext);
+  if (ctx === null) {
+    throw new Error(
+      "useBrand() must be called inside a <BrandProvider>. " +
+        "Ensure the root layout wraps its children with <BrandProvider brand={...}>.",
+    );
+  }
+  return ctx.brand;
+}

--- a/packages/ui/src/brand/provider.tsx
+++ b/packages/ui/src/brand/provider.tsx
@@ -2,8 +2,8 @@
 
 import type { BrandConfig } from "@enterprise/contracts";
 import { useContext } from "react";
-import { BrandContext } from "./context";
 import { ThemeProvider } from "../theme/provider";
+import { BrandContext } from "./context";
 
 // ============================================================================
 // BrandProvider

--- a/packages/ui/src/brand/registry.ts
+++ b/packages/ui/src/brand/registry.ts
@@ -1,0 +1,113 @@
+// Brand registry — validates and stores all registered brand configs.
+// This module is imported at server startup; any validation errors throw immediately,
+// preventing the server from starting with invalid brand configuration.
+
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Registry builder — pure function used by both module init and tests
+// ============================================================================
+
+/**
+ * Builds an immutable Map<slug, BrandConfig> from an array of raw brand objects.
+ * Throws on duplicate slugs.
+ */
+export function buildRegistry(brands: BrandConfig[]): Map<string, BrandConfig> {
+  const registry = new Map<string, BrandConfig>();
+
+  for (const brand of brands) {
+    if (registry.has(brand.slug)) {
+      throw new Error(
+        `[brand] Duplicate brand slug "${brand.slug}" detected. ` +
+          `Each brand must have a unique slug.`,
+      );
+    }
+    registry.set(brand.slug, brand);
+  }
+
+  return registry;
+}
+
+// ============================================================================
+// Registry helpers — operate on a Map parameter (testable, pure)
+// ============================================================================
+
+/**
+ * Returns the brand with isDefault=true.
+ * Falls back to the "enterprise" slug if no isDefault is declared.
+ * Throws if neither is available.
+ */
+export function getDefaultBrand(registry: Map<string, BrandConfig>): BrandConfig {
+  for (const brand of registry.values()) {
+    if (brand.isDefault) return brand;
+  }
+
+  // Fallback: return the "enterprise" brand if no isDefault is declared
+  const enterprise = registry.get("enterprise");
+  if (!enterprise) {
+    throw new Error(
+      '[brand] No default brand found and no "enterprise" brand registered. ' +
+        "Ensure at least one brand config exists in packages/ui/src/brands/.",
+    );
+  }
+  return enterprise;
+}
+
+/**
+ * Returns the brand for the given slug, or undefined if not found.
+ */
+export function getBrandBySlug(
+  registry: Map<string, BrandConfig>,
+  slug: string,
+): BrandConfig | undefined {
+  return registry.get(slug);
+}
+
+/**
+ * Returns all registered brands as an array.
+ */
+export function getAllBrands(registry: Map<string, BrandConfig>): BrandConfig[] {
+  return Array.from(registry.values());
+}
+
+// ============================================================================
+// Module-level registry — populated at startup from brands/index.ts
+// ============================================================================
+
+// Lazy-import to avoid circular deps and allow testing registry helpers in isolation.
+// The actual populated registry is exported below for server-side use.
+let _registry: Map<string, BrandConfig> | null = null;
+
+/**
+ * Returns the singleton brand registry, initializing it on first access.
+ * The registry is populated from all brand configs exported by brands/index.ts.
+ */
+export function getBrandRegistry(): Map<string, BrandConfig> {
+  if (_registry !== null) return _registry;
+
+  // Dynamic require to allow test isolation without triggering the real import chain.
+  // In production builds, Next.js statically resolves this.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const brandsModule = require("../brands/index") as Record<string, unknown>;
+  const configs: BrandConfig[] = [];
+
+  for (const [, mod] of Object.entries(brandsModule)) {
+    const raw = (mod as { default?: unknown }).default ?? mod;
+    configs.push(raw as BrandConfig);
+  }
+
+  _registry = buildRegistry(configs);
+  return _registry;
+}
+
+// Named re-export of the singleton for server-side access (used by resolve.ts)
+export const brandRegistry: Map<string, BrandConfig> = new Map();
+
+/**
+ * Re-initialize the singleton — intended for testing only.
+ * Do NOT call this in production code.
+ */
+export function _resetRegistryForTesting(): void {
+  _registry = null;
+  brandRegistry.clear();
+}

--- a/packages/ui/src/brand/resolve.ts
+++ b/packages/ui/src/brand/resolve.ts
@@ -1,0 +1,95 @@
+// Brand resolution — server-only utility.
+// Determines which brand to render based on: env var → subdomain → path prefix → default.
+// This file MUST only be imported from Server Components or Server Actions.
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { getBrandBySlug, getBrandRegistry, getDefaultBrand } from "./registry";
+
+// ============================================================================
+// Internal resolution logic (pure, testable)
+// ============================================================================
+
+interface ResolutionContext {
+  host: string;
+  pathname: string;
+}
+
+/**
+ * Pure resolution function that operates on an explicit registry Map.
+ * This signature is exported for testing without real next/headers.
+ */
+export async function resolveBrandFromRegistry(
+  registry: Map<string, BrandConfig>,
+  ctx: ResolutionContext,
+): Promise<BrandConfig> {
+  // Priority 1: BRAND_SLUG environment variable
+  const envSlug = process.env["BRAND_SLUG"];
+  if (envSlug) {
+    const brand = getBrandBySlug(registry, envSlug);
+    if (!brand) {
+      const available = Array.from(registry.keys()).join(", ");
+      throw new Error(
+        `[brand] BRAND_SLUG="${envSlug}" does not match any registered brand. ` +
+          `Available slugs: ${available}`,
+      );
+    }
+    return brand;
+  }
+
+  const { host, pathname } = ctx;
+
+  // Priority 2: Subdomain matching
+  // Strip port from host, split by ".", take first segment if > 2 parts
+  const hostWithoutPort = host.split(":")[0] ?? "";
+  const subdomainSegments = hostWithoutPort.split(".");
+  if (subdomainSegments.length > 2) {
+    const subdomainSlug = subdomainSegments[0] ?? "";
+    const brand = getBrandBySlug(registry, subdomainSlug);
+    if (brand) return brand;
+    console.warn(
+      `[brand] Unrecognized subdomain slug: "${subdomainSlug}". Falling back to default brand.`,
+    );
+  }
+
+  // Priority 3: Path prefix matching
+  const firstPathSegment = pathname.split("/")[1] ?? "";
+  if (firstPathSegment) {
+    const brand = getBrandBySlug(registry, firstPathSegment);
+    if (brand) return brand;
+    // Only warn if the segment looks like an intentional brand slug (no dots → not a file extension)
+    if (!firstPathSegment.includes(".")) {
+      console.warn(
+        `[brand] Path prefix "${firstPathSegment}" did not match any brand slug. ` +
+          `Falling back to default brand.`,
+      );
+    }
+  }
+
+  // Priority 4: Default brand
+  return getDefaultBrand(registry);
+}
+
+// ============================================================================
+// Public server-side API
+// ============================================================================
+
+/**
+ * Resolves the active brand for the current request.
+ * Reads env vars and Next.js request headers.
+ * Server-only — do NOT import in Client Components.
+ *
+ * Resolution priority:
+ * 1. BRAND_SLUG env var
+ * 2. Subdomain matching (acme.platform.com → "acme")
+ * 3. Path prefix matching (/acme/dashboard → "acme")
+ * 4. Default brand (isDefault=true or "enterprise" slug)
+ */
+export async function resolveBrand(): Promise<BrandConfig> {
+  const { headers } = await import("next/headers");
+  const headerList = await headers();
+  const host = headerList.get("host") ?? "";
+  const pathname = headerList.get("x-invoke-path") ?? "/";
+
+  const registry = getBrandRegistry();
+  return resolveBrandFromRegistry(registry, { host, pathname });
+}

--- a/packages/ui/src/brands/enterprise.brand.ts
+++ b/packages/ui/src/brands/enterprise.brand.ts
@@ -1,0 +1,44 @@
+import type { BrandConfig } from "@enterprise/contracts";
+
+const enterpriseBrand: BrandConfig = {
+  slug: "enterprise",
+  name: "enterprise",
+  displayName: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  logo: {
+    light: {
+      src: "/images/enterprise/logo-light.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+    dark: {
+      src: "/images/enterprise/logo-dark.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+  },
+  favicon: "/images/enterprise/favicon.svg",
+  metadata: {
+    titleTemplate: "%s | Enterprise Platform",
+    defaultTitle: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template for modern teams.",
+    ogImage: "/images/enterprise/og-image.png",
+  },
+  legal: {
+    // Replace these placeholder URLs with your actual legal pages before go-live
+    privacyUrl: "#",
+    termsUrl: "#",
+  },
+  social: {
+    github: "https://github.com/your-org",
+  },
+  themeRef: "light",
+  features: {
+    showPoweredBy: true,
+  },
+  isDefault: true,
+};
+
+export default enterpriseBrand;

--- a/packages/ui/src/brands/index.ts
+++ b/packages/ui/src/brands/index.ts
@@ -1,0 +1,8 @@
+// Brand config barrel — export all brand configs for registry consumption.
+// Add new *.brand.ts files here to register them with the brand registry.
+// Each exported value must be a default export from its module.
+
+export { default as enterprise } from "./enterprise.brand";
+
+// Example: Uncomment to register a second brand
+// export { default as acme } from "./acme.brand";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,12 @@
+// Brand
+
+export type { BrandConfig } from "@enterprise/contracts";
+export { BrandContext } from "./brand/context";
+export type { BrandContextValue } from "./brand/context";
+export { BrandProvider, useBrand } from "./brand/provider";
+export type { BrandProviderProps } from "./brand/provider";
+export { generateBrandMetadata } from "./brand/metadata";
+
 // Theme
 
 export * from "./components/avatar";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,11 +1,11 @@
 // Brand
 
 export type { BrandConfig } from "@enterprise/contracts";
-export { BrandContext } from "./brand/context";
 export type { BrandContextValue } from "./brand/context";
-export { BrandProvider, useBrand } from "./brand/provider";
-export type { BrandProviderProps } from "./brand/provider";
+export { BrandContext } from "./brand/context";
 export { generateBrandMetadata } from "./brand/metadata";
+export type { BrandProviderProps } from "./brand/provider";
+export { BrandProvider, useBrand } from "./brand/provider";
 
 // Theme
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      next:
+        specifier: 15.5.18
+        version: 15.5.18(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,4 +1,6 @@
-import { ThemeProvider } from "@enterprise/ui";
+import { generateBrandMetadata } from "@enterprise/ui/brand/metadata";
+import { BrandProvider } from "@enterprise/ui/brand/provider";
+import { resolveBrand } from "@enterprise/ui/brand/resolve";
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono, Plus_Jakarta_Sans, Space_Grotesk } from "next/font/google";
 import { Toaster } from "sonner";
@@ -24,15 +26,14 @@ const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: {
-    default: "Enterprise Platform",
-    template: "%s | Enterprise Platform",
-  },
-  description: "Multi-tenant enterprise platform",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveBrand();
+  return generateBrandMetadata(brand);
+}
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const brand = await resolveBrand();
+
   return (
     <html
       lang="en"
@@ -41,7 +42,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={`${inter.variable} ${jetbrainsMono.variable} ${plusJakartaSans.variable} ${spaceGrotesk.variable}`}
     >
       <body className="min-h-screen bg-background font-sans antialiased">
-        <ThemeProvider defaultMode="dark">{children}</ThemeProvider>
+        <BrandProvider brand={brand}>{children}</BrandProvider>
         <Toaster richColors position="top-right" />
       </body>
     </html>


### PR DESCRIPTION
## What
Implements the Brand Abstraction Layer foundation (#14, PR-B1): config-driven multi-brand support with BrandConfig schema, BrandProvider context, brand registry, resolution strategy, and layout integration.

## Why
Enables multi-brand deployments from a single codebase. The template ships with a default 'enterprise' brand — adding a second brand requires only a new config file, zero code changes.

## Changes

### packages/contracts
- `src/schemas/brand.ts`: Full BrandConfig Zod schema with 5 sub-schemas (logo, metadata, legal, social, features)

### packages/ui
- `src/brand/registry.ts`: Brand registry (register/get/getDefault/getAll)
- `src/brand/resolve.ts`: Server-only resolution (ENV → subdomain → path-prefix → default)
- `src/brand/context.ts` + `provider.tsx`: BrandProvider + useBrand() hook
- `src/brand/metadata.ts`: generateBrandMetadata() for Next.js Metadata
- `src/brands/enterprise.brand.ts`: Default brand configuration
- Subpath exports for all brand modules

### ui/app
- `layout.tsx`: Converted static metadata → generateMetadata(), wrapped with BrandProvider

## Tests
- 55 new unit tests (schema validation, registry, resolution, provider, metadata)
- All 516 suite tests passing

## PR Chain
This is **PR-B1** of the brand-and-decoupling change (stacked-to-main).
Next: PR-B2 (BrandLogo + BrandFooter + E2E)