### PR TITLE
feat(brand): add BrandLogo, BrandFooter components and E2E tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,17 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhY
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54332/postgres
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Brand Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Brand slug — forces a specific brand to be rendered regardless of subdomain
+# or path prefix. Required for single-brand deployments and local development.
+# Must match the `slug` field of a brand config in packages/ui/src/brands/.
+# Example: BRAND_SLUG=enterprise
+# Omit to enable subdomain-based or path-prefix-based brand resolution.
+BRAND_SLUG=enterprise
+
+# ─────────────────────────────────────────────────────────────────────────────
 # App Configuration
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,7 +16,9 @@
     "./brand/provider": "./src/brand/provider.tsx",
     "./brand/resolve": "./src/brand/resolve.ts",
     "./brand/registry": "./src/brand/registry.ts",
-    "./brand/metadata": "./src/brand/metadata.ts"
+    "./brand/metadata": "./src/brand/metadata.ts",
+    "./brand/brand-logo": "./src/brand/brand-logo.tsx",
+    "./brand/brand-footer": "./src/brand/brand-footer.tsx"
   },
   "scripts": {
     "build:theme": "tsx scripts/build-theme.ts",

--- a/packages/ui/src/brand/__tests__/brand-footer.test.ts
+++ b/packages/ui/src/brand/__tests__/brand-footer.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+/**
+ * BrandFooter component tests — RED phase
+ *
+ * Tests cover:
+ * - Renders copyright line with displayName and current year
+ * - Legal links rendered when privacyUrl and termsUrl are non-empty
+ * - Legal links omitted when privacyUrl/termsUrl are empty string
+ * - Social links rendered when brand.social is present
+ * - "Powered by" text rendered when features.showPoweredBy is true
+ * - "Powered by" text omitted when features.showPoweredBy is false
+ * - className prop applied to root <footer>
+ */
+
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Mock dependencies
+// ============================================================================
+
+vi.mock("../provider", () => ({
+  useBrand: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+const baseLogo = {
+  light: { src: "/logo-light.svg", alt: "Logo", width: 160, height: 32 },
+  dark: { src: "/logo-dark.svg", alt: "Logo", width: 160, height: 32 },
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: {
+      titleTemplate: "%s | Enterprise Platform",
+      defaultTitle: "Enterprise Platform",
+      description: "Enterprise Platform template.",
+      ogImage: "/images/enterprise/og-image.png",
+    },
+    legal: {
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    },
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): {
+  container: HTMLDivElement;
+  root: ReactDOM.Root;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandFooter", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("renders copyright line with displayName", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const footer = container.querySelector("footer");
+    expect(footer?.textContent).toContain("Enterprise Platform");
+  });
+
+  it("renders the current year in the copyright line", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const currentYear = new Date().getFullYear().toString();
+    const footer = container.querySelector("footer");
+    expect(footer?.textContent).toContain(currentYear);
+  });
+
+  it("renders privacy and terms links when URLs are non-empty", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: {
+          privacyUrl: "https://example.com/privacy",
+          termsUrl: "https://example.com/terms",
+        },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = container.querySelectorAll("a");
+    const hrefs = Array.from(links).map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://example.com/privacy");
+    expect(hrefs).toContain("https://example.com/terms");
+  });
+
+  it("omits privacy link when privacyUrl is empty string", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: { privacyUrl: "", termsUrl: "https://example.com/terms" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).not.toContain("");
+    // terms link still present
+    expect(hrefs).toContain("https://example.com/terms");
+  });
+
+  it("omits terms link when termsUrl is empty string", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: { privacyUrl: "https://example.com/privacy", termsUrl: "" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://example.com/privacy");
+    // terms link should NOT be present
+    expect(hrefs.every((h) => h !== "")).toBe(true);
+    expect(links).toHaveLength(1); // only privacy
+  });
+
+  it("renders GitHub social link when brand.social.github is present", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        social: { github: "https://github.com/your-org" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://github.com/your-org");
+  });
+
+  it("renders 'Powered by' when features.showPoweredBy is true", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand({ features: { showPoweredBy: true } }));
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.textContent).toContain("Powered by");
+  });
+
+  it("omits 'Powered by' when features.showPoweredBy is false", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand({ features: { showPoweredBy: false } }));
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.textContent).not.toContain("Powered by");
+  });
+
+  it("applies className prop to root <footer>", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(
+      createElement(BrandFooter, { className: "py-8 border-t" }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    const footer = container.querySelector("footer");
+    expect(footer?.className).toContain("py-8");
+    expect(footer?.className).toContain("border-t");
+  });
+});

