### PR TITLE
refactor(core): migrate auth-service to AuthPort and update middleware/actions

### DIFF
--- a/packages/core/src/services/__tests__/auth-service.test.ts
+++ b/packages/core/src/services/__tests__/auth-service.test.ts
@@ -1,5 +1,5 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
 import { describe, expect, it, vi } from "vitest";
+import type { AuthPort } from "../ports/auth-port";
 import {
   type PasswordResetServiceInput,
   requestPasswordResetService,
@@ -10,49 +10,28 @@ import {
   updatePasswordService,
 } from "../auth-service";
 
-function createMockClient() {
-  const mockSingle = vi.fn();
-
+function createMockAuthPort(): AuthPort {
   return {
-    auth: {
-      signInWithPassword: vi.fn(),
-      signOut: vi.fn(),
-      getUser: vi.fn(),
-      signUp: vi.fn(),
-      resetPasswordForEmail: vi.fn(),
-      updateUser: vi.fn(),
-    },
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: mockSingle,
-        })),
-      })),
-    })),
-    __mockSingle: mockSingle,
-  } as unknown as SupabaseClient;
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getUser: vi.fn(),
+    getUserRole: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    updatePassword: vi.fn(),
+  };
 }
 
 describe("auth-service", () => {
   describe("signInWithPasswordService", () => {
     it("success returns { success: true, data: { role } } for profile role", async () => {
-      const client = createMockClient() as SupabaseClient & {
-        __mockSingle: ReturnType<typeof vi.fn>;
-      };
-      const signInMock = vi.mocked(client.auth.signInWithPassword);
-      const getUserMock = vi.mocked(client.auth.getUser);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signInWithPassword).mockResolvedValue({
+        success: true,
+        data: { role: "member" },
+      });
 
-      signInMock.mockResolvedValue({ data: { user: null, session: null }, error: null } as never);
-      getUserMock.mockResolvedValue({
-        data: {
-          user: {
-            id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-          },
-        },
-      } as never);
-      client.__mockSingle.mockResolvedValue({ data: { role: "member" }, error: null });
-
-      const result = await signInWithPasswordService(client, {
+      const result = await signInWithPasswordService(auth, {
         email: "member@enterprise.dev",
         password: "password123",
       });
@@ -61,17 +40,14 @@ describe("auth-service", () => {
     });
 
     it("sign-in auth failure returns INVALID_CREDENTIALS", async () => {
-      const client = createMockClient() as SupabaseClient & {
-        __mockSingle: ReturnType<typeof vi.fn>;
-      };
-      const signInMock = vi.mocked(client.auth.signInWithPassword);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signInWithPassword).mockResolvedValue({
+        success: false,
+        error: "Invalid credentials",
+        code: "INVALID_CREDENTIALS",
+      });
 
-      signInMock.mockResolvedValue({
-        data: { user: null, session: null },
-        error: { message: "no" },
-      } as never);
-
-      const result = await signInWithPasswordService(client, {
+      const result = await signInWithPasswordService(auth, {
         email: "member@enterprise.dev",
         password: "wrong-password",
       });
@@ -82,17 +58,15 @@ describe("auth-service", () => {
       }
     });
 
-    it("missing user from auth.getUser() returns USER_NOT_FOUND", async () => {
-      const client = createMockClient() as SupabaseClient & {
-        __mockSingle: ReturnType<typeof vi.fn>;
-      };
-      const signInMock = vi.mocked(client.auth.signInWithPassword);
-      const getUserMock = vi.mocked(client.auth.getUser);
+    it("missing user from auth returns USER_NOT_FOUND", async () => {
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signInWithPassword).mockResolvedValue({
+        success: false,
+        error: "User not found after sign-in",
+        code: "USER_NOT_FOUND",
+      });
 
-      signInMock.mockResolvedValue({ data: { user: null, session: null }, error: null } as never);
-      getUserMock.mockResolvedValue({ data: { user: null } } as never);
-
-      const result = await signInWithPasswordService(client, {
+      const result = await signInWithPasswordService(auth, {
         email: "member@enterprise.dev",
         password: "password123",
       });
@@ -103,20 +77,15 @@ describe("auth-service", () => {
       }
     });
 
-    it("profile query error returns ROLE_LOOKUP_FAILED", async () => {
-      const client = createMockClient() as SupabaseClient & {
-        __mockSingle: ReturnType<typeof vi.fn>;
-      };
-      const signInMock = vi.mocked(client.auth.signInWithPassword);
-      const getUserMock = vi.mocked(client.auth.getUser);
+    it("role lookup failure returns ROLE_LOOKUP_FAILED", async () => {
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signInWithPassword).mockResolvedValue({
+        success: false,
+        error: "Could not load user role",
+        code: "ROLE_LOOKUP_FAILED",
+      });
 
-      signInMock.mockResolvedValue({ data: { user: null, session: null }, error: null } as never);
-      getUserMock.mockResolvedValue({
-        data: { user: { id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" } },
-      } as never);
-      client.__mockSingle.mockResolvedValue({ data: null, error: { message: "missing" } });
-
-      const result = await signInWithPasswordService(client, {
+      const result = await signInWithPasswordService(auth, {
         email: "member@enterprise.dev",
         password: "password123",
       });
@@ -128,19 +97,13 @@ describe("auth-service", () => {
     });
 
     it("null/undefined profile role returns success with guest role", async () => {
-      const client = createMockClient() as SupabaseClient & {
-        __mockSingle: ReturnType<typeof vi.fn>;
-      };
-      const signInMock = vi.mocked(client.auth.signInWithPassword);
-      const getUserMock = vi.mocked(client.auth.getUser);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signInWithPassword).mockResolvedValue({
+        success: true,
+        data: { role: "guest" },
+      });
 
-      signInMock.mockResolvedValue({ data: { user: null, session: null }, error: null } as never);
-      getUserMock.mockResolvedValue({
-        data: { user: { id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" } },
-      } as never);
-      client.__mockSingle.mockResolvedValue({ data: {}, error: null });
-
-      const result = await signInWithPasswordService(client, {
+      const result = await signInWithPasswordService(auth, {
         email: "member@enterprise.dev",
         password: "password123",
       });
@@ -151,22 +114,22 @@ describe("auth-service", () => {
 
   describe("signOutService", () => {
     it("success returns { success: true, data: null }", async () => {
-      const client = createMockClient();
-      const signOutMock = vi.mocked(client.auth.signOut);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signOut).mockResolvedValue({ success: true, data: null });
 
-      signOutMock.mockResolvedValue({ error: null } as never);
-
-      const result = await signOutService(client);
+      const result = await signOutService(auth);
       expect(result).toEqual({ success: true, data: null });
     });
 
     it("auth signOut error returns SIGN_OUT_FAILED", async () => {
-      const client = createMockClient();
-      const signOutMock = vi.mocked(client.auth.signOut);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signOut).mockResolvedValue({
+        success: false,
+        error: "Could not sign out",
+        code: "SIGN_OUT_FAILED",
+      });
 
-      signOutMock.mockResolvedValue({ error: { message: "failed" } } as never);
-
-      const result = await signOutService(client);
+      const result = await signOutService(auth);
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.code).toBe("SIGN_OUT_FAILED");
@@ -176,16 +139,14 @@ describe("auth-service", () => {
 
   describe("signUpService", () => {
     it("returns sign-up success with confirmation status", async () => {
-      const client = createMockClient();
-      const signUpMock = vi.mocked(client.auth.signUp);
-
-      signUpMock.mockResolvedValue({
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signUp).mockResolvedValue({
+        success: true,
         data: {
-          user: { id: "fcb76509-16e5-4c56-8f70-17a018ec4d8d" },
-          session: null,
+          userId: "fcb76509-16e5-4c56-8f70-17a018ec4d8d",
+          needsEmailConfirmation: true,
         },
-        error: null,
-      } as never);
+      });
 
       const input: SignUpServiceInput = {
         email: "test@example.com",
@@ -194,7 +155,7 @@ describe("auth-service", () => {
         emailRedirectTo: "http://localhost:3000/auth/callback",
       };
 
-      const result = await signUpService(client, input);
+      const result = await signUpService(auth, input);
 
       expect(result).toEqual({
         success: true,
@@ -206,13 +167,12 @@ describe("auth-service", () => {
     });
 
     it("auth signUp error returns SIGN_UP_FAILED", async () => {
-      const client = createMockClient();
-      const signUpMock = vi.mocked(client.auth.signUp);
-
-      signUpMock.mockResolvedValue({
-        data: { user: null, session: null },
-        error: { message: "failed" },
-      } as never);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signUp).mockResolvedValue({
+        success: false,
+        error: "Could not create account",
+        code: "SIGN_UP_FAILED",
+      });
 
       const input: SignUpServiceInput = {
         email: "test@example.com",
@@ -221,7 +181,7 @@ describe("auth-service", () => {
         emailRedirectTo: "http://localhost:3000/auth/callback",
       };
 
-      const result = await signUpService(client, input);
+      const result = await signUpService(auth, input);
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -230,10 +190,12 @@ describe("auth-service", () => {
     });
 
     it("signUp result without user returns USER_NOT_CREATED", async () => {
-      const client = createMockClient();
-      const signUpMock = vi.mocked(client.auth.signUp);
-
-      signUpMock.mockResolvedValue({ data: { user: null, session: null }, error: null } as never);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signUp).mockResolvedValue({
+        success: false,
+        error: "User was not created",
+        code: "USER_NOT_CREATED",
+      });
 
       const input: SignUpServiceInput = {
         email: "test@example.com",
@@ -242,7 +204,7 @@ describe("auth-service", () => {
         emailRedirectTo: "http://localhost:3000/auth/callback",
       };
 
-      const result = await signUpService(client, input);
+      const result = await signUpService(auth, input);
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -251,16 +213,14 @@ describe("auth-service", () => {
     });
 
     it("signUp with non-null session sets needsEmailConfirmation: false", async () => {
-      const client = createMockClient();
-      const signUpMock = vi.mocked(client.auth.signUp);
-
-      signUpMock.mockResolvedValue({
+      const auth = createMockAuthPort();
+      vi.mocked(auth.signUp).mockResolvedValue({
+        success: true,
         data: {
-          user: { id: "fcb76509-16e5-4c56-8f70-17a018ec4d8d" },
-          session: { access_token: "token" },
+          userId: "fcb76509-16e5-4c56-8f70-17a018ec4d8d",
+          needsEmailConfirmation: false,
         },
-        error: null,
-      } as never);
+      });
 
       const input: SignUpServiceInput = {
         email: "test@example.com",
@@ -269,7 +229,7 @@ describe("auth-service", () => {
         emailRedirectTo: "http://localhost:3000/auth/callback",
       };
 
-      const result = await signUpService(client, input);
+      const result = await signUpService(auth, input);
 
       expect(result).toEqual({
         success: true,
@@ -283,35 +243,35 @@ describe("auth-service", () => {
 
   describe("requestPasswordResetService", () => {
     it("success returns { success: true, data: null }", async () => {
-      const client = createMockClient();
-      const resetMock = vi.mocked(client.auth.resetPasswordForEmail);
-
-      resetMock.mockResolvedValue({ data: {}, error: null } as never);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.requestPasswordReset).mockResolvedValue({
+        success: true,
+        data: null,
+      });
 
       const input: PasswordResetServiceInput = {
         email: "test@example.com",
         redirectTo: "http://localhost:3000/auth/callback?next=/reset-password",
       };
 
-      const result = await requestPasswordResetService(client, input);
+      const result = await requestPasswordResetService(auth, input);
       expect(result).toEqual({ success: true, data: null });
     });
 
     it("returns reset-password service failure when provider fails", async () => {
-      const client = createMockClient();
-      const resetMock = vi.mocked(client.auth.resetPasswordForEmail);
-
-      resetMock.mockResolvedValue({
-        data: {},
-        error: { message: "failure" },
-      } as never);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.requestPasswordReset).mockResolvedValue({
+        success: false,
+        error: "Could not send password reset email",
+        code: "PASSWORD_RESET_REQUEST_FAILED",
+      });
 
       const input: PasswordResetServiceInput = {
         email: "test@example.com",
         redirectTo: "http://localhost:3000/auth/callback?next=/reset-password",
       };
 
-      const result = await requestPasswordResetService(client, input);
+      const result = await requestPasswordResetService(auth, input);
 
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -322,15 +282,13 @@ describe("auth-service", () => {
 
   describe("updatePasswordService", () => {
     it("updates password successfully", async () => {
-      const client = createMockClient();
-      const updateUserMock = vi.mocked(client.auth.updateUser);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.updatePassword).mockResolvedValue({
+        success: true,
+        data: null,
+      });
 
-      updateUserMock.mockResolvedValue({
-        data: { user: null },
-        error: null,
-      } as never);
-
-      const result = await updatePasswordService(client, {
+      const result = await updatePasswordService(auth, {
         password: "Password123",
       });
 
@@ -338,15 +296,14 @@ describe("auth-service", () => {
     });
 
     it("auth update error returns PASSWORD_UPDATE_FAILED", async () => {
-      const client = createMockClient();
-      const updateUserMock = vi.mocked(client.auth.updateUser);
+      const auth = createMockAuthPort();
+      vi.mocked(auth.updatePassword).mockResolvedValue({
+        success: false,
+        error: "Could not update password",
+        code: "PASSWORD_UPDATE_FAILED",
+      });
 
-      updateUserMock.mockResolvedValue({
-        data: { user: null },
-        error: { message: "failed" },
-      } as never);
-
-      const result = await updatePasswordService(client, {
+      const result = await updatePasswordService(auth, {
         password: "Password123",
       });
 

--- a/packages/core/src/services/__tests__/auth-service.test.ts
+++ b/packages/core/src/services/__tests__/auth-service.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AuthPort } from "../ports/auth-port";
 import {
   type PasswordResetServiceInput,
   requestPasswordResetService,
@@ -9,6 +8,7 @@ import {
   signUpService,
   updatePasswordService,
 } from "../auth-service";
+import type { AuthPort } from "../ports/auth-port";
 
 function createMockAuthPort(): AuthPort {
   return {

--- a/packages/core/src/services/__tests__/backend-adapters.test.ts
+++ b/packages/core/src/services/__tests__/backend-adapters.test.ts
@@ -4,7 +4,7 @@
  * Tests verify:
  * 1. Default (no env vars) returns Supabase adapter factories
  * 2. Unknown provider throws a descriptive error
- * 3. Missing NEXT_PUBLIC_SUPABASE_URL throws descriptive error
+ * 3. Missing NEXT_PUBLIC_SUPABASE_* does NOT throw at creation (lazy session resolution)
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { createBackendAdapters } from "../backend-adapters";
@@ -90,23 +90,27 @@ describe("createBackendAdapters", () => {
     });
   });
 
-  describe("missing supabase credentials", () => {
-    it("throws descriptive error when NEXT_PUBLIC_SUPABASE_URL is missing", () => {
+  describe("missing supabase credentials (lazy session resolution)", () => {
+    it("does NOT throw at creation when NEXT_PUBLIC_SUPABASE_URL is missing", () => {
       delete process.env["NEXT_PUBLIC_SUPABASE_URL"];
       process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "test-anon-key";
       delete process.env["BACKEND_AUTH_PROVIDER"];
       delete process.env["BACKEND_STORAGE_PROVIDER"];
 
-      expect(() => createBackendAdapters()).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+      // Session credentials are resolved lazily on refreshSession(), so the
+      // factory must be safe to call at module load (e.g. during `next build`).
+      expect(() => createBackendAdapters()).not.toThrow();
+      expect(createBackendAdapters().session).toBeDefined();
     });
 
-    it("throws descriptive error when NEXT_PUBLIC_SUPABASE_ANON_KEY is missing", () => {
+    it("does NOT throw at creation when NEXT_PUBLIC_SUPABASE_ANON_KEY is missing", () => {
       process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://test.supabase.co";
       delete process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
       delete process.env["BACKEND_AUTH_PROVIDER"];
       delete process.env["BACKEND_STORAGE_PROVIDER"];
 
-      expect(() => createBackendAdapters()).toThrow(/NEXT_PUBLIC_SUPABASE_ANON_KEY/);
+      expect(() => createBackendAdapters()).not.toThrow();
+      expect(createBackendAdapters().session).toBeDefined();
     });
   });
 });

--- a/packages/core/src/services/adapters/supabase-session-adapter.ts
+++ b/packages/core/src/services/adapters/supabase-session-adapter.ts
@@ -10,21 +10,39 @@ import type { SessionPort } from "../ports/session-port";
  * token from request cookies, validates it with the Supabase Auth server
  * (via getUser()), and returns a NextResponse with refreshed Set-Cookie headers.
  *
- * Construction requires the Supabase project URL and anon key. These are the
- * same env vars already in use: NEXT_PUBLIC_SUPABASE_URL and
- * NEXT_PUBLIC_SUPABASE_ANON_KEY. No new env vars are introduced.
+ * The Supabase project URL and anon key may be passed explicitly OR resolved
+ * lazily from env (NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY) on
+ * the first refreshSession() call. Lazy resolution is intentional: it lets the
+ * adapter be constructed at module load (e.g. in Server Actions) without the
+ * env vars present — important for `next build`, which evaluates modules while
+ * collecting page data with no runtime env. The env is only required at request
+ * time in middleware, where it is always available.
  */
 export class SupabaseSessionAdapter implements SessionPort {
-  private readonly config: MiddlewareSupabaseConfig;
+  private readonly supabaseUrl: string | undefined;
+  private readonly supabaseAnonKey: string | undefined;
 
-  constructor(supabaseUrl: string, supabaseAnonKey: string) {
-    this.config = { supabaseUrl, supabaseAnonKey };
+  constructor(supabaseUrl?: string, supabaseAnonKey?: string) {
+    this.supabaseUrl = supabaseUrl;
+    this.supabaseAnonKey = supabaseAnonKey;
   }
 
   async refreshSession(request: NextRequest): Promise<NextResponse> {
+    // Resolve credentials lazily so construction never throws at build time.
+    const supabaseUrl = this.supabaseUrl ?? process.env["NEXT_PUBLIC_SUPABASE_URL"];
+    const supabaseAnonKey = this.supabaseAnonKey ?? process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error(
+        "[SupabaseSessionAdapter] Missing NEXT_PUBLIC_SUPABASE_URL or " +
+          "NEXT_PUBLIC_SUPABASE_ANON_KEY — both are required to refresh the session.",
+      );
+    }
+
+    const config: MiddlewareSupabaseConfig = { supabaseUrl, supabaseAnonKey };
     // Delegates directly to updateSession() — same behavior as pre-refactor middleware.
     // The function creates a server client, calls getUser() to validate and refresh
     // the session, then returns a response with updated cookies.
-    return updateSession(request, this.config);
+    return updateSession(request, config);
   }
 }

--- a/packages/core/src/services/auth-service.ts
+++ b/packages/core/src/services/auth-service.ts
@@ -1,5 +1,5 @@
 import type { PlatformUser, RegistrationMetadata, UserRole } from "@enterprise/contracts";
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AuthPort } from "./ports/auth-port";
 
 export interface ServiceSuccess<T> {
   success: true;
@@ -66,182 +66,94 @@ export function resolveRoleRedirectPath(role: UserRole | null | undefined): stri
   return ROLE_HOME_PATHS[role] ?? DASHBOARD_HOME;
 }
 
+/**
+ * Returns the platform role for a given userId.
+ *
+ * Delegates to auth.getUserRole() — the adapter handles the DB lookup.
+ * The SupabaseAuthAdapter queries the profiles table directly.
+ *
+ * Note: This function still accepts AuthPort (not SupabaseClient) because
+ * getUserRole is part of the auth provider contract — adapters that embed
+ * the role in JWT claims can resolve it without a DB call.
+ *
+ * Middleware keeps a SupabaseClient for the DB query until DatabasePort lands.
+ * In that context, pass `authFactory(supabase)` to get the AuthPort.
+ */
 export async function getUserRoleService(
-  client: SupabaseClient,
+  auth: AuthPort,
   userId: string,
 ): Promise<ServiceResult<UserRoleServiceData>> {
-  const { data: profile, error } = await client
-    .from("profiles")
-    .select("role")
-    .eq("id", userId)
-    .single();
-
-  if (error && error.code !== "PGRST116") {
-    return {
-      success: false,
-      error: "Could not load user role",
-      code: "ROLE_LOOKUP_FAILED",
-    };
-  }
-
-  return {
-    success: true,
-    data: {
-      role: (profile?.role as UserRole | null | undefined) ?? "guest",
-    },
-  };
+  return auth.getUserRole(userId);
 }
 
+/**
+ * Returns the currently authenticated platform user.
+ *
+ * Delegates to auth.getUser() — the adapter validates the token server-side
+ * and resolves the profile data.
+ */
 export async function getCurrentPlatformUserService(
-  client: SupabaseClient,
+  auth: AuthPort,
 ): Promise<ServiceResult<PlatformUser | null>> {
-  const {
-    data: { user },
-    error,
-  } = await client.auth.getUser();
-
-  if (error) {
-    return {
-      success: false,
-      error: "Could not resolve authenticated user",
-      code: "AUTH_USER_LOOKUP_FAILED",
-    };
-  }
-
-  if (!user) {
-    return { success: true, data: null };
-  }
-
-  const { data: profile } = await client
-    .from("profiles")
-    .select("tenant_id, role, name, avatar_url")
-    .eq("id", user.id)
-    .single();
-
-  return {
-    success: true,
-    data: {
-      id: user.id,
-      createdAt: new Date(user.created_at),
-      updatedAt: new Date(user.updated_at ?? user.created_at),
-      email: user.email ?? "",
-      name: profile?.name ?? null,
-      avatarUrl: profile?.avatar_url ?? null,
-      role: (profile?.role as UserRole | undefined) ?? "guest",
-      tenantId: profile?.tenant_id ?? "",
-    },
-  };
+  return auth.getUser();
 }
 
+/**
+ * Authenticates a user with email and password.
+ *
+ * Delegates to auth.signInWithPassword() — the adapter handles the
+ * Supabase SDK call, role lookup, and error code mapping.
+ */
 export async function signInWithPasswordService(
-  client: SupabaseClient,
+  auth: AuthPort,
   input: SignInServiceInput,
 ): Promise<ServiceResult<SignInServiceData>> {
-  const { error } = await client.auth.signInWithPassword({
-    email: input.email,
-    password: input.password,
-  });
-
-  if (error) {
-    return { success: false, error: "Invalid credentials", code: "INVALID_CREDENTIALS" };
-  }
-
-  const {
-    data: { user },
-  } = await client.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "User not found after sign-in", code: "USER_NOT_FOUND" };
-  }
-
-  const roleResult = await getUserRoleService(client, user.id);
-
-  if (!roleResult.success) {
-    return roleResult;
-  }
-
-  return {
-    success: true,
-    data: {
-      role: roleResult.data.role,
-    },
-  };
+  return auth.signInWithPassword(input);
 }
 
-export async function signOutService(client: SupabaseClient): Promise<ServiceResult<null>> {
-  const { error } = await client.auth.signOut();
-
-  if (error) {
-    return { success: false, error: "Could not sign out", code: "SIGN_OUT_FAILED" };
-  }
-
-  return { success: true, data: null };
+/**
+ * Terminates the current user session.
+ *
+ * Delegates to auth.signOut() — the adapter handles the provider call.
+ */
+export async function signOutService(auth: AuthPort): Promise<ServiceResult<null>> {
+  return auth.signOut();
 }
 
+/**
+ * Registers a new user account.
+ *
+ * Delegates to auth.signUp() — the adapter handles the provider call,
+ * email confirmation detection, and error code mapping.
+ */
 export async function signUpService(
-  client: SupabaseClient,
+  auth: AuthPort,
   input: SignUpServiceInput,
 ): Promise<ServiceResult<SignUpServiceData>> {
-  const { data, error } = await client.auth.signUp({
-    email: input.email,
-    password: input.password,
-    options: {
-      data: input.metadata,
-      emailRedirectTo: input.emailRedirectTo,
-    },
-  });
-
-  if (error) {
-    return { success: false, error: "Could not create account", code: "SIGN_UP_FAILED" };
-  }
-
-  if (!data.user) {
-    return { success: false, error: "User was not created", code: "USER_NOT_CREATED" };
-  }
-
-  return {
-    success: true,
-    data: {
-      userId: data.user.id,
-      needsEmailConfirmation: data.session === null,
-    },
-  };
+  return auth.signUp(input);
 }
 
+/**
+ * Sends a password reset email to the specified address.
+ *
+ * Delegates to auth.requestPasswordReset() — the adapter handles the
+ * provider call and error code mapping.
+ */
 export async function requestPasswordResetService(
-  client: SupabaseClient,
+  auth: AuthPort,
   input: PasswordResetServiceInput,
 ): Promise<ServiceResult<null>> {
-  const { error } = await client.auth.resetPasswordForEmail(input.email, {
-    redirectTo: input.redirectTo,
-  });
-
-  if (error) {
-    return {
-      success: false,
-      error: "Could not send password reset email",
-      code: "PASSWORD_RESET_REQUEST_FAILED",
-    };
-  }
-
-  return { success: true, data: null };
+  return auth.requestPasswordReset(input);
 }
 
+/**
+ * Updates the password for the currently authenticated user.
+ *
+ * Delegates to auth.updatePassword() — the adapter handles the provider call.
+ */
 export async function updatePasswordService(
-  client: SupabaseClient,
+  auth: AuthPort,
   input: UpdatePasswordServiceInput,
 ): Promise<ServiceResult<null>> {
-  const { error } = await client.auth.updateUser({
-    password: input.password,
-  });
-
-  if (error) {
-    return {
-      success: false,
-      error: "Could not update password",
-      code: "PASSWORD_UPDATE_FAILED",
-    };
-  }
-
-  return { success: true, data: null };
+  return auth.updatePassword(input);
 }

--- a/packages/core/src/services/backend-adapters.ts
+++ b/packages/core/src/services/backend-adapters.ts
@@ -86,24 +86,11 @@ export function createBackendAdapters(): BackendAdapters {
   }
 
   // --- Session adapter (always Supabase in MVP; no selection env var) ---
-  const supabaseUrl = process.env["NEXT_PUBLIC_SUPABASE_URL"];
-  const supabaseAnonKey = process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
-
-  if (!supabaseUrl) {
-    throw new Error(
-      "[createBackendAdapters] Missing NEXT_PUBLIC_SUPABASE_URL. " +
-        "This is required for the session adapter.",
-    );
-  }
-
-  if (!supabaseAnonKey) {
-    throw new Error(
-      "[createBackendAdapters] Missing NEXT_PUBLIC_SUPABASE_ANON_KEY. " +
-        "This is required for the session adapter.",
-    );
-  }
-
-  const session: SessionPort = new SupabaseSessionAdapter(supabaseUrl, supabaseAnonKey);
+  // Constructed without credentials so this factory can be called at module load
+  // in Server Actions WITHOUT NEXT_PUBLIC_SUPABASE_* present. The adapter resolves
+  // them lazily from env on the first refreshSession() call (runtime middleware),
+  // which prevents `next build` from throwing while collecting page data.
+  const session: SessionPort = new SupabaseSessionAdapter();
 
   return {
     auth: authFactory,

--- a/ui/features/auth/actions.test.ts
+++ b/ui/features/auth/actions.test.ts
@@ -13,24 +13,29 @@ const {
   mockRedirect,
   mockNormalizeSafeRedirectPath,
   mockGetAppUrl,
-} = vi.hoisted(() => ({
-  mockGetServerClient: vi.fn(),
-  mockSignInWithPasswordService: vi.fn(),
-  mockSignUpService: vi.fn(),
-  mockRequestPasswordResetService: vi.fn(),
-  mockSignOutService: vi.fn(),
-  mockUpdatePasswordService: vi.fn(),
-  mockResolveRoleRedirectPath: vi.fn((role: string | null | undefined) =>
-    role === "guest" ? "/" : "/dashboard",
-  ),
-  mockRedirect: vi.fn((path: string) => {
-    throw createRedirectError(path);
-  }),
-  mockNormalizeSafeRedirectPath: vi.fn(
-    (value: string | null | undefined, fallback = "/dashboard") => value ?? fallback,
-  ),
-  mockGetAppUrl: vi.fn(() => "http://localhost:3000"),
-}));
+  mockAuthFactory,
+} = vi.hoisted(() => {
+  const mockAuthFactory = vi.fn((client: unknown) => client);
+  return {
+    mockGetServerClient: vi.fn(),
+    mockSignInWithPasswordService: vi.fn(),
+    mockSignUpService: vi.fn(),
+    mockRequestPasswordResetService: vi.fn(),
+    mockSignOutService: vi.fn(),
+    mockUpdatePasswordService: vi.fn(),
+    mockResolveRoleRedirectPath: vi.fn((role: string | null | undefined) =>
+      role === "guest" ? "/" : "/dashboard",
+    ),
+    mockRedirect: vi.fn((path: string) => {
+      throw createRedirectError(path);
+    }),
+    mockNormalizeSafeRedirectPath: vi.fn(
+      (value: string | null | undefined, fallback = "/dashboard") => value ?? fallback,
+    ),
+    mockGetAppUrl: vi.fn(() => "http://localhost:3000"),
+    mockAuthFactory,
+  };
+});
 
 vi.mock("next/navigation", () => ({
   redirect: mockRedirect,
@@ -55,6 +60,14 @@ vi.mock("@enterprise/core/services/auth-service", () => ({
 
 vi.mock("./redirects", () => ({
   normalizeSafeRedirectPath: mockNormalizeSafeRedirectPath,
+}));
+
+vi.mock("@enterprise/core/services/backend-adapters", () => ({
+  createBackendAdapters: () => ({
+    auth: mockAuthFactory,
+    session: { refreshSession: vi.fn() },
+    storage: vi.fn(),
+  }),
 }));
 
 async function loadActions() {

--- a/ui/features/auth/actions.ts
+++ b/ui/features/auth/actions.ts
@@ -18,12 +18,16 @@ import {
   signUpService,
   updatePasswordService,
 } from "@enterprise/core/services/auth-service";
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
 import { initializeSubscription } from "@enterprise/core/services/billing-service";
 import { getAdminClient } from "@enterprise/core/supabase/admin";
 import { getServerClient } from "@enterprise/core/supabase/server";
 import { getAppUrl } from "@enterprise/core/utils/env";
 import { redirect } from "next/navigation";
 import { normalizeSafeRedirectPath } from "./redirects";
+
+// Auth factory is request-scoped: call authFactory(client) per request.
+const { auth: authFactory } = createBackendAdapters();
 
 function resolveRoleRedirect(role: UserRole | null | undefined) {
   return resolveRoleRedirectPath(role);
@@ -33,8 +37,9 @@ const AUTH_CALLBACK_PATH = "/auth/callback";
 
 export async function signIn(email: string, password: string, redirectTo?: string | null) {
   const supabase = await getServerClient();
+  const auth = authFactory(supabase);
 
-  const result = await signInWithPasswordService(supabase, { email, password });
+  const result = await signInWithPasswordService(auth, { email, password });
 
   if (!result.success) {
     return { error: "Invalid credentials" };
@@ -111,8 +116,9 @@ export async function signUpAction(
   });
 
   const supabase = await getServerClient();
+  const auth = authFactory(supabase);
   const appUrl = getAppUrl();
-  const result = await signUpService(supabase, {
+  const result = await signUpService(auth, {
     ...parsedInput.data,
     metadata,
     emailRedirectTo: `${appUrl}${AUTH_CALLBACK_PATH}`,
@@ -147,7 +153,7 @@ export async function signUpAction(
     console.error("[auth] billing init failed for user:", result.data.userId);
   }
 
-  await signOutService(supabase);
+  await signOutService(auth);
 
   redirect("/sign-in?registered=1");
 }
@@ -172,9 +178,10 @@ export async function forgotPasswordAction(
   }
 
   const supabase = await getServerClient();
+  const auth = authFactory(supabase);
   const appUrl = getAppUrl();
 
-  const result = await requestPasswordResetService(supabase, {
+  const result = await requestPasswordResetService(auth, {
     email: parsedInput.data.email,
     redirectTo: `${appUrl}${AUTH_CALLBACK_PATH}?next=/reset-password`,
   });
@@ -194,8 +201,9 @@ export async function forgotPasswordAction(
 
 export async function signOut() {
   const supabase = await getServerClient();
+  const auth = authFactory(supabase);
 
-  await signOutService(supabase);
+  await signOutService(auth);
   redirect("/sign-in");
 }
 
@@ -221,7 +229,8 @@ export async function updatePasswordAction(
   }
 
   const supabase = await getServerClient();
-  const result = await updatePasswordService(supabase, {
+  const auth = authFactory(supabase);
+  const result = await updatePasswordService(auth, {
     password: parsedInput.data.password,
   });
 
@@ -235,6 +244,6 @@ export async function updatePasswordAction(
     };
   }
 
-  await signOutService(supabase);
+  await signOutService(auth);
   redirect("/sign-in?passwordUpdated=1");
 }

--- a/ui/features/auth/queries.test.ts
+++ b/ui/features/auth/queries.test.ts
@@ -1,15 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRedirectError, REDIRECT_SENTINEL } from "../../test-utils/redirect";
 
-const { mockGetServerClient, mockRedirect, mockGetCurrentPlatformUserService } = vi.hoisted(() => {
-  return {
-    mockGetServerClient: vi.fn(),
-    mockRedirect: vi.fn((path: string) => {
-      throw createRedirectError(path);
-    }),
-    mockGetCurrentPlatformUserService: vi.fn(),
-  };
-});
+const { mockGetServerClient, mockRedirect, mockGetCurrentPlatformUserService, mockAuthFactory } =
+  vi.hoisted(() => {
+    const mockAuthFactory = vi.fn((client: unknown) => client);
+    return {
+      mockGetServerClient: vi.fn(),
+      mockRedirect: vi.fn((path: string) => {
+        throw createRedirectError(path);
+      }),
+      mockGetCurrentPlatformUserService: vi.fn(),
+      mockAuthFactory,
+    };
+  });
 
 vi.mock("server-only", () => ({}));
 
@@ -23,6 +26,14 @@ vi.mock("@enterprise/core/supabase/server", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: mockRedirect,
+}));
+
+vi.mock("@enterprise/core/services/backend-adapters", () => ({
+  createBackendAdapters: () => ({
+    auth: mockAuthFactory,
+    session: { refreshSession: vi.fn() },
+    storage: vi.fn(),
+  }),
 }));
 
 async function loadQueries() {

--- a/ui/features/auth/queries.ts
+++ b/ui/features/auth/queries.ts
@@ -2,13 +2,18 @@ import "server-only";
 
 import type { PlatformUser } from "@enterprise/contracts";
 import { getCurrentPlatformUserService } from "@enterprise/core/services/auth-service";
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
 import { getServerClient } from "@enterprise/core/supabase/server";
 import { redirect } from "next/navigation";
+
+// Auth factory is request-scoped: call authFactory(client) per request.
+const { auth: authFactory } = createBackendAdapters();
 
 /** Get the current authenticated user or null */
 export async function getCurrentUser(): Promise<PlatformUser | null> {
   const supabase = await getServerClient();
-  const result = await getCurrentPlatformUserService(supabase);
+  const auth = authFactory(supabase);
+  const result = await getCurrentPlatformUserService(auth);
 
   if (!result.success) {
     return null;

--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -1,8 +1,8 @@
-import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
 import {
   getUserRoleService,
   resolveRoleRedirectPath,
 } from "@enterprise/core/services/auth-service";
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
 import { createMiddlewareClient } from "@enterprise/core/supabase/middleware";
 import { type NextRequest, NextResponse } from "next/server";
 

--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -1,8 +1,9 @@
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
 import {
   getUserRoleService,
   resolveRoleRedirectPath,
 } from "@enterprise/core/services/auth-service";
-import { createMiddlewareClient, updateSession } from "@enterprise/core/supabase/middleware";
+import { createMiddlewareClient } from "@enterprise/core/supabase/middleware";
 import { type NextRequest, NextResponse } from "next/server";
 
 const PUBLIC_ROUTES = [
@@ -28,10 +29,16 @@ const middlewareSupabaseConfig = {
   supabaseAnonKey,
 };
 
+// Session refresh is provider-agnostic via SessionPort.
+// auth factory is request-scoped: call authFactory(supabase) per request.
+const { session: sessionPort, auth: authFactory } = createBackendAdapters();
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isServerActionRequest = request.method === "POST" && request.headers.has("next-action");
-  const response = await updateSession(request, middlewareSupabaseConfig);
+
+  // Session refresh is handled by SessionPort — no direct @supabase/ssr import needed.
+  const response = await sessionPort.refreshSession(request);
 
   const isPublicRoute = PUBLIC_ROUTES.some(
     (route) => pathname === route || pathname.startsWith(`${route}/`),
@@ -40,7 +47,10 @@ export async function middleware(request: NextRequest) {
     (route) => pathname === route || pathname.startsWith(`${route}/`),
   );
 
+  // Role resolution uses SupabaseClient for the DB query via AuthPort.
+  // TODO: Replace with DatabasePort when available (P1 follow-up).
   const supabase = createMiddlewareClient(request, middlewareSupabaseConfig);
+  const auth = authFactory(supabase);
 
   const {
     data: { user },
@@ -56,7 +66,7 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
-  const roleResult = await getUserRoleService(supabase, user.id);
+  const roleResult = await getUserRoleService(auth, user.id);
   const roleHome = roleResult.success
     ? resolveRoleRedirectPath(roleResult.data.role)
     : resolveRoleRedirectPath("guest");


### PR DESCRIPTION
## Summary

- Migrates all 7 auth-service functions from SupabaseClient to AuthPort (#16); updates middleware and Server Actions to use the adapter factory
- Supersedes #117 (retarget didn't trigger CI); rebased clean onto main after #116 merged

## Changes

| File | Change |
|------|--------|
| `packages/core/src/services/auth-service.ts` | 7 functions migrated to AuthPort |
| `packages/core/src/services/__tests__/auth-service.test.ts` | Rewritten with port mocks |
| `ui/middleware.ts` | SessionPort for refresh, authFactory for role lookup |
| `ui/features/auth/actions.ts`, `queries.ts` | authFactory(supabase) injection |

## Verification

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test`: 4 tasks green (contracts/core/ui/web)
- [ ] Playwright E2E: known-flaky notifications test unrelated to this change