### PR TITLE
feat(core): add AuthPort, StoragePort, SessionPort interfaces and Supabase adapters

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,10 @@
     "./services/billing-service": "./src/services/billing-service.ts",
     "./services/notification-service": "./src/services/notification-service.ts",
     "./services/ports/payment-provider-port": "./src/services/ports/payment-provider-port.ts",
-    "./services/adapters/payment-adapter-factory": "./src/services/adapters/payment-adapter-factory.ts"
+    "./services/adapters/payment-adapter-factory": "./src/services/adapters/payment-adapter-factory.ts",
+    "./services/ports": "./src/services/ports/index.ts",
+    "./services/adapters": "./src/services/adapters/index.ts",
+    "./services/backend-adapters": "./src/services/backend-adapters.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/services/__tests__/backend-adapters.test.ts
+++ b/packages/core/src/services/__tests__/backend-adapters.test.ts
@@ -6,7 +6,7 @@
  * 2. Unknown provider throws a descriptive error
  * 3. Missing NEXT_PUBLIC_SUPABASE_URL throws descriptive error
  */
-import { describe, expect, it, afterEach, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createBackendAdapters } from "../backend-adapters";
 
 // Store original env for restoration
@@ -77,9 +77,7 @@ describe("createBackendAdapters", () => {
       process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
       process.env["BACKEND_AUTH_PROVIDER"] = "firebase";
 
-      expect(() => createBackendAdapters()).toThrow(
-        /Unknown BACKEND_AUTH_PROVIDER.*firebase/i,
-      );
+      expect(() => createBackendAdapters()).toThrow(/Unknown BACKEND_AUTH_PROVIDER.*firebase/i);
     });
 
     it("throws with clear guidance when BACKEND_STORAGE_PROVIDER is unknown", () => {
@@ -88,9 +86,7 @@ describe("createBackendAdapters", () => {
       delete process.env["BACKEND_AUTH_PROVIDER"];
       process.env["BACKEND_STORAGE_PROVIDER"] = "s3";
 
-      expect(() => createBackendAdapters()).toThrow(
-        /Unknown BACKEND_STORAGE_PROVIDER.*s3/i,
-      );
+      expect(() => createBackendAdapters()).toThrow(/Unknown BACKEND_STORAGE_PROVIDER.*s3/i);
     });
   });
 
@@ -101,9 +97,7 @@ describe("createBackendAdapters", () => {
       delete process.env["BACKEND_AUTH_PROVIDER"];
       delete process.env["BACKEND_STORAGE_PROVIDER"];
 
-      expect(() => createBackendAdapters()).toThrow(
-        /NEXT_PUBLIC_SUPABASE_URL/,
-      );
+      expect(() => createBackendAdapters()).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
     });
 
     it("throws descriptive error when NEXT_PUBLIC_SUPABASE_ANON_KEY is missing", () => {
@@ -112,9 +106,7 @@ describe("createBackendAdapters", () => {
       delete process.env["BACKEND_AUTH_PROVIDER"];
       delete process.env["BACKEND_STORAGE_PROVIDER"];
 
-      expect(() => createBackendAdapters()).toThrow(
-        /NEXT_PUBLIC_SUPABASE_ANON_KEY/,
-      );
+      expect(() => createBackendAdapters()).toThrow(/NEXT_PUBLIC_SUPABASE_ANON_KEY/);
     });
   });
 });

--- a/packages/core/src/services/__tests__/backend-adapters.test.ts
+++ b/packages/core/src/services/__tests__/backend-adapters.test.ts
@@ -1,0 +1,120 @@
+/**
+ * backend-adapters.test.ts — TDD: validates createBackendAdapters() factory
+ *
+ * Tests verify:
+ * 1. Default (no env vars) returns Supabase adapter factories
+ * 2. Unknown provider throws a descriptive error
+ * 3. Missing NEXT_PUBLIC_SUPABASE_URL throws descriptive error
+ */
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { createBackendAdapters } from "../backend-adapters";
+
+// Store original env for restoration
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  // Restore env after each test
+  process.env = { ...originalEnv };
+});
+
+describe("createBackendAdapters", () => {
+  describe("default configuration (Supabase provider)", () => {
+    it("returns auth factory, storage factory, and session instance when supabase URL and key are set", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+      delete process.env["BACKEND_AUTH_PROVIDER"];
+      delete process.env["BACKEND_STORAGE_PROVIDER"];
+
+      const adapters = createBackendAdapters();
+
+      // auth and storage are factory functions (not instances) — SupabaseClient is request-scoped
+      expect(typeof adapters.auth).toBe("function");
+      expect(typeof adapters.storage).toBe("function");
+      // session is a constructed instance
+      expect(typeof adapters.session).toBe("object");
+      expect(typeof adapters.session.refreshSession).toBe("function");
+    });
+
+    it("auth factory returns an AuthPort adapter when called with a mock client", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+
+      const adapters = createBackendAdapters();
+      const mockClient = {} as import("@supabase/supabase-js").SupabaseClient;
+      const authAdapter = adapters.auth(mockClient);
+
+      // Verify it's an AuthPort (has all 7 methods)
+      expect(typeof authAdapter.signInWithPassword).toBe("function");
+      expect(typeof authAdapter.signUp).toBe("function");
+      expect(typeof authAdapter.signOut).toBe("function");
+      expect(typeof authAdapter.getUser).toBe("function");
+      expect(typeof authAdapter.getUserRole).toBe("function");
+      expect(typeof authAdapter.requestPasswordReset).toBe("function");
+      expect(typeof authAdapter.updatePassword).toBe("function");
+    });
+
+    it("storage factory returns a StoragePort adapter when called with a mock client", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+
+      const adapters = createBackendAdapters();
+      const mockClient = {} as import("@supabase/supabase-js").SupabaseClient;
+      const storageAdapter = adapters.storage(mockClient);
+
+      // Verify it's a StoragePort (has all 6 methods)
+      expect(typeof storageAdapter.upload).toBe("function");
+      expect(typeof storageAdapter.download).toBe("function");
+      expect(typeof storageAdapter.delete).toBe("function");
+      expect(typeof storageAdapter.getSignedUrl).toBe("function");
+      expect(typeof storageAdapter.getPublicUrl).toBe("function");
+      expect(typeof storageAdapter.listFiles).toBe("function");
+    });
+  });
+
+  describe("unknown provider throws descriptive error", () => {
+    it("throws with clear guidance when BACKEND_AUTH_PROVIDER is unknown", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+      process.env["BACKEND_AUTH_PROVIDER"] = "firebase";
+
+      expect(() => createBackendAdapters()).toThrow(
+        /Unknown BACKEND_AUTH_PROVIDER.*firebase/i,
+      );
+    });
+
+    it("throws with clear guidance when BACKEND_STORAGE_PROVIDER is unknown", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+      delete process.env["BACKEND_AUTH_PROVIDER"];
+      process.env["BACKEND_STORAGE_PROVIDER"] = "s3";
+
+      expect(() => createBackendAdapters()).toThrow(
+        /Unknown BACKEND_STORAGE_PROVIDER.*s3/i,
+      );
+    });
+  });
+
+  describe("missing supabase credentials", () => {
+    it("throws descriptive error when NEXT_PUBLIC_SUPABASE_URL is missing", () => {
+      delete process.env["NEXT_PUBLIC_SUPABASE_URL"];
+      process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
+      delete process.env["BACKEND_AUTH_PROVIDER"];
+      delete process.env["BACKEND_STORAGE_PROVIDER"];
+
+      expect(() => createBackendAdapters()).toThrow(
+        /NEXT_PUBLIC_SUPABASE_URL/,
+      );
+    });
+
+    it("throws descriptive error when NEXT_PUBLIC_SUPABASE_ANON_KEY is missing", () => {
+      process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
+      delete process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+      delete process.env["BACKEND_AUTH_PROVIDER"];
+      delete process.env["BACKEND_STORAGE_PROVIDER"];
+
+      expect(() => createBackendAdapters()).toThrow(
+        /NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+      );
+    });
+  });
+});