--- a/packages/ui/src/brand/__tests__/brand-footer.test.ts
+++ b/packages/ui/src/brand/__tests__/brand-footer.test.ts
@@ -12,10 +12,10 @@
  * - className prop applied to root <footer>
  */
 
+import type { BrandConfig } from "@enterprise/contracts";
 import { act, createElement } from "react";
 import * as ReactDOM from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BrandConfig } from "@enterprise/contracts";
 
 // ============================================================================
 // Mock dependencies

--- a/packages/ui/src/brand/__tests__/brand-logo.test.ts
+++ b/packages/ui/src/brand/__tests__/brand-logo.test.ts
@@ -1,0 +1,259 @@
+// @vitest-environment happy-dom
+/**
+ * BrandLogo component tests — RED phase
+ *
+ * Tests cover:
+ * - Renders light variant <img> in light mode
+ * - Renders dark variant <img> in dark mode
+ * - alt attribute matches active variant
+ * - Empty src renders displayName text fallback (no <img>)
+ * - width and height passed to <img> when provided
+ * - className prop applied to root element
+ */
+
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Mock dependencies
+// ============================================================================
+
+// Mock useBrand() to inject test brand configs
+vi.mock("../provider", () => ({
+  useBrand: vi.fn(),
+}));
+
+// Mock useTheme() to inject test mode
+vi.mock("../../theme/provider", () => ({
+  useTheme: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+const baseLightVariant = {
+  src: "/images/enterprise/logo-light.svg",
+  alt: "Enterprise Platform Light",
+  width: 160,
+  height: 32,
+};
+
+const baseDarkVariant = {
+  src: "/images/enterprise/logo-dark.svg",
+  alt: "Enterprise Platform Dark",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLightVariant,
+  dark: baseDarkVariant,
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: {
+      titleTemplate: "%s | Enterprise Platform",
+      defaultTitle: "Enterprise Platform",
+      description: "Enterprise Platform template.",
+      ogImage: "/images/enterprise/og-image.png",
+    },
+    legal: {
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    },
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): {
+  container: HTMLDivElement;
+  root: ReactDOM.Root;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandLogo", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(async () => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("renders <img> with light variant src in light mode", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/images/enterprise/logo-light.svg");
+  });
+
+  it("renders <img> with dark variant src in dark mode", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "dark",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/images/enterprise/logo-dark.svg");
+  });
+
+  it("alt attribute matches the active variant", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("alt")).toBe("Enterprise Platform Light");
+  });
+
+  it("renders displayName text fallback when light src is empty", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    const brand = makeBrand({
+      logo: {
+        light: { src: "", alt: "Enterprise Platform", width: 160, height: 32 },
+        dark: baseDarkVariant,
+      },
+    });
+    vi.mocked(useBrand).mockReturnValue(brand);
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.querySelector("img")).toBeNull();
+    const span = container.querySelector("span");
+    expect(span?.textContent).toBe("Enterprise Platform");
+  });
+
+  it("passes width and height to <img> when provided", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "dark",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("width")).toBe("160");
+    expect(img?.getAttribute("height")).toBe("32");
+  });
+
+  it("applies className prop to the root <img>", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, { className: "h-8 w-auto" }));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.className).toContain("h-8");
+    expect(img?.className).toContain("w-auto");
+  });
+
+  it("applies className prop to the text fallback <span>", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("../../theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    const brand = makeBrand({
+      logo: {
+        light: { src: "", alt: "Enterprise Platform" },
+        dark: baseDarkVariant,
+      },
+    });
+    vi.mocked(useBrand).mockReturnValue(brand);
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, { className: "text-primary" }));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const span = container.querySelector("span");
+    expect(span?.className).toContain("text-primary");
+  });
+});

--- a/packages/ui/src/brand/__tests__/brand-logo.test.ts
+++ b/packages/ui/src/brand/__tests__/brand-logo.test.ts
@@ -11,10 +11,10 @@
  * - className prop applied to root element
  */
 
+import type { BrandConfig } from "@enterprise/contracts";
 import { act, createElement } from "react";
 import * as ReactDOM from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BrandConfig } from "@enterprise/contracts";
 
 // ============================================================================
 // Mock dependencies

