### PR TITLE
test(ui): add test script so @enterprise/ui tests run in CI

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build:theme": "tsx scripts/build-theme.ts",
     "typecheck": "tsc --noEmit",
+    "test": "cd ../.. && vitest run --project ui",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `@enterprise/ui` had NO `test` script, so `turbo run test` (and CI) silently skipped ALL of its tests — 164 unit tests across 18 files (form/button/theme + brand once merged) had ZERO CI coverage
- The `ui` project was already defined in the root `vitest.config.ts`; only the package script was missing
- Adds `"test": "cd ../.. && vitest run --project ui"` matching the `contracts`/`core` pattern

## Why This Matters

This gap meant the brand abstraction PRs (#114/#115) would merge branding code whose unit tests never run in CI. Merging this first restores real CI coverage to `packages/ui` before the brand chain lands.

## Changes

| File | Change |
|------|--------|
| `packages/ui/package.json` | Add `test` script wiring the existing `ui` vitest project |

## Verification

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm test` now runs 4 tasks (was 3): contracts, core, **ui**, web
- [x] `@enterprise/ui`: 164 tests passed (18 files)
- [x] `pnpm lint` passes (0 errors)

## Merge Order

Merge this FIRST. Then rebase the brand chain (#114 → #115) onto main so their brand tests inherit CI coverage.