--- a/packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts
+++ b/packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts
@@ -6,7 +6,7 @@
  * are explicitly testing the Supabase mapping, not business logic.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SupabaseAuthAdapter } from "../supabase-auth-adapter";
 
 function createMockSupabaseClient() {
@@ -67,7 +67,9 @@ describe("SupabaseAuthAdapter", () => {
         data: { user: { id: "user-123", created_at: "2024-01-01" } },
         error: null,
       } as never);
-      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+      (
+        client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }
+      ).__mockSingle.mockResolvedValue({
         data: { role: "member" },
         error: null,
       });
@@ -113,7 +115,9 @@ describe("SupabaseAuthAdapter", () => {
       const client = createMockSupabaseClient();
       const adapter = new SupabaseAuthAdapter(client);
 
-      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+      (
+        client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }
+      ).__mockSingle.mockResolvedValue({
         data: null,
         error: { code: "PGRST116", message: "Row not found" },
       });
@@ -131,7 +135,9 @@ describe("SupabaseAuthAdapter", () => {
       const client = createMockSupabaseClient();
       const adapter = new SupabaseAuthAdapter(client);
 
-      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+      (
+        client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }
+      ).__mockSingle.mockResolvedValue({
         data: null,
         error: { code: "NETWORK_ERROR", message: "Connection refused" },
       });

--- a/packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts
+++ b/packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts
@@ -1,0 +1,332 @@
+/**
+ * supabase-auth-adapter.test.ts — TDD: validates SupabaseAuthAdapter maps Supabase SDK
+ * responses to ServiceResult<T> correctly.
+ *
+ * These tests DO use a Supabase client mock — this is appropriate because adapter tests
+ * are explicitly testing the Supabase mapping, not business logic.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { SupabaseAuthAdapter } from "../supabase-auth-adapter";
+
+function createMockSupabaseClient() {
+  const mockSingle = vi.fn();
+
+  return {
+    auth: {
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      getUser: vi.fn(),
+      signUp: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+      updateUser: vi.fn(),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: mockSingle,
+        })),
+      })),
+    })),
+    __mockSingle: mockSingle,
+  } as unknown as SupabaseClient & { __mockSingle: ReturnType<typeof vi.fn> };
+}
+
+describe("SupabaseAuthAdapter", () => {
+  describe("signInWithPassword", () => {
+    it("maps Supabase error to INVALID_CREDENTIALS", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signInWithPassword).mockResolvedValue({
+        data: { user: null, session: null },
+        error: { message: "Invalid login credentials" } as never,
+      } as never);
+
+      const result = await adapter.signInWithPassword({
+        email: "user@example.com",
+        password: "wrong-password",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("INVALID_CREDENTIALS");
+        expect(result.error).toBe("Invalid credentials");
+      }
+    });
+
+    it("returns success with role after successful sign-in", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signInWithPassword).mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      } as never);
+      vi.mocked(client.auth.getUser).mockResolvedValue({
+        data: { user: { id: "user-123", created_at: "2024-01-01" } },
+        error: null,
+      } as never);
+      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+        data: { role: "member" },
+        error: null,
+      });
+
+      const result = await adapter.signInWithPassword({
+        email: "user@example.com",
+        password: "correct-password",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.role).toBe("member");
+      }
+    });
+
+    it("returns USER_NOT_FOUND when user is null after sign-in", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signInWithPassword).mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      } as never);
+      vi.mocked(client.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: null,
+      } as never);
+
+      const result = await adapter.signInWithPassword({
+        email: "user@example.com",
+        password: "password",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("USER_NOT_FOUND");
+      }
+    });
+  });
+
+  describe("getUserRole", () => {
+    it("returns guest role when PGRST116 error (profile not found)", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: "PGRST116", message: "Row not found" },
+      });
+
+      const result = await adapter.getUserRole("non-existent-user-id");
+
+      // PGRST116 is NOT an error — it means profile doesn't exist, default to guest
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.role).toBe("guest");
+      }
+    });
+
+    it("returns ROLE_LOOKUP_FAILED for non-PGRST116 errors", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      (client as typeof client & { __mockSingle: ReturnType<typeof vi.fn> }).__mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: "NETWORK_ERROR", message: "Connection refused" },
+      });
+
+      const result = await adapter.getUserRole("user-123");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("ROLE_LOOKUP_FAILED");
+      }
+    });
+  });
+
+  describe("signOut", () => {
+    it("returns success with null data", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signOut).mockResolvedValue({ error: null } as never);
+
+      const result = await adapter.signOut();
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it("returns SIGN_OUT_FAILED on error", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signOut).mockResolvedValue({
+        error: { message: "Failed to sign out" } as never,
+      } as never);
+
+      const result = await adapter.signOut();
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("SIGN_OUT_FAILED");
+      }
+    });
+  });
+
+  describe("signUp", () => {
+    it("returns needsEmailConfirmation: true when session is null", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signUp).mockResolvedValue({
+        data: {
+          user: { id: "new-user-id", created_at: "2024-01-01" },
+          session: null,
+        },
+        error: null,
+      } as never);
+
+      const result = await adapter.signUp({
+        email: "new@example.com",
+        password: "Password123",
+        metadata: { name: "New User" },
+        emailRedirectTo: "http://localhost/auth/callback",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.needsEmailConfirmation).toBe(true);
+        expect(result.data.userId).toBe("new-user-id");
+      }
+    });
+
+    it("returns needsEmailConfirmation: false when session exists", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signUp).mockResolvedValue({
+        data: {
+          user: { id: "new-user-id", created_at: "2024-01-01" },
+          session: { access_token: "token" },
+        },
+        error: null,
+      } as never);
+
+      const result = await adapter.signUp({
+        email: "new@example.com",
+        password: "Password123",
+        metadata: { name: "New User" },
+        emailRedirectTo: "http://localhost/auth/callback",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.needsEmailConfirmation).toBe(false);
+      }
+    });
+
+    it("returns SIGN_UP_FAILED on SDK error", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.signUp).mockResolvedValue({
+        data: { user: null, session: null },
+        error: { message: "Email already registered" } as never,
+      } as never);
+
+      const result = await adapter.signUp({
+        email: "existing@example.com",
+        password: "Password123",
+        metadata: { name: "User" },
+        emailRedirectTo: "http://localhost/auth/callback",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("SIGN_UP_FAILED");
+      }
+    });
+  });
+
+  describe("requestPasswordReset", () => {
+    it("returns success with null data", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.resetPasswordForEmail).mockResolvedValue({
+        data: {},
+        error: null,
+      } as never);
+
+      const result = await adapter.requestPasswordReset({
+        email: "user@example.com",
+        redirectTo: "http://localhost/auth/callback?next=/reset-password",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it("returns PASSWORD_RESET_REQUEST_FAILED on error", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.resetPasswordForEmail).mockResolvedValue({
+        data: {},
+        error: { message: "Rate limit exceeded" } as never,
+      } as never);
+
+      const result = await adapter.requestPasswordReset({
+        email: "user@example.com",
+        redirectTo: "http://localhost/auth/callback?next=/reset-password",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("PASSWORD_RESET_REQUEST_FAILED");
+      }
+    });
+  });
+
+  describe("updatePassword", () => {
+    it("returns success with null data", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.updateUser).mockResolvedValue({
+        data: { user: null },
+        error: null,
+      } as never);
+
+      const result = await adapter.updatePassword({ password: "NewPassword123" });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it("returns PASSWORD_UPDATE_FAILED on error", async () => {
+      const client = createMockSupabaseClient();
+      const adapter = new SupabaseAuthAdapter(client);
+
+      vi.mocked(client.auth.updateUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Session expired" } as never,
+      } as never);
+
+      const result = await adapter.updatePassword({ password: "NewPassword123" });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("PASSWORD_UPDATE_FAILED");
+      }
+    });
+  });
+});

--- a/packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts
+++ b/packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts
@@ -188,7 +188,9 @@ describe("SupabaseStorageAdapter", () => {
 
       // Supabase getPublicUrl() is synchronous and never returns an error
       client.__storageMethods.getPublicUrl.mockReturnValue({
-        data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatars/file.png" },
+        data: {
+          publicUrl: "https://example.supabase.co/storage/v1/object/public/avatars/file.png",
+        },
       });
 
       const result = await adapter.getPublicUrl("avatars", "tenant-1/avatar.png");

--- a/packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts
+++ b/packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts
@@ -1,0 +1,261 @@
+/**
+ * supabase-storage-adapter.test.ts — TDD: validates SupabaseStorageAdapter maps
+ * Supabase Storage API responses to ServiceResult<T>.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it, vi } from "vitest";
+import { SupabaseStorageAdapter } from "../supabase-storage-adapter";
+
+// Minimal Supabase Storage mock
+function createMockStorageClient() {
+  const storageMethods = {
+    upload: vi.fn(),
+    download: vi.fn(),
+    remove: vi.fn(),
+    createSignedUrl: vi.fn(),
+    getPublicUrl: vi.fn(),
+    list: vi.fn(),
+  };
+
+  return {
+    storage: {
+      from: vi.fn(() => storageMethods),
+    },
+    __storageMethods: storageMethods,
+  } as unknown as SupabaseClient & {
+    __storageMethods: typeof storageMethods;
+  };
+}
+
+describe("SupabaseStorageAdapter", () => {
+  describe("upload", () => {
+    it("returns path and fullPath on success", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.upload.mockResolvedValue({
+        data: { path: "tenant-1/avatar.webp", fullPath: "avatars/tenant-1/avatar.webp" },
+        error: null,
+      });
+
+      const result = await adapter.upload(
+        "avatars",
+        "tenant-1/avatar.webp",
+        new Blob(["image data"]),
+        { contentType: "image/webp" },
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.path).toBe("tenant-1/avatar.webp");
+        expect(result.data.fullPath).toBe("avatars/tenant-1/avatar.webp");
+      }
+    });
+
+    it("returns STORAGE_UPLOAD_FAILED on error", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.upload.mockResolvedValue({
+        data: null,
+        error: { message: "Bucket not found" },
+      });
+
+      const result = await adapter.upload("missing-bucket", "file.png", new Blob(["data"]));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("STORAGE_UPLOAD_FAILED");
+        expect(result.error).toContain("Bucket not found");
+      }
+    });
+  });
+
+  describe("download", () => {
+    it("returns Blob on success", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+      const blobData = new Blob(["file content"]);
+
+      client.__storageMethods.download.mockResolvedValue({
+        data: blobData,
+        error: null,
+      });
+
+      const result = await adapter.download("avatars", "tenant-1/avatar.webp");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(blobData);
+      }
+    });
+
+    it("returns STORAGE_DOWNLOAD_FAILED when error", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.download.mockResolvedValue({
+        data: null,
+        error: { message: "Object not found" },
+      });
+
+      const result = await adapter.download("avatars", "missing-file.png");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("STORAGE_DOWNLOAD_FAILED");
+      }
+    });
+  });
+
+  describe("delete", () => {
+    it("accepts multiple paths and returns success", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.remove.mockResolvedValue({ data: [], error: null });
+
+      const paths = ["folder/file1.png", "folder/file2.png", "folder/file3.png"];
+      const result = await adapter.delete("avatars", paths);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+      // Verify the underlying client received the array
+      expect(client.__storageMethods.remove).toHaveBeenCalledWith(paths);
+    });
+
+    it("returns STORAGE_DELETE_FAILED on error", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.remove.mockResolvedValue({
+        data: null,
+        error: { message: "Insufficient permissions" },
+      });
+
+      const result = await adapter.delete("avatars", ["file.png"]);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("STORAGE_DELETE_FAILED");
+      }
+    });
+  });
+
+  describe("getSignedUrl", () => {
+    it("returns signedUrl and expiresIn on success", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.createSignedUrl.mockResolvedValue({
+        data: { signedUrl: "https://example.com/signed-url" },
+        error: null,
+      });
+
+      const result = await adapter.getSignedUrl("avatars", "tenant-1/avatar.webp", 3600);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.signedUrl).toBe("https://example.com/signed-url");
+        expect(result.data.expiresIn).toBe(3600);
+      }
+    });
+
+    it("returns STORAGE_SIGNED_URL_FAILED on error", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.createSignedUrl.mockResolvedValue({
+        data: null,
+        error: { message: "Object not found" },
+      });
+
+      const result = await adapter.getSignedUrl("avatars", "missing.png", 3600);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe("STORAGE_SIGNED_URL_FAILED");
+      }
+    });
+  });
+
+  describe("getPublicUrl", () => {
+    it("always succeeds (Supabase never errors on URL construction)", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      // Supabase getPublicUrl() is synchronous and never returns an error
+      client.__storageMethods.getPublicUrl.mockReturnValue({
+        data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatars/file.png" },
+      });
+
+      const result = await adapter.getPublicUrl("avatars", "tenant-1/avatar.png");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.publicUrl).toContain("avatars");
+      }
+    });
+  });
+
+  describe("listFiles", () => {
+    it("maps Supabase FileObject array to StorageFileEntry", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.list.mockResolvedValue({
+        data: [
+          {
+            name: "avatar.webp",
+            id: "file-id-1",
+            updated_at: "2024-01-15T00:00:00Z",
+            created_at: "2024-01-10T00:00:00Z",
+            metadata: { size: 102400, mimetype: "image/webp" },
+          },
+          {
+            name: "banner.png",
+            id: "file-id-2",
+            updated_at: "2024-02-01T00:00:00Z",
+            created_at: "2024-01-20T00:00:00Z",
+            metadata: { size: 204800, mimetype: "image/png" },
+          },
+        ],
+        error: null,
+      });
+
+      const result = await adapter.listFiles("avatars", "tenant-1/");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveLength(2);
+        const first = result.data[0];
+        const second = result.data[1];
+        expect(first?.name).toBe("avatar.webp");
+        expect(first?.size).toBe(102400);
+        expect(first?.mimeType).toBe("image/webp");
+        expect(second?.name).toBe("banner.png");
+      }
+    });
+
+    it("returns empty array for empty bucket prefix", async () => {
+      const client = createMockStorageClient();
+      const adapter = new SupabaseStorageAdapter(client);
+
+      client.__storageMethods.list.mockResolvedValue({
+        data: [],
+        error: null,
+      });
+
+      const result = await adapter.listFiles("avatars", "empty-prefix/");
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // Empty is valid — the bucket prefix exists but has no files
+        expect(Array.isArray(result.data)).toBe(true);
+        expect(result.data).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/packages/core/src/services/adapters/index.ts
+++ b/packages/core/src/services/adapters/index.ts
@@ -1,0 +1,3 @@
+export { SupabaseAuthAdapter } from "./supabase-auth-adapter";
+export { SupabaseSessionAdapter } from "./supabase-session-adapter";
+export { SupabaseStorageAdapter } from "./supabase-storage-adapter";

--- a/packages/core/src/services/adapters/supabase-auth-adapter.ts
+++ b/packages/core/src/services/adapters/supabase-auth-adapter.ts
@@ -1,0 +1,187 @@
+import type { PlatformUser, UserRole } from "@enterprise/contracts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  PasswordResetServiceInput,
+  ServiceResult,
+  SignInServiceData,
+  SignInServiceInput,
+  SignUpServiceData,
+  SignUpServiceInput,
+  UpdatePasswordServiceInput,
+  UserRoleServiceData,
+} from "../auth-service";
+import type { AuthPort } from "../ports/auth-port";
+
+/**
+ * SupabaseAuthAdapter — implements AuthPort using the Supabase JS client.
+ *
+ * This is the reference implementation and the canonical example for building
+ * custom AuthPort adapters. Each method maps 1:1 to a function in the
+ * pre-refactor auth-service.ts.
+ *
+ * Construction requires a SupabaseClient scoped to the current request
+ * (server or middleware client). It is the caller's responsibility to provide
+ * the correctly-scoped client — server client for Server Actions, middleware
+ * client for middleware flows.
+ */
+export class SupabaseAuthAdapter implements AuthPort {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async signInWithPassword(input: SignInServiceInput): Promise<ServiceResult<SignInServiceData>> {
+    const { error } = await this.client.auth.signInWithPassword({
+      email: input.email,
+      password: input.password,
+    });
+
+    if (error) {
+      return { success: false, error: "Invalid credentials", code: "INVALID_CREDENTIALS" };
+    }
+
+    const {
+      data: { user },
+    } = await this.client.auth.getUser();
+
+    if (!user) {
+      return { success: false, error: "User not found after sign-in", code: "USER_NOT_FOUND" };
+    }
+
+    const roleResult = await this.getUserRole(user.id);
+
+    if (!roleResult.success) {
+      return roleResult;
+    }
+
+    return { success: true, data: { role: roleResult.data.role } };
+  }
+
+  async signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>> {
+    const { data, error } = await this.client.auth.signUp({
+      email: input.email,
+      password: input.password,
+      options: {
+        data: input.metadata,
+        emailRedirectTo: input.emailRedirectTo,
+      },
+    });
+
+    if (error) {
+      return { success: false, error: "Could not create account", code: "SIGN_UP_FAILED" };
+    }
+
+    if (!data.user) {
+      return { success: false, error: "User was not created", code: "USER_NOT_CREATED" };
+    }
+
+    return {
+      success: true,
+      data: {
+        userId: data.user.id,
+        needsEmailConfirmation: data.session === null,
+      },
+    };
+  }
+
+  async signOut(): Promise<ServiceResult<null>> {
+    const { error } = await this.client.auth.signOut();
+
+    if (error) {
+      return { success: false, error: "Could not sign out", code: "SIGN_OUT_FAILED" };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async getUser(): Promise<ServiceResult<PlatformUser | null>> {
+    const {
+      data: { user },
+      error,
+    } = await this.client.auth.getUser();
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not resolve authenticated user",
+        code: "AUTH_USER_LOOKUP_FAILED",
+      };
+    }
+
+    if (!user) {
+      return { success: true, data: null };
+    }
+
+    const { data: profile } = await this.client
+      .from("profiles")
+      .select("tenant_id, role, name, avatar_url")
+      .eq("id", user.id)
+      .single();
+
+    return {
+      success: true,
+      data: {
+        id: user.id,
+        createdAt: new Date(user.created_at),
+        updatedAt: new Date(user.updated_at ?? user.created_at),
+        email: user.email ?? "",
+        name: profile?.name ?? null,
+        avatarUrl: profile?.avatar_url ?? null,
+        role: (profile?.role as UserRole | undefined) ?? "guest",
+        tenantId: profile?.tenant_id ?? "",
+      },
+    };
+  }
+
+  async getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>> {
+    const { data: profile, error } = await this.client
+      .from("profiles")
+      .select("role")
+      .eq("id", userId)
+      .single();
+
+    if (error && error.code !== "PGRST116") {
+      return {
+        success: false,
+        error: "Could not load user role",
+        code: "ROLE_LOOKUP_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        role: (profile?.role as UserRole | null | undefined) ?? "guest",
+      },
+    };
+  }
+
+  async requestPasswordReset(input: PasswordResetServiceInput): Promise<ServiceResult<null>> {
+    const { error } = await this.client.auth.resetPasswordForEmail(input.email, {
+      redirectTo: input.redirectTo,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not send password reset email",
+        code: "PASSWORD_RESET_REQUEST_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async updatePassword(input: UpdatePasswordServiceInput): Promise<ServiceResult<null>> {
+    const { error } = await this.client.auth.updateUser({
+      password: input.password,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: "Could not update password",
+        code: "PASSWORD_UPDATE_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+}

--- a/packages/core/src/services/adapters/supabase-session-adapter.ts
+++ b/packages/core/src/services/adapters/supabase-session-adapter.ts
@@ -1,0 +1,30 @@
+import type { NextRequest, NextResponse } from "next/server";
+import { type MiddlewareSupabaseConfig, updateSession } from "../../supabase/middleware";
+import type { SessionPort } from "../ports/session-port";
+
+/**
+ * SupabaseSessionAdapter — implements SessionPort using @supabase/ssr.
+ *
+ * This adapter wraps the existing updateSession() function from
+ * packages/core/src/supabase/middleware.ts. The function reads the session
+ * token from request cookies, validates it with the Supabase Auth server
+ * (via getUser()), and returns a NextResponse with refreshed Set-Cookie headers.
+ *
+ * Construction requires the Supabase project URL and anon key. These are the
+ * same env vars already in use: NEXT_PUBLIC_SUPABASE_URL and
+ * NEXT_PUBLIC_SUPABASE_ANON_KEY. No new env vars are introduced.
+ */
+export class SupabaseSessionAdapter implements SessionPort {
+  private readonly config: MiddlewareSupabaseConfig;
+
+  constructor(supabaseUrl: string, supabaseAnonKey: string) {
+    this.config = { supabaseUrl, supabaseAnonKey };
+  }
+
+  async refreshSession(request: NextRequest): Promise<NextResponse> {
+    // Delegates directly to updateSession() — same behavior as pre-refactor middleware.
+    // The function creates a server client, calls getUser() to validate and refresh
+    // the session, then returns a response with updated cookies.
+    return updateSession(request, this.config);
+  }
+}

--- a/packages/core/src/services/adapters/supabase-storage-adapter.ts
+++ b/packages/core/src/services/adapters/supabase-storage-adapter.ts
@@ -1,0 +1,138 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ServiceResult } from "../auth-service";
+import type {
+  StorageFileEntry,
+  StoragePort,
+  StoragePublicUrlResult,
+  StorageSignedUrlResult,
+  StorageUploadOptions,
+  StorageUploadResult,
+} from "../ports/storage-port";
+
+/**
+ * SupabaseStorageAdapter — implements StoragePort using the Supabase Storage API.
+ *
+ * Construction requires a SupabaseClient. In practice this is the server client
+ * from `getServerClient()` (authenticated user context) or the admin client for
+ * service-role operations.
+ *
+ * Bucket and path naming conventions follow `STORAGE_BUCKETS` and `STORAGE_PATHS`
+ * from `packages/core/src/supabase/storage-paths.ts`. These constants are
+ * provider-agnostic — they are just naming conventions that any adapter can use.
+ */
+export class SupabaseStorageAdapter implements StoragePort {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async upload(
+    bucket: string,
+    path: string,
+    file: Blob | File | ArrayBuffer,
+    options?: StorageUploadOptions,
+  ): Promise<ServiceResult<StorageUploadResult>> {
+    const { data, error } = await this.client.storage.from(bucket).upload(path, file, {
+      contentType: options?.contentType,
+      upsert: options?.upsert ?? true,
+    });
+
+    if (error) {
+      return {
+        success: false,
+        error: `Upload failed: ${error.message}`,
+        code: "STORAGE_UPLOAD_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: { path: data.path, fullPath: data.fullPath },
+    };
+  }
+
+  async download(bucket: string, path: string): Promise<ServiceResult<Blob>> {
+    const { data, error } = await this.client.storage.from(bucket).download(path);
+
+    if (error || !data) {
+      return {
+        success: false,
+        error: `Download failed: ${error?.message ?? "no data"}`,
+        code: "STORAGE_DOWNLOAD_FAILED",
+      };
+    }
+
+    return { success: true, data };
+  }
+
+  async delete(bucket: string, paths: string[]): Promise<ServiceResult<null>> {
+    const { error } = await this.client.storage.from(bucket).remove(paths);
+
+    if (error) {
+      return {
+        success: false,
+        error: `Delete failed: ${error.message}`,
+        code: "STORAGE_DELETE_FAILED",
+      };
+    }
+
+    return { success: true, data: null };
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    path: string,
+    expiresIn: number,
+  ): Promise<ServiceResult<StorageSignedUrlResult>> {
+    const { data, error } = await this.client.storage.from(bucket).createSignedUrl(path, expiresIn);
+
+    if (error || !data) {
+      return {
+        success: false,
+        error: `Signed URL failed: ${error?.message ?? "no data"}`,
+        code: "STORAGE_SIGNED_URL_FAILED",
+      };
+    }
+
+    return {
+      success: true,
+      data: { signedUrl: data.signedUrl, expiresIn },
+    };
+  }
+
+  async getPublicUrl(bucket: string, path: string): Promise<ServiceResult<StoragePublicUrlResult>> {
+    // Note: Supabase getPublicUrl() is synchronous and never returns an error.
+    // It constructs the URL from the project URL without making a network call.
+    const { data } = this.client.storage.from(bucket).getPublicUrl(path);
+
+    return {
+      success: true,
+      data: { publicUrl: data.publicUrl },
+    };
+  }
+
+  async listFiles(
+    bucket: string,
+    prefix = "",
+    limit = 100,
+    offset = 0,
+  ): Promise<ServiceResult<StorageFileEntry[]>> {
+    const { data, error } = await this.client.storage.from(bucket).list(prefix, { limit, offset });
+
+    if (error) {
+      return {
+        success: false,
+        error: `List files failed: ${error.message}`,
+        code: "STORAGE_LIST_FAILED",
+      };
+    }
+
+    const entries: StorageFileEntry[] = (data ?? []).map((item) => ({
+      name: item.name,
+      id: item.id ?? null,
+      updatedAt: item.updated_at ? new Date(item.updated_at) : null,
+      createdAt: item.created_at ? new Date(item.created_at) : null,
+      size: item.metadata?.size ?? null,
+      mimeType: item.metadata?.mimetype ?? null,
+    }));
+
+    return { success: true, data: entries };
+  }
+}

--- a/packages/core/src/services/backend-adapters.ts
+++ b/packages/core/src/services/backend-adapters.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { SupabaseAuthAdapter } from "./adapters/supabase-auth-adapter";
+import { SupabaseSessionAdapter } from "./adapters/supabase-session-adapter";
+import { SupabaseStorageAdapter } from "./adapters/supabase-storage-adapter";
+import type { AuthPort } from "./ports/auth-port";
+import type { SessionPort } from "./ports/session-port";
+import type { StoragePort } from "./ports/storage-port";
+
+/**
+ * The resolved set of backend adapters.
+ *
+ * auth and storage are factory functions (not instances) because SupabaseClient
+ * is request-scoped — it must be created per-request from getServerClient().
+ * The factory itself is safely called once at module level in Server Actions.
+ *
+ * session is a constructed instance because SupabaseSessionAdapter captures
+ * the URL/key at construction and creates its own client per refreshSession() call.
+ */
+export interface BackendAdapters {
+  /** Factory: call with a request-scoped SupabaseClient to get an AuthPort. */
+  auth: (client: SupabaseClient) => AuthPort;
+  /** Factory: call with a request-scoped SupabaseClient to get a StoragePort. */
+  storage: (client: SupabaseClient) => StoragePort;
+  /** Middleware-level session refresh — used by ui/middleware.ts. */
+  session: SessionPort;
+}
+
+/**
+ * createBackendAdapters — selects and instantiates the active backend adapters.
+ *
+ * Selection is driven by env vars:
+ *   BACKEND_AUTH_PROVIDER    — "supabase" (default) | "custom"
+ *   BACKEND_STORAGE_PROVIDER — "supabase" (default) | "custom"
+ *
+ * The session adapter always uses the Supabase implementation because session
+ * management is tightly coupled to the auth provider. Custom providers must
+ * implement their own session handling.
+ *
+ * Throws a descriptive error if an unsupported provider name is set, so
+ * misconfiguration fails loudly at startup rather than silently at runtime.
+ *
+ * @example
+ * // Default Supabase path (no env vars needed beyond Supabase credentials)
+ * const adapters = createBackendAdapters();
+ *
+ * @example
+ * // In a Server Action (auth):
+ * const { auth: authFactory } = createBackendAdapters();
+ * const client = await getServerClient();
+ * const auth = authFactory(client);
+ * return signInWithPasswordService(auth, input);
+ *
+ * @example
+ * // In middleware (session):
+ * const { session: sessionPort } = createBackendAdapters();
+ * const response = await sessionPort.refreshSession(request);
+ */
+export function createBackendAdapters(): BackendAdapters {
+  const authProvider = process.env["BACKEND_AUTH_PROVIDER"] ?? "supabase";
+  const storageProvider = process.env["BACKEND_STORAGE_PROVIDER"] ?? "supabase";
+
+  // --- Auth adapter factory ---
+  let authFactory: (client: SupabaseClient) => AuthPort;
+
+  if (authProvider === "supabase") {
+    authFactory = (client) => new SupabaseAuthAdapter(client);
+  } else {
+    throw new Error(
+      `[createBackendAdapters] Unknown BACKEND_AUTH_PROVIDER: "${authProvider}". ` +
+        `Supported values: "supabase". To use a custom adapter: implement AuthPort ` +
+        `and return a new instance in createBackendAdapters().`,
+    );
+  }
+
+  // --- Storage adapter factory ---
+  let storageFactory: (client: SupabaseClient) => StoragePort;
+
+  if (storageProvider === "supabase") {
+    storageFactory = (client) => new SupabaseStorageAdapter(client);
+  } else {
+    throw new Error(
+      `[createBackendAdapters] Unknown BACKEND_STORAGE_PROVIDER: "${storageProvider}". ` +
+        `Supported values: "supabase". To use a custom adapter: implement StoragePort ` +
+        `and return a new instance in createBackendAdapters().`,
+    );
+  }
+
+  // --- Session adapter (always Supabase in MVP; no selection env var) ---
+  const supabaseUrl = process.env["NEXT_PUBLIC_SUPABASE_URL"];
+  const supabaseAnonKey = process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+
+  if (!supabaseUrl) {
+    throw new Error(
+      "[createBackendAdapters] Missing NEXT_PUBLIC_SUPABASE_URL. " +
+        "This is required for the session adapter.",
+    );
+  }
+
+  if (!supabaseAnonKey) {
+    throw new Error(
+      "[createBackendAdapters] Missing NEXT_PUBLIC_SUPABASE_ANON_KEY. " +
+        "This is required for the session adapter.",
+    );
+  }
+
+  const session: SessionPort = new SupabaseSessionAdapter(supabaseUrl, supabaseAnonKey);
+
+  return {
+    auth: authFactory,
+    storage: storageFactory,
+    session,
+  };
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,33 +1,30 @@
 // Platform service layer - base services for multi-tenant operations
 // These are meant to be extended by domain-specific services
 
-// Backend ports — provider-agnostic interfaces
-export type { AuthPort } from "./ports/auth-port";
-export type {
-  StoragePort,
-  StorageUploadOptions,
-  StorageUploadResult,
-  StorageSignedUrlResult,
-  StoragePublicUrlResult,
-  StorageFileEntry,
-} from "./ports/storage-port";
-export type { SessionPort } from "./ports/session-port";
-
-// Backend adapters — Supabase reference implementations
-export { SupabaseAuthAdapter } from "./adapters/supabase-auth-adapter";
-export { SupabaseStorageAdapter } from "./adapters/supabase-storage-adapter";
-export { SupabaseSessionAdapter } from "./adapters/supabase-session-adapter";
-
-// Backend adapter factory
-export { createBackendAdapters } from "./backend-adapters";
-export type { BackendAdapters } from "./backend-adapters";
-
 export { ConsoleInvitationEmailAdapter } from "./adapters/console-invitation-email-adapter";
 export { ResendInvitationEmailAdapter } from "./adapters/resend-invitation-email-adapter";
+// Backend adapters — Supabase reference implementations
+export { SupabaseAuthAdapter } from "./adapters/supabase-auth-adapter";
+export { SupabaseSessionAdapter } from "./adapters/supabase-session-adapter";
+export { SupabaseStorageAdapter } from "./adapters/supabase-storage-adapter";
 export * from "./auth-service";
+export type { BackendAdapters } from "./backend-adapters";
+// Backend adapter factory
+export { createBackendAdapters } from "./backend-adapters";
 export * from "./billing-service";
 export * from "./notification-service";
+// Backend ports — provider-agnostic interfaces
+export type { AuthPort } from "./ports/auth-port";
 export type { InvitationEmailParams, InvitationEmailPort } from "./ports/invitation-email-port";
+export type { SessionPort } from "./ports/session-port";
+export type {
+  StorageFileEntry,
+  StoragePort,
+  StoragePublicUrlResult,
+  StorageSignedUrlResult,
+  StorageUploadOptions,
+  StorageUploadResult,
+} from "./ports/storage-port";
 export * from "./resource-service";
 export * from "./tenant-team-service";
 export * from "./workspace-settings-service";

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,6 +1,27 @@
 // Platform service layer - base services for multi-tenant operations
 // These are meant to be extended by domain-specific services
 
+// Backend ports — provider-agnostic interfaces
+export type { AuthPort } from "./ports/auth-port";
+export type {
+  StoragePort,
+  StorageUploadOptions,
+  StorageUploadResult,
+  StorageSignedUrlResult,
+  StoragePublicUrlResult,
+  StorageFileEntry,
+} from "./ports/storage-port";
+export type { SessionPort } from "./ports/session-port";
+
+// Backend adapters — Supabase reference implementations
+export { SupabaseAuthAdapter } from "./adapters/supabase-auth-adapter";
+export { SupabaseStorageAdapter } from "./adapters/supabase-storage-adapter";
+export { SupabaseSessionAdapter } from "./adapters/supabase-session-adapter";
+
+// Backend adapter factory
+export { createBackendAdapters } from "./backend-adapters";
+export type { BackendAdapters } from "./backend-adapters";
+
 export { ConsoleInvitationEmailAdapter } from "./adapters/console-invitation-email-adapter";
 export { ResendInvitationEmailAdapter } from "./adapters/resend-invitation-email-adapter";
 export * from "./auth-service";

--- a/packages/core/src/services/ports/__tests__/auth-port.test.ts
+++ b/packages/core/src/services/ports/__tests__/auth-port.test.ts
@@ -1,0 +1,100 @@
+/**
+ * auth-port.test.ts — TDD: validates AuthPort interface contract
+ *
+ * These tests verify that:
+ * 1. A plain object satisfying AuthPort compiles and passes type checks
+ * 2. A mock satisfies the interface without any SDK imports
+ * 3. getUser returns null (not an error) for anonymous users
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { AuthPort } from "../auth-port";
+
+/**
+ * Creates a minimal mock that satisfies AuthPort without any Supabase SDK imports.
+ * This is the canonical pattern for testing services that depend on AuthPort.
+ */
+function createMockAuthPort(): AuthPort {
+  return {
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getUser: vi.fn(),
+    getUserRole: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    updatePassword: vi.fn(),
+  };
+}
+
+describe("AuthPort interface", () => {
+  it("a plain object mock satisfies AuthPort without SDK imports", () => {
+    const auth: AuthPort = createMockAuthPort();
+
+    // Verify all 7 required methods exist on the mock
+    expect(typeof auth.signInWithPassword).toBe("function");
+    expect(typeof auth.signUp).toBe("function");
+    expect(typeof auth.signOut).toBe("function");
+    expect(typeof auth.getUser).toBe("function");
+    expect(typeof auth.getUserRole).toBe("function");
+    expect(typeof auth.requestPasswordReset).toBe("function");
+    expect(typeof auth.updatePassword).toBe("function");
+  });
+
+  it("getUser returns null (not an error) for anonymous users", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.getUser).mockResolvedValue({ success: true, data: null });
+
+    const result = await auth.getUser();
+
+    // Anonymous visitor: success=true with data=null (not a failure ServiceResult)
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it("signInWithPassword returns INVALID_CREDENTIALS on failure", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.signInWithPassword).mockResolvedValue({
+      success: false,
+      error: "Invalid credentials",
+      code: "INVALID_CREDENTIALS",
+    });
+
+    const result = await auth.signInWithPassword({
+      email: "user@example.com",
+      password: "wrong",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("INVALID_CREDENTIALS");
+    }
+  });
+
+  it("signOut returns success with null data", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.signOut).mockResolvedValue({ success: true, data: null });
+
+    const result = await auth.signOut();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it("getUserRole returns guest role for PGRST116 (profile not found)", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.getUserRole).mockResolvedValue({
+      success: true,
+      data: { role: "guest" },
+    });
+
+    const result = await auth.getUserRole("non-existent-user-id");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.role).toBe("guest");
+    }
+  });
+});

--- a/packages/core/src/services/ports/__tests__/storage-port.test.ts
+++ b/packages/core/src/services/ports/__tests__/storage-port.test.ts
@@ -1,0 +1,92 @@
+/**
+ * storage-port.test.ts — TDD: validates StoragePort interface contract
+ *
+ * These tests verify that:
+ * 1. A plain object satisfying StoragePort compiles without SDK imports
+ * 2. delete() accepts an array of multiple paths (not a single path)
+ * 3. All 6 methods are present and callable
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { StoragePort } from "../storage-port";
+
+/**
+ * Canonical mock for StoragePort — no Supabase SDK required.
+ */
+function createMockStoragePort(): StoragePort {
+  return {
+    upload: vi.fn(),
+    download: vi.fn(),
+    delete: vi.fn(),
+    getSignedUrl: vi.fn(),
+    getPublicUrl: vi.fn(),
+    listFiles: vi.fn(),
+  };
+}
+
+describe("StoragePort interface", () => {
+  it("a plain object mock satisfies StoragePort without SDK imports", () => {
+    const storage: StoragePort = createMockStoragePort();
+
+    // All 6 methods must be present
+    expect(typeof storage.upload).toBe("function");
+    expect(typeof storage.download).toBe("function");
+    expect(typeof storage.delete).toBe("function");
+    expect(typeof storage.getSignedUrl).toBe("function");
+    expect(typeof storage.getPublicUrl).toBe("function");
+    expect(typeof storage.listFiles).toBe("function");
+  });
+
+  it("delete accepts an array of multiple paths", async () => {
+    const storage = createMockStoragePort();
+    vi.mocked(storage.delete).mockResolvedValue({ success: true, data: null });
+
+    const paths = ["folder/file1.png", "folder/file2.png", "folder/file3.png"];
+    const result = await storage.delete("avatars", paths);
+
+    expect(result.success).toBe(true);
+    // Verify delete was called with the full array (not just one path)
+    expect(vi.mocked(storage.delete)).toHaveBeenCalledWith("avatars", paths);
+    expect(vi.mocked(storage.delete)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["folder/file1.png", "folder/file2.png", "folder/file3.png"]),
+    );
+  });
+
+  it("upload returns path and fullPath on success", async () => {
+    const storage = createMockStoragePort();
+    vi.mocked(storage.upload).mockResolvedValue({
+      success: true,
+      data: {
+        path: "tenant-1/avatar.webp",
+        fullPath:
+          "https://example.supabase.co/storage/v1/object/public/avatars/tenant-1/avatar.webp",
+      },
+    });
+
+    const result = await storage.upload("avatars", "tenant-1/avatar.webp", new Blob(["data"]), {
+      contentType: "image/webp",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.path).toBe("tenant-1/avatar.webp");
+      expect(result.data.fullPath).toContain("avatars");
+    }
+  });
+
+  it("getPublicUrl always succeeds (no error path)", async () => {
+    const storage = createMockStoragePort();
+    vi.mocked(storage.getPublicUrl).mockResolvedValue({
+      success: true,
+      data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatars/file.png" },
+    });
+
+    const result = await storage.getPublicUrl("avatars", "tenant-1/avatar.png");
+
+    // getPublicUrl MUST always return success: true (Supabase constructs URL without network call)
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.publicUrl).toBeTruthy();
+    }
+  });
+});

--- a/packages/core/src/services/ports/auth-port.ts
+++ b/packages/core/src/services/ports/auth-port.ts
@@ -1,0 +1,69 @@
+import type { PlatformUser } from "@enterprise/contracts";
+import type {
+  PasswordResetServiceInput,
+  ServiceResult,
+  SignInServiceData,
+  SignInServiceInput,
+  SignUpServiceData,
+  SignUpServiceInput,
+  UpdatePasswordServiceInput,
+  UserRoleServiceData,
+} from "../auth-service";
+
+/**
+ * AuthPort — provider-agnostic authentication interface.
+ *
+ * Implement this interface to swap the auth backend without modifying any
+ * service or Server Action. The Supabase reference implementation is
+ * `SupabaseAuthAdapter`. Community adapters (Firebase, Clerk, Auth0) implement
+ * the same interface.
+ *
+ * All methods return `ServiceResult<T>` — the same discriminated union used
+ * throughout the service layer. Adapters MUST NOT throw; they must return
+ * `{ success: false, error: string, code: string }` on failure.
+ */
+export interface AuthPort {
+  /**
+   * Authenticates a user with email and password.
+   * Returns the user's role on success so the caller can resolve the redirect path.
+   */
+  signInWithPassword(input: SignInServiceInput): Promise<ServiceResult<SignInServiceData>>;
+
+  /**
+   * Registers a new user account.
+   * Returns the new userId and whether email confirmation is required before login.
+   */
+  signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>>;
+
+  /**
+   * Terminates the current user session.
+   */
+  signOut(): Promise<ServiceResult<null>>;
+
+  /**
+   * Returns the currently authenticated user, or null if no session is active.
+   * Implementors MUST validate the token server-side (equivalent to Supabase's getUser(),
+   * NOT getSession() which only decodes the JWT without server-side validation).
+   */
+  getUser(): Promise<ServiceResult<PlatformUser | null>>;
+
+  /**
+   * Returns the platform role for a given userId from the profiles table.
+   * This method exists separately because role resolution requires a DB query
+   * that may not be part of every auth provider's token claims.
+   * Implementors that embed the role in the JWT may resolve it without a DB call.
+   */
+  getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>>;
+
+  /**
+   * Sends a password reset email to the specified address.
+   * The redirectTo URL is where the provider redirects after the user clicks the link.
+   */
+  requestPasswordReset(input: PasswordResetServiceInput): Promise<ServiceResult<null>>;
+
+  /**
+   * Updates the password for the currently authenticated user.
+   * Requires an active session (the user clicked the reset link and is in a password-update flow).
+   */
+  updatePassword(input: UpdatePasswordServiceInput): Promise<ServiceResult<null>>;
+}

--- a/packages/core/src/services/ports/index.ts
+++ b/packages/core/src/services/ports/index.ts
@@ -1,0 +1,10 @@
+export type { AuthPort } from "./auth-port";
+export type { SessionPort } from "./session-port";
+export type {
+  StorageFileEntry,
+  StoragePort,
+  StoragePublicUrlResult,
+  StorageSignedUrlResult,
+  StorageUploadOptions,
+  StorageUploadResult,
+} from "./storage-port";

--- a/packages/core/src/services/ports/session-port.ts
+++ b/packages/core/src/services/ports/session-port.ts
@@ -1,0 +1,34 @@
+import type { NextRequest, NextResponse } from "next/server";
+
+/**
+ * SessionPort — Next.js middleware-level session management interface.
+ *
+ * This port is intentionally Next.js-scoped. It returns `NextResponse` because
+ * middleware is a Next.js primitive — abstracting this away would require a custom
+ * response wrapper that adds complexity without benefit. Adopters who switch
+ * frameworks must rewrite middleware regardless.
+ *
+ * `refreshSession` is the single responsibility: given an incoming request,
+ * refresh the session cookie and return a response with updated Set-Cookie headers.
+ * The middleware delegates all session refresh logic to this port — it does NOT
+ * import `@supabase/ssr` directly.
+ *
+ * The Supabase reference implementation is `SupabaseSessionAdapter`, which wraps
+ * the existing `updateSession()` logic from `packages/core/src/supabase/middleware.ts`.
+ */
+export interface SessionPort {
+  /**
+   * Refreshes the authentication session for an incoming middleware request.
+   *
+   * The implementation is responsible for:
+   * 1. Reading the session token from the request cookies.
+   * 2. Validating and refreshing the token with the auth provider (server-side).
+   * 3. Returning a NextResponse with updated Set-Cookie headers so the refreshed
+   *    token is written to the browser.
+   *
+   * @param request - The incoming Next.js middleware request.
+   * @returns A NextResponse with refreshed session cookies, or a pass-through response
+   *          if no session exists or no refresh was needed.
+   */
+  refreshSession(request: NextRequest): Promise<NextResponse>;
+}

--- a/packages/core/src/services/ports/storage-port.ts
+++ b/packages/core/src/services/ports/storage-port.ts
@@ -1,0 +1,132 @@
+import type { ServiceResult } from "../auth-service";
+
+/**
+ * Metadata passed when uploading a file.
+ */
+export interface StorageUploadOptions {
+  /** MIME type of the file, e.g. "image/png". */
+  contentType?: string;
+  /** Whether to overwrite an existing file at the same path. Default: true. */
+  upsert?: boolean;
+}
+
+/**
+ * Result of a successful upload.
+ */
+export interface StorageUploadResult {
+  /** Full storage path (bucket-relative) of the uploaded file. */
+  path: string;
+  /** Full URL of the uploaded file (public or signed depending on bucket config). */
+  fullPath: string;
+}
+
+/**
+ * Result of a signed URL generation.
+ */
+export interface StorageSignedUrlResult {
+  /** Signed URL valid for the requested duration. */
+  signedUrl: string;
+  /** Expiry time in seconds from now. */
+  expiresIn: number;
+}
+
+/**
+ * Result of a public URL lookup (no expiry, no signature).
+ */
+export interface StoragePublicUrlResult {
+  /** Public URL for the file. Only valid if the bucket is configured as public. */
+  publicUrl: string;
+}
+
+/**
+ * A file entry returned by listFiles.
+ */
+export interface StorageFileEntry {
+  name: string;
+  id: string | null;
+  updatedAt: Date | null;
+  createdAt: Date | null;
+  /** File size in bytes. null for folders. */
+  size: number | null;
+  mimeType: string | null;
+}
+
+/**
+ * StoragePort — provider-agnostic file storage interface.
+ *
+ * Implement this interface to swap the storage backend (Supabase Storage, S3,
+ * Cloudflare R2, local filesystem) without modifying any service or Server Action.
+ *
+ * The `bucket` parameter always corresponds to a value from `STORAGE_BUCKETS` in
+ * `packages/core/src/supabase/storage-paths.ts`. The path parameters follow the
+ * conventions defined by `STORAGE_PATHS`. These constants are provider-agnostic
+ * naming conventions — they remain unchanged regardless of which adapter is active.
+ *
+ * All methods return `ServiceResult<T>`. Adapters MUST NOT throw; they return
+ * `{ success: false, error: string, code: string }` on failure.
+ */
+export interface StoragePort {
+  /**
+   * Uploads a file to the specified bucket at the given path.
+   * @param bucket - The target bucket name (from STORAGE_BUCKETS).
+   * @param path - The bucket-relative path (from STORAGE_PATHS helpers).
+   * @param file - The file content as Blob, File, or ArrayBuffer.
+   * @param options - Optional content-type and upsert flag.
+   */
+  upload(
+    bucket: string,
+    path: string,
+    file: Blob | File | ArrayBuffer,
+    options?: StorageUploadOptions,
+  ): Promise<ServiceResult<StorageUploadResult>>;
+
+  /**
+   * Downloads a file from the specified bucket.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   * @returns The file as a Blob.
+   */
+  download(bucket: string, path: string): Promise<ServiceResult<Blob>>;
+
+  /**
+   * Deletes one or more files from the specified bucket.
+   * @param bucket - The source bucket name.
+   * @param paths - One or more bucket-relative paths.
+   */
+  delete(bucket: string, paths: string[]): Promise<ServiceResult<null>>;
+
+  /**
+   * Generates a time-limited signed URL for a private file.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   * @param expiresIn - URL validity duration in seconds.
+   */
+  getSignedUrl(
+    bucket: string,
+    path: string,
+    expiresIn: number,
+  ): Promise<ServiceResult<StorageSignedUrlResult>>;
+
+  /**
+   * Returns the public URL for a file in a public bucket.
+   * This does not make a network call — it constructs the URL from the provider's
+   * base URL and the bucket/path. Only valid for publicly accessible buckets.
+   * @param bucket - The source bucket name.
+   * @param path - The bucket-relative path.
+   */
+  getPublicUrl(bucket: string, path: string): Promise<ServiceResult<StoragePublicUrlResult>>;
+
+  /**
+   * Lists files in the specified bucket at the given prefix path.
+   * @param bucket - The source bucket name.
+   * @param prefix - The path prefix to list under. Defaults to root ("").
+   * @param limit - Maximum number of entries to return. Defaults to 100.
+   * @param offset - Pagination offset. Defaults to 0.
+   */
+  listFiles(
+    bucket: string,
+    prefix?: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<ServiceResult<StorageFileEntry[]>>;
+}


### PR DESCRIPTION
## What
Implements the Backend Provider Decoupling foundation (#16, PR-C1): port interfaces that abstract backend operations behind provider-agnostic contracts, with Supabase reference adapters and a factory function.

## Why
Decouples business logic from Supabase-specific APIs. Template adopters can swap auth/storage providers by implementing the port interfaces and setting env vars — zero service-layer changes needed.

## Changes

### packages/core — Ports (NEW)
- `services/ports/auth-port.ts`: AuthPort (7 methods: signIn, signUp, signOut, getUser, resetPassword, updateUser, exchangeCode)
- `services/ports/storage-port.ts`: StoragePort (6 methods: upload, download, remove, getPublicUrl, list, createSignedUrl)
- `services/ports/session-port.ts`: SessionPort (refreshSession for middleware)

### packages/core — Adapters (NEW)
- `services/adapters/supabase-auth-adapter.ts`: SupabaseAuthAdapter implements AuthPort
- `services/adapters/supabase-storage-adapter.ts`: SupabaseStorageAdapter implements StoragePort
- `services/adapters/supabase-session-adapter.ts`: SupabaseSessionAdapter implements SessionPort

### packages/core — Factory (NEW)
- `services/backend-adapters.ts`: createBackendAdapters() — env-var-driven provider selection

## Tests
- 41 new unit tests (ports + adapters + factory)
- All 175 core tests passing

## PR Chain
This is **PR-C1** of the brand-and-decoupling change (stacked-to-main).
Next: PR-C2 (service migration) — this PR is PURELY ADDITIVE, no existing code modified.