--- a/packages/ui/src/brand/__tests__/provider.test.ts
+++ b/packages/ui/src/brand/__tests__/provider.test.ts
@@ -9,7 +9,7 @@
  */
 
 import type { BrandConfig } from "@enterprise/contracts";
-import { act, createElement, useContext } from "react";
+import { act, createElement } from "react";
 import * as ReactDOM from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/ui/src/brand/brand-footer.tsx
+++ b/packages/ui/src/brand/brand-footer.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { cn } from "../lib/utils";
+import { useBrand } from "./provider";
+
+// ============================================================================
+// BrandFooter
+// ============================================================================
+
+export interface BrandFooterProps {
+  /**
+   * Optional Tailwind class(es) to apply to the root <footer> element.
+   */
+  className?: string;
+}
+
+/**
+ * BrandFooter — renders the brand's copyright, legal links, social links,
+ * and optional "Powered by" attribution.
+ *
+ * - Copyright: © {year} {brand.displayName}
+ * - Legal links: only rendered when privacyUrl/termsUrl are non-empty strings
+ * - Social links: only rendered when brand.social is present
+ * - "Powered by": only rendered when brand.features?.showPoweredBy === true
+ *
+ * Must be rendered inside a BrandProvider.
+ */
+export function BrandFooter({ className }: BrandFooterProps) {
+  const brand = useBrand();
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={cn(className)}>
+      <p>
+        © {currentYear} {brand.displayName}
+      </p>
+
+      <nav aria-label="Legal links">
+        {brand.legal.privacyUrl && (
+          <a href={brand.legal.privacyUrl} rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+        )}
+        {brand.legal.termsUrl && (
+          <a href={brand.legal.termsUrl} rel="noopener noreferrer">
+            Terms of Service
+          </a>
+        )}
+      </nav>
+
+      {brand.social && (
+        <nav aria-label="Social links">
+          {brand.social.twitter && (
+            <a href={brand.social.twitter} rel="noopener noreferrer" aria-label="Twitter">
+              Twitter
+            </a>
+          )}
+          {brand.social.linkedin && (
+            <a href={brand.social.linkedin} rel="noopener noreferrer" aria-label="LinkedIn">
+              LinkedIn
+            </a>
+          )}
+          {brand.social.github && (
+            <a href={brand.social.github} rel="noopener noreferrer" aria-label="GitHub">
+              GitHub
+            </a>
+          )}
+        </nav>
+      )}
+
+      {brand.features?.["showPoweredBy"] === true && (
+        <p>
+          <small>Powered by Enterprise Platform</small>
+        </p>
+      )}
+    </footer>
+  );
+}

--- a/packages/ui/src/brand/brand-logo.tsx
+++ b/packages/ui/src/brand/brand-logo.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "../lib/utils";
+import { useTheme } from "../theme/provider";
+import { useBrand } from "./provider";
+
+// ============================================================================
+// BrandLogo
+// ============================================================================
+
+export interface BrandLogoProps {
+  /**
+   * Optional Tailwind class(es) to apply to the root element.
+   * Applied to both the <img> and the text fallback <span>.
+   */
+  className?: string;
+}
+
+/**
+ * BrandLogo — renders the correct logo variant for the active theme mode.
+ *
+ * - In "light" mode: renders brand.logo.light
+ * - In "dark" mode: renders brand.logo.dark
+ * - When the active variant's src is empty: renders a <span> with displayName as text fallback
+ *
+ * Must be rendered inside a BrandProvider (inherits from useBrand()) and a
+ * ThemeProvider (inherits from useTheme()).
+ */
+export function BrandLogo({ className }: BrandLogoProps) {
+  const brand = useBrand();
+  const { mode } = useTheme();
+
+  const logoVariant = mode === "light" ? brand.logo.light : brand.logo.dark;
+
+  // Text fallback when src is empty or undefined
+  if (!logoVariant.src) {
+    return (
+      // role="img" allows aria-label on the text fallback container
+      <span role="img" className={cn(className)} aria-label={logoVariant.alt}>
+        {brand.displayName}
+      </span>
+    );
+  }
+
+  return (
+    // biome-ignore lint/performance/noImgElement: packages/ui cannot use next/image (no Next.js dep in source)
+    <img
+      src={logoVariant.src}
+      alt={logoVariant.alt}
+      width={logoVariant.width}
+      height={logoVariant.height}
+      className={cn(className)}
+    />
+  );
+}

--- a/packages/ui/src/brand/index.ts
+++ b/packages/ui/src/brand/index.ts
@@ -1,6 +1,10 @@
 // Brand module barrel — re-exports for consumers that prefer the index import.
 // For server-only utilities (resolveBrand), import from the specific subpath.
 
+export type { BrandFooterProps } from "./brand-footer";
+export { BrandFooter } from "./brand-footer";
+export type { BrandLogoProps } from "./brand-logo";
+export { BrandLogo } from "./brand-logo";
 export type { BrandContextValue } from "./context";
 export { BrandContext } from "./context";
 export { generateBrandMetadata } from "./metadata";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,10 @@
 // Brand
 
 export type { BrandConfig } from "@enterprise/contracts";
+export type { BrandFooterProps } from "./brand/brand-footer";
+export { BrandFooter } from "./brand/brand-footer";
+export type { BrandLogoProps } from "./brand/brand-logo";
+export { BrandLogo } from "./brand/brand-logo";
 export type { BrandContextValue } from "./brand/context";
 export { BrandContext } from "./brand/context";
 export { generateBrandMetadata } from "./brand/metadata";

--- a/ui/e2e/brand/brand.spec.ts
+++ b/ui/e2e/brand/brand.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Brand E2E Tests — Brand Abstraction Layer
+ *
+ * Verifies that the default "enterprise" brand resolves correctly and renders
+ * expected metadata and page structure. Tests are minimal by design — the
+ * unit tests cover component behavior; E2E covers the full server resolution
+ * and rendering integration.
+ *
+ * Tests:
+ * - Page title contains the brand default title
+ * - Document has a favicon link
+ * - Sign-in page loads without errors (brand provider does not crash the app)
+ */
+
+test.describe("Brand System", () => {
+  test("page title contains the enterprise brand default title", async ({ page }) => {
+    // The enterprise brand metadata.defaultTitle = "Enterprise Platform"
+    // generateMetadata() in layout.tsx uses this via generateBrandMetadata()
+    await page.goto("/sign-in");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveTitle(/Enterprise Platform/);
+  });
+
+  test("document has a favicon link", async ({ page }) => {
+    // The enterprise brand favicon = "/images/enterprise/favicon.svg"
+    // generateBrandMetadata maps brand.favicon to icons.icon
+    await page.goto("/sign-in");
+    await page.waitForLoadState("networkidle");
+
+    const favicon = page.locator("link[rel='icon']");
+    await expect(favicon).toHaveCount(1);
+    const href = await favicon.getAttribute("href");
+    expect(href).toBeTruthy();
+  });
+
+  test("page loads without hydration errors (BrandProvider does not crash)", async ({ page }) => {
+    const errors: string[] = [];
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(msg.text());
+      }
+    });
+
+    await page.goto("/sign-in");
+    await page.waitForLoadState("networkidle");
+
+    // Filter to only brand-related or hydration errors — ignore network errors
+    const brandErrors = errors.filter(
+      (e) =>
+        e.includes("brand") ||
+        e.includes("BrandProvider") ||
+        e.includes("Hydration") ||
+        e.includes("useBrand"),
+    );
+
+    expect(brandErrors).toHaveLength(0);
+  });
+
+  test("sign-in page is accessible and brand name appears in title", async ({ page }) => {
+    // Full integration: brand resolves → metadata generated → page renders correctly
+    await page.goto("/sign-in");
+
+    const title = await page.title();
+    expect(title).toContain("Enterprise Platform");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds presentational brand components (BrandLogo, BrandFooter) and E2E coverage for the Brand Abstraction Layer (#14)
- Supersedes #115 (auto-closed when its base branch was deleted on #114 merge); rebased clean onto main

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/brand/brand-logo.tsx` | Mode-aware logo with text fallback |
| `packages/ui/src/brand/brand-footer.tsx` | Copyright, legal links, social |
| `packages/ui/src/brand/index.ts`, `src/index.ts` | Barrel + subpath exports |
| `ui/e2e/brand/brand.spec.ts` | 4 E2E scenarios (default brand) |
| `.env.example` | BRAND_SLUG documentation |

## Verification

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `@enterprise/ui` tests: 209 passed (incl. brand)
- [ ] Playwright E2E: known-flaky notifications test unrelated to this change