### PR TITLE
docs(core): add migration guide, mock helpers, and AGENTS.md updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,27 @@ EMAIL_FROM=noreply@yourdomain.com
 # SENTRY_PROJECT=
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Backend Provider Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+# Controls which adapter is selected by createBackendAdapters() in
+# packages/core/src/services/backend-adapters.ts.
+# Both variables default to "supabase" when unset — no changes needed for the
+# default Supabase path. Set to "custom" when wiring a custom adapter
+# (e.g. Firebase, Clerk, or Auth0 for auth; S3 or Cloudflare R2 for storage).
+#
+# See docs/developer-guide/backend-provider-migration.md for the full guide.
+
+# Supported values: "supabase" (default) | "custom"
+# Set to "custom" to wire your own AuthPort implementation (e.g. Firebase, Clerk, Auth0).
+# When "custom", update createBackendAdapters() to return your adapter instance.
+BACKEND_AUTH_PROVIDER=supabase
+
+# Supported values: "supabase" (default) | "custom"
+# Set to "custom" to wire your own StoragePort implementation (e.g. S3, Cloudflare R2, local).
+# When "custom", update createBackendAdapters() to return your adapter instance.
+BACKEND_STORAGE_PROVIDER=supabase
+
+# ─────────────────────────────────────────────────────────────────────────────
 # E2E Testing (used by Playwright tests — credentials from supabase/seed.sql)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/docs/developer-guide/backend-provider-migration.md
+++ b/docs/developer-guide/backend-provider-migration.md
@@ -1,0 +1,454 @@
+---
+title: "Backend provider migration guide"
+description: "How the port/adapter pattern works in Enterprise Platform, how to use it with zero changes (default Supabase path), and how to wire a custom auth or storage provider."
+owner: "Engineering"
+lastUpdated: "2026-05-31"
+---
+
+# Backend provider migration guide
+
+## Purpose
+
+This guide explains the port/adapter abstraction layer introduced in `packages/core` for
+authentication, storage, and session management. It covers:
+
+- What changed and why
+- The default Supabase path (zero changes needed)
+- Before/after examples for code that calls auth services
+- How to create a custom adapter for a different provider
+- How to wire adapters through environment variables
+- How to write tests using port mocks
+- Common pitfalls to avoid
+
+## Scope
+
+- Included: `AuthPort`, `StoragePort`, `SessionPort` interfaces; `SupabaseAuthAdapter`, `SupabaseStorageAdapter`, `SupabaseSessionAdapter`; `createBackendAdapters()` factory; mock helpers for unit tests
+- Excluded: `DatabasePort` (planned for a later phase — see [rfc.md](../features/backend-provider-decoupling/rfc.md)); Realtime abstraction; community adapters for Firebase, Clerk, Auth0 (extension points — not shipped)
+
+---
+
+## Overview — what changed and why
+
+Before this change, `auth-service.ts` accepted `SupabaseClient` directly and called
+`client.auth.*` inline. This created a hard coupling between the service layer and the
+Supabase SDK. Swapping to a different auth provider (Firebase, Clerk, Auth0) required
+rewriting every service function.
+
+The port/adapter pattern solves this by introducing a provider-agnostic interface
+(`AuthPort`) that any auth backend can satisfy. The `SupabaseAuthAdapter` implements
+`AuthPort` using the Supabase SDK — it is the reference implementation and the default.
+All services now accept `AuthPort` instead of `SupabaseClient` for auth operations.
+
+This follows the same pattern already established by the billing feature
+(`PaymentProviderPort` + `createPaymentAdapter()`). Adopters familiar with billing have
+zero new concepts to learn.
+
+**Key guarantee**: The default Supabase path is behaviorally identical to the pre-refactor
+direct calls. All existing tests and E2E flows pass without modification.
+
+---
+
+## Quick start — default Supabase path works with zero changes
+
+If you are using Supabase (the default), no changes are required. The factory
+`createBackendAdapters()` returns Supabase adapters automatically when
+`BACKEND_AUTH_PROVIDER` and `BACKEND_STORAGE_PROVIDER` are unset (or set to `"supabase"`).
+
+The only required environment variables remain the same:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
+```
+
+You do not need to set `BACKEND_AUTH_PROVIDER` or `BACKEND_STORAGE_PROVIDER` for the
+default path.
+
+---
+
+## Before/after: auth service callers
+
+The auth service functions changed their first argument from `SupabaseClient` to `AuthPort`.
+The caller site in Server Actions changes to wire the adapter via `createBackendAdapters()`.
+
+### Sign-in action
+
+```typescript
+// ✅ After — ui/features/auth/actions.ts
+"use server";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
+import { signInWithPasswordService } from "@enterprise/core/services/auth-service";
+
+// Factory called once at module level — safe because it only reads env vars.
+// The client (request-scoped) is passed per-invocation below.
+const { auth: authFactory } = createBackendAdapters();
+
+export async function signInAction(input: SignInInput): Promise<ActionResult<SignInData>> {
+  const client = await getServerClient();
+  const auth = authFactory(client);                  // ← per-request adapter
+  const result = await signInWithPasswordService(auth, input);
+  // ...
+}
+```
+
+```typescript
+// ❌ Before (pre-refactor)
+import { signInWithPasswordService } from "@enterprise/core/services/auth-service";
+
+export async function signInAction(input: SignInInput): Promise<ActionResult<SignInData>> {
+  const client = await getServerClient();
+  const result = await signInWithPasswordService(client, input);  // ← direct client
+  // ...
+}
+```
+
+### Why `authFactory(client)` instead of passing the adapter directly
+
+`SupabaseClient` is request-scoped — it must be created per-request from
+`getServerClient()`. The factory returns a function `(client: SupabaseClient) => AuthPort`
+so the expensive Supabase environment setup happens once at module level, while the
+request-specific client is wired per-invocation.
+
+### Service layer signature changes
+
+| Function | Before | After |
+|----------|--------|-------|
+| `signInWithPasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signUpService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signOutService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getCurrentPlatformUserService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getUserRoleService` | `(client: SupabaseClient, userId)` | `(auth: AuthPort, userId)` |
+| `requestPasswordResetService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `updatePasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+
+---
+
+## How to create a custom auth adapter
+
+To swap to a different auth provider, implement the `AuthPort` interface. Every method
+returns `ServiceResult<T>` — the same discriminated union used across the service layer.
+
+```typescript
+// ✅ Correct — custom adapter implementing AuthPort
+import type { AuthPort } from "@enterprise/core/services/ports/auth-port";
+import type {
+  ServiceResult,
+  SignInServiceData,
+  SignInServiceInput,
+  SignUpServiceData,
+  SignUpServiceInput,
+  PasswordResetServiceInput,
+  UpdatePasswordServiceInput,
+  UserRoleServiceData,
+} from "@enterprise/core/services/auth-service";
+import type { PlatformUser } from "@enterprise/contracts";
+
+export class MyCustomAuthAdapter implements AuthPort {
+  constructor(private readonly apiKey: string) {}
+
+  async signInWithPassword(input: SignInServiceInput): Promise<ServiceResult<SignInServiceData>> {
+    // Call your provider SDK
+    // Map the response to ServiceResult<{ role: UserRole }>
+    // NEVER throw — return { success: false, error: "...", code: "..." } on failure
+    return { success: true, data: { role: "member" } };
+  }
+
+  async signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>> {
+    return { success: true, data: { userId: "...", needsEmailConfirmation: false } };
+  }
+
+  async signOut(): Promise<ServiceResult<null>> {
+    return { success: true, data: null };
+  }
+
+  async getUser(): Promise<ServiceResult<PlatformUser | null>> {
+    return { success: true, data: null };
+  }
+
+  async getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>> {
+    // Role may come from JWT claims (no DB call needed) or from your own DB
+    return { success: true, data: { role: "member" } };
+  }
+
+  async requestPasswordReset(input: PasswordResetServiceInput): Promise<ServiceResult<null>> {
+    return { success: true, data: null };
+  }
+
+  async updatePassword(input: UpdatePasswordServiceInput): Promise<ServiceResult<null>> {
+    return { success: true, data: null };
+  }
+}
+```
+
+**Rules for adapter implementors:**
+
+- NEVER throw from an adapter method — always return `{ success: false, error, code }` on failure
+- Use `ServiceResult<T>` from `@enterprise/core/services/auth-service` as the return type
+- `getUser()` MUST validate the token server-side (equivalent to Supabase's `getUser()`, NOT `getSession()`)
+- `getUserRole()` may read from JWT claims if your provider embeds the role, or query your own DB
+
+---
+
+## How to create a custom storage adapter
+
+Implement `StoragePort` from `packages/core/src/services/ports/storage-port.ts`:
+
+```typescript
+// ✅ Correct — S3-based storage adapter
+import type { StoragePort, StorageUploadOptions, StorageUploadResult,
+  StorageSignedUrlResult, StoragePublicUrlResult, StorageFileEntry } from
+  "@enterprise/core/services/ports/storage-port";
+import type { ServiceResult } from "@enterprise/core/services/auth-service";
+
+export class S3StorageAdapter implements StoragePort {
+  constructor(private readonly s3Client: S3Client, private readonly region: string) {}
+
+  async upload(
+    bucket: string,
+    path: string,
+    file: Blob | File | ArrayBuffer,
+    options?: StorageUploadOptions,
+  ): Promise<ServiceResult<StorageUploadResult>> {
+    // Map to PutObjectCommand
+    return { success: true, data: { path, fullPath: `${bucket}/${path}` } };
+  }
+
+  // ... implement remaining methods
+}
+```
+
+The `bucket` and `path` values always follow `STORAGE_BUCKETS` and `STORAGE_PATHS` from
+`packages/core/src/supabase/storage-paths.ts`. These constants are provider-agnostic naming
+conventions — they work with any adapter.
+
+---
+
+## How to wire a custom adapter via environment variables
+
+Update `packages/core/src/services/backend-adapters.ts` to instantiate your adapter when
+the custom provider is selected:
+
+```typescript
+// ✅ Correct — wiring a custom auth adapter in backend-adapters.ts
+import { MyCustomAuthAdapter } from "./adapters/my-custom-auth-adapter";
+
+// Inside createBackendAdapters():
+if (authProvider === "supabase") {
+  authFactory = (client) => new SupabaseAuthAdapter(client);
+} else if (authProvider === "custom") {
+  const apiKey = process.env["CUSTOM_AUTH_API_KEY"];
+  if (!apiKey) throw new Error("[createBackendAdapters] Missing CUSTOM_AUTH_API_KEY");
+  authFactory = (_client) => new MyCustomAuthAdapter(apiKey);
+} else {
+  throw new Error(`[createBackendAdapters] Unknown BACKEND_AUTH_PROVIDER: "${authProvider}"`);
+}
+```
+
+Then set the environment variable:
+
+```bash
+# .env.local
+BACKEND_AUTH_PROVIDER=custom
+CUSTOM_AUTH_API_KEY=<your-api-key>
+```
+
+> **Note**: When `BACKEND_AUTH_PROVIDER=custom` and you do not use Supabase for session
+> management, you must also provide a custom `SessionPort` implementation and wire it in
+> `createBackendAdapters()`. The `SupabaseSessionAdapter` requires
+> `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — if you set both
+> `BACKEND_AUTH_PROVIDER=custom` and `BACKEND_STORAGE_PROVIDER=custom` with no Supabase
+> connection, replace the session adapter too.
+
+---
+
+## Testing with port mocks
+
+Use the pre-built mock helpers from `packages/core/src/services/__tests__/mocks/` in your
+service unit tests. These helpers return fully-typed port implementations where every method
+is a `vi.fn()` stub — no Supabase SDK import needed.
+
+### Auth service test
+
+```typescript
+// ✅ Correct — testing a service that accepts AuthPort
+import { describe, expect, it, vi } from "vitest";
+import { createMockAuthPort } from "../mocks";
+import { signInWithPasswordService } from "../../auth-service";
+
+describe("signInWithPasswordService", () => {
+  it("returns success with role on valid credentials", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.signInWithPassword).mockResolvedValue({
+      success: true,
+      data: { role: "member" },
+    });
+
+    const result = await signInWithPasswordService(auth, {
+      email: "user@example.com",
+      password: "Password123",
+    });
+
+    expect(result).toEqual({ success: true, data: { role: "member" } });
+  });
+
+  it("propagates INVALID_CREDENTIALS from adapter", async () => {
+    const auth = createMockAuthPort();
+    vi.mocked(auth.signInWithPassword).mockResolvedValue({
+      success: false,
+      error: "Invalid credentials",
+      code: "INVALID_CREDENTIALS",
+    });
+
+    const result = await signInWithPasswordService(auth, {
+      email: "user@example.com",
+      password: "wrong",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("INVALID_CREDENTIALS");
+    }
+  });
+});
+```
+
+### Storage service test
+
+```typescript
+// ✅ Correct — testing a service that accepts StoragePort
+import { createMockStoragePort } from "../mocks";
+
+describe("uploadAvatarService", () => {
+  it("returns public URL on successful upload", async () => {
+    const storage = createMockStoragePort();
+    vi.mocked(storage.upload).mockResolvedValue({
+      success: true,
+      data: { path: "avatars/tenant-1/user-1.webp", fullPath: "avatars/tenant-1/user-1.webp" },
+    });
+    vi.mocked(storage.getPublicUrl).mockResolvedValue({
+      success: true,
+      data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/avatars/tenant-1/user-1.webp" },
+    });
+
+    // const result = await uploadAvatarService(storage, client, "tenant-1", "user-1", file);
+    // expect(result.success).toBe(true);
+  });
+});
+```
+
+### Available mock factories
+
+| Factory | Port | Import |
+|---------|------|--------|
+| `createMockAuthPort()` | `AuthPort` | `from "./__tests__/mocks"` |
+| `createMockStoragePort()` | `StoragePort` | `from "./__tests__/mocks"` |
+| `createMockSessionPort()` | `SessionPort` | `from "./__tests__/mocks"` |
+
+Each factory:
+- Returns a fresh instance per call (no shared state between tests)
+- Wires all interface methods as `vi.fn()` stubs with zero calls on creation
+- Is fully typed — TypeScript catches drift between mock and live interface at compile time
+
+---
+
+## Common pitfalls
+
+### Module-level `createBackendAdapters()` calls fail in tests
+
+`createBackendAdapters()` reads `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+at call time. In test environments these env vars are not set, causing the factory to throw.
+
+```typescript
+// ❌ Wrong — factory called at module level without a test mock
+import { createBackendAdapters } from "@enterprise/core/services/backend-adapters";
+const { auth: authFactory } = createBackendAdapters();  // throws in vitest
+```
+
+```typescript
+// ✅ Correct — mock the module in tests that import it
+vi.mock("@enterprise/core/services/backend-adapters", () => ({
+  createBackendAdapters: vi.fn().mockReturnValue({
+    auth: vi.fn().mockReturnValue(createMockAuthPort()),
+    storage: vi.fn().mockReturnValue(createMockStoragePort()),
+    session: createMockSessionPort(),
+  }),
+}));
+```
+
+This is already handled in `ui/features/auth/actions.test.ts` and
+`ui/features/auth/queries.test.ts` — use those files as reference.
+
+### Passing `SupabaseClient` to auth services (new code after decoupling)
+
+After this change merges, new services that touch auth operations MUST accept `AuthPort`,
+not `SupabaseClient`. The QA checklist in `packages/core/AGENTS.md` enforces this.
+
+```typescript
+// ❌ Wrong — new service accepts SupabaseClient for auth operations
+export async function myNewService(client: SupabaseClient, input: MyInput) {
+  const { data: { user } } = await client.auth.getUser();  // direct SDK call
+  // ...
+}
+
+// ✅ Correct — new service accepts AuthPort
+export async function myNewService(auth: AuthPort, input: MyInput) {
+  const userResult = await auth.getUser();                  // via port
+  // ...
+}
+```
+
+### Request-scoped adapter creation in middleware
+
+Do not call `authFactory(client)` outside of a request handler in middleware. The
+`SupabaseClient` created by `createMiddlewareClient()` is scoped to the current request's
+cookies. Capturing it at module level would reuse stale cookies across requests.
+
+```typescript
+// ❌ Wrong — adapter captured at module level
+const supabase = createMiddlewareClient(request, config);
+const auth = authFactory(supabase);  // stale after first request
+
+// ✅ Correct — adapter created fresh per request inside the handler
+export async function middleware(request: NextRequest) {
+  const supabase = createMiddlewareClient(request, middlewareConfig);
+  const auth = authFactory(supabase);
+  // ...
+}
+```
+
+### Split dependency: auth port vs. database client
+
+`middleware.ts` currently uses `SessionPort` for session refresh but retains a direct
+`SupabaseClient` for the role lookup DB query. This is a documented, temporary state until
+`DatabasePort` ships. Do not remove the `createMiddlewareClient()` call — it is needed for
+the DB query.
+
+```typescript
+// ✅ Correct — documented split dependency in middleware
+const { session: sessionPort, auth: authFactory } = createBackendAdapters();
+
+export async function middleware(request: NextRequest) {
+  // Session refresh via SessionPort (provider-agnostic)
+  const response = await sessionPort.refreshSession(request);
+
+  // Role lookup via Supabase middleware client (DB query — until DatabasePort lands)
+  const supabase = createMiddlewareClient(request, middlewareSupabaseConfig);
+  // ...
+}
+```
+
+---
+
+## Reference
+
+- Port interfaces: `packages/core/src/services/ports/`
+- Supabase reference adapters: `packages/core/src/services/adapters/`
+- Factory: `packages/core/src/services/backend-adapters.ts`
+- Mock helpers: `packages/core/src/services/__tests__/mocks/`
+- Full RFC and architecture decisions: [docs/features/backend-provider-decoupling/rfc.md](../features/backend-provider-decoupling/rfc.md)
+- QA checklist and agent rules: [`packages/core/AGENTS.md`](../../packages/core/AGENTS.md)
+
+---
+
+*Last updated: 2026-05-31*

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -35,6 +35,56 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 ---
 
+## Architecture: Port/Adapter Pattern
+
+`@enterprise/core` implements a port/adapter abstraction for auth, storage, and session management. This follows the same pattern as the billing feature (`PaymentProviderPort` + `createPaymentAdapter()`).
+
+### Port interfaces
+
+| Port | Location | Responsibility |
+|------|----------|----------------|
+| `AuthPort` | `src/services/ports/auth-port.ts` | Sign in, sign up, sign out, get user, password reset |
+| `StoragePort` | `src/services/ports/storage-port.ts` | Upload, download, delete, signed URLs, list files |
+| `SessionPort` | `src/services/ports/session-port.ts` | Middleware-level session cookie refresh |
+
+### Adapter factory
+
+`createBackendAdapters()` in `src/services/backend-adapters.ts` selects the active adapter
+based on env vars:
+- `BACKEND_AUTH_PROVIDER` — `"supabase"` (default) | `"custom"`
+- `BACKEND_STORAGE_PROVIDER` — `"supabase"` (default) | `"custom"`
+
+The default Supabase path requires no env var changes. See
+`docs/developer-guide/backend-provider-migration.md` for the full guide.
+
+### Wiring in Server Actions
+
+```typescript
+// ✅ Correct — module-level factory, per-request adapter
+const { auth: authFactory } = createBackendAdapters();
+
+export async function signInAction(input: SignInInput) {
+  const client = await getServerClient();
+  const auth = authFactory(client);     // per-request
+  return signInWithPasswordService(auth, input);
+}
+```
+
+### Mock helpers for tests
+
+Use the pre-built mock factories from `src/services/__tests__/mocks/`:
+
+```typescript
+import { createMockAuthPort, createMockStoragePort } from "./__tests__/mocks";
+
+const auth = createMockAuthPort();
+vi.mocked(auth.signInWithPassword).mockResolvedValue({ success: true, data: { role: "member" } });
+```
+
+Each factory returns a fresh, fully-typed `vi.fn()` stub per call — no Supabase SDK import needed.
+
+---
+
 ## Critical Rules — Non-Negotiable
 
 ### Supabase Clients
@@ -47,8 +97,10 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 ### Service Layer
 
-- ALWAYS: Services receive `SupabaseClient` as first argument (dependency injection)
 - ALWAYS: Services return `ServiceResult<T>` (discriminated union: success/failure)
+- ALWAYS: New auth services accept `AuthPort` as first argument — NOT `SupabaseClient`
+- ALWAYS: New storage services accept `StoragePort` as first argument — NOT `SupabaseClient`
+- ALWAYS: Services that need DB access (non-auth, non-storage) still receive `SupabaseClient`
 - NEVER: `"use server"` in this package — that belongs in `ui/features/*/actions.ts`
 - NEVER: `revalidatePath`, `redirect`, `cookies()` — those are Next.js server-only APIs
 - NEVER: Sentry calls in services — error tracking belongs in Server Actions or boundaries
@@ -200,11 +252,23 @@ packages/core/
     ├── index.ts                    # Barrel export
     ├── services/
     │   ├── index.ts                # Legacy class-based services (TenantService, ProfileService, AuditService)
-    │   ├── auth-service.ts         # Function-based auth (sign in, sign up, password reset)
+    │   ├── auth-service.ts         # Function-based auth — accepts AuthPort (not SupabaseClient)
+    │   ├── backend-adapters.ts     # createBackendAdapters() factory — env-var-driven adapter selection
     │   ├── resource-service.ts     # Function-based CRUD example
+    │   ├── ports/
+    │   │   ├── auth-port.ts        # AuthPort interface — provider-agnostic auth contract
+    │   │   ├── storage-port.ts     # StoragePort interface — provider-agnostic storage contract
+    │   │   ├── session-port.ts     # SessionPort interface — middleware session refresh contract
+    │   │   └── index.ts            # Port barrel exports
+    │   ├── adapters/
+    │   │   ├── supabase-auth-adapter.ts     # SupabaseAuthAdapter — reference AuthPort implementation
+    │   │   ├── supabase-storage-adapter.ts  # SupabaseStorageAdapter — reference StoragePort implementation
+    │   │   ├── supabase-session-adapter.ts  # SupabaseSessionAdapter — reference SessionPort implementation
+    │   │   └── __tests__/          # Adapter tests (only place where SupabaseClient is mocked directly)
     │   └── __tests__/
+    │       ├── mocks/              # Port mock helpers (createMockAuthPort, createMockStoragePort, createMockSessionPort)
     │       ├── auth-service.test.ts
-    │       ├── resource-service.test.ts
+    │       ├── backend-adapters.test.ts
     │       └── platform-services.test.ts
     ├── supabase/
     │   ├── client.ts               # Browser client (createBrowserClient)
@@ -212,7 +276,7 @@ packages/core/
     │   ├── middleware.ts           # Middleware client (session refresh)
     │   ├── admin.ts                # Admin client (service role — server-only)
     │   ├── contracts.ts            # Auth metadata re-exports from @enterprise/contracts
-    │   └── storage-paths.ts        # buildStoragePath() utility
+    │   └── storage-paths.ts        # buildStoragePath() utility + STORAGE_BUCKETS + STORAGE_PATHS
     └── utils/
         └── env.ts                  # getEnv(), getAppUrl() — validated env access
 ```
@@ -244,10 +308,12 @@ pnpm --filter @enterprise/core test:watch   # Watch mode for TDD
 ## QA Checklist (before commit)
 
 - [ ] New service uses function-based pattern (not class-based)
-- [ ] Services receive `SupabaseClient` as first arg
+- [ ] New auth services accept `AuthPort` as first arg (NOT `SupabaseClient`)
+- [ ] New storage services accept `StoragePort` as first arg (NOT `SupabaseClient`)
 - [ ] Services return `ServiceResult<T>`, not `ActionResult<T>`
 - [ ] No `"use server"`, `revalidatePath`, `redirect`, or `cookies()` in this package
 - [ ] No Sentry calls in services (belongs in actions/boundaries)
-- [ ] Unit tests exist with mocked Supabase client
+- [ ] Unit tests use port mock helpers (`createMockAuthPort`, `createMockStoragePort`) — no direct Supabase mock in service tests
+- [ ] Adapter tests (in `adapters/__tests__/`) are the only place where `SupabaseClient` is mocked directly
 - [ ] CUD operations write to audit log
 - [ ] Types imported from `@enterprise/contracts`, not redefined locally

--- a/packages/core/src/services/__tests__/auth-service.test.ts
+++ b/packages/core/src/services/__tests__/auth-service.test.ts
@@ -8,19 +8,7 @@ import {
   signUpService,
   updatePasswordService,
 } from "../auth-service";
-import type { AuthPort } from "../ports/auth-port";
-
-function createMockAuthPort(): AuthPort {
-  return {
-    signInWithPassword: vi.fn(),
-    signUp: vi.fn(),
-    signOut: vi.fn(),
-    getUser: vi.fn(),
-    getUserRole: vi.fn(),
-    requestPasswordReset: vi.fn(),
-    updatePassword: vi.fn(),
-  };
-}
+import { createMockAuthPort } from "./mocks/auth-port.mock";
 
 describe("auth-service", () => {
   describe("signInWithPasswordService", () => {

--- a/packages/core/src/services/__tests__/mocks/auth-port.mock.test.ts
+++ b/packages/core/src/services/__tests__/mocks/auth-port.mock.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockAuthPort } from "./auth-port.mock";
+
+describe("createMockAuthPort", () => {
+  it("returns an object with all AuthPort methods as vi.fn() stubs", () => {
+    const auth = createMockAuthPort();
+
+    expect(typeof auth.signInWithPassword).toBe("function");
+    expect(typeof auth.signUp).toBe("function");
+    expect(typeof auth.signOut).toBe("function");
+    expect(typeof auth.getUser).toBe("function");
+    expect(typeof auth.getUserRole).toBe("function");
+    expect(typeof auth.requestPasswordReset).toBe("function");
+    expect(typeof auth.updatePassword).toBe("function");
+  });
+
+  it("stubs are independently mockable via vi.mocked()", async () => {
+    const auth = createMockAuthPort();
+
+    vi.mocked(auth.signOut).mockResolvedValue({ success: true, data: null });
+
+    const result = await auth.signOut();
+    expect(result).toEqual({ success: true, data: null });
+  });
+
+  it("returns a fresh instance each call (no shared state)", () => {
+    const auth1 = createMockAuthPort();
+    const auth2 = createMockAuthPort();
+
+    expect(auth1.signInWithPassword).not.toBe(auth2.signInWithPassword);
+  });
+
+  it("stubs start with zero call count", () => {
+    const auth = createMockAuthPort();
+
+    expect(vi.mocked(auth.signInWithPassword).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.signUp).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.signOut).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.getUser).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.getUserRole).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.requestPasswordReset).mock.calls).toHaveLength(0);
+    expect(vi.mocked(auth.updatePassword).mock.calls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/services/__tests__/mocks/auth-port.mock.ts
+++ b/packages/core/src/services/__tests__/mocks/auth-port.mock.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+import type { AuthPort } from "../../ports/auth-port";
+
+/**
+ * createMockAuthPort — returns a fully-typed AuthPort where every method is a
+ * `vi.fn()` stub with no default implementation.
+ *
+ * Usage in test files:
+ *
+ * ```typescript
+ * import { createMockAuthPort } from "./__tests__/mocks/auth-port.mock";
+ *
+ * const auth = createMockAuthPort();
+ * vi.mocked(auth.signInWithPassword).mockResolvedValue({ success: true, data: { role: "member" } });
+ * ```
+ *
+ * All methods conform to the AuthPort interface, so TypeScript will catch any
+ * drift between the mock and the live interface at compile time.
+ */
+export function createMockAuthPort(): AuthPort {
+  return {
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getUser: vi.fn(),
+    getUserRole: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    updatePassword: vi.fn(),
+  };
+}

--- a/packages/core/src/services/__tests__/mocks/index.ts
+++ b/packages/core/src/services/__tests__/mocks/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Port mock helpers — shared test utilities for service unit tests.
+ *
+ * Import from this barrel when writing tests for services that depend on
+ * AuthPort, StoragePort, or SessionPort:
+ *
+ * ```typescript
+ * import { createMockAuthPort, createMockStoragePort } from "./__tests__/mocks";
+ * ```
+ *
+ * Each factory returns a fresh object per call (no shared state between tests)
+ * with all interface methods wired as `vi.fn()` stubs ready for
+ * `vi.mocked(port.method).mockResolvedValue(...)`.
+ */
+export { createMockAuthPort } from "./auth-port.mock";
+export { createMockSessionPort } from "./session-port.mock";
+export { createMockStoragePort } from "./storage-port.mock";

--- a/packages/core/src/services/__tests__/mocks/session-port.mock.test.ts
+++ b/packages/core/src/services/__tests__/mocks/session-port.mock.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockSessionPort } from "./session-port.mock";
+
+describe("createMockSessionPort", () => {
+  it("returns an object with all SessionPort methods as vi.fn() stubs", () => {
+    const session = createMockSessionPort();
+
+    expect(typeof session.refreshSession).toBe("function");
+  });
+
+  it("stubs are independently mockable via vi.mocked()", async () => {
+    const session = createMockSessionPort();
+
+    const fakeResponse = { status: 200 } as unknown as import("next/server").NextResponse;
+    vi.mocked(session.refreshSession).mockResolvedValue(fakeResponse);
+
+    const fakeRequest = {} as import("next/server").NextRequest;
+    const result = await session.refreshSession(fakeRequest);
+    expect(result).toBe(fakeResponse);
+  });
+
+  it("returns a fresh instance each call (no shared state)", () => {
+    const session1 = createMockSessionPort();
+    const session2 = createMockSessionPort();
+
+    expect(session1.refreshSession).not.toBe(session2.refreshSession);
+  });
+
+  it("stub starts with zero call count", () => {
+    const session = createMockSessionPort();
+
+    expect(vi.mocked(session.refreshSession).mock.calls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/services/__tests__/mocks/session-port.mock.ts
+++ b/packages/core/src/services/__tests__/mocks/session-port.mock.ts
@@ -1,0 +1,24 @@
+import { vi } from "vitest";
+import type { SessionPort } from "../../ports/session-port";
+
+/**
+ * createMockSessionPort — returns a fully-typed SessionPort where every method
+ * is a `vi.fn()` stub with no default implementation.
+ *
+ * Usage in test files:
+ *
+ * ```typescript
+ * import { createMockSessionPort } from "./__tests__/mocks/session-port.mock";
+ *
+ * const session = createMockSessionPort();
+ * vi.mocked(session.refreshSession).mockResolvedValue(NextResponse.next());
+ * ```
+ *
+ * All methods conform to the SessionPort interface, so TypeScript will catch
+ * any drift between the mock and the live interface at compile time.
+ */
+export function createMockSessionPort(): SessionPort {
+  return {
+    refreshSession: vi.fn<SessionPort["refreshSession"]>(),
+  };
+}

--- a/packages/core/src/services/__tests__/mocks/storage-port.mock.test.ts
+++ b/packages/core/src/services/__tests__/mocks/storage-port.mock.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMockStoragePort } from "./storage-port.mock";
+
+describe("createMockStoragePort", () => {
+  it("returns an object with all StoragePort methods as vi.fn() stubs", () => {
+    const storage = createMockStoragePort();
+
+    expect(typeof storage.upload).toBe("function");
+    expect(typeof storage.download).toBe("function");
+    expect(typeof storage.delete).toBe("function");
+    expect(typeof storage.getSignedUrl).toBe("function");
+    expect(typeof storage.getPublicUrl).toBe("function");
+    expect(typeof storage.listFiles).toBe("function");
+  });
+
+  it("stubs are independently mockable via vi.mocked()", async () => {
+    const storage = createMockStoragePort();
+
+    vi.mocked(storage.upload).mockResolvedValue({
+      success: true,
+      data: { path: "avatars/file.webp", fullPath: "avatars/tenant-1/file.webp" },
+    });
+
+    const result = await storage.upload("avatars", "tenant-1/file.webp", new Blob(["data"]));
+    expect(result).toEqual({
+      success: true,
+      data: { path: "avatars/file.webp", fullPath: "avatars/tenant-1/file.webp" },
+    });
+  });
+
+  it("returns a fresh instance each call (no shared state)", () => {
+    const storage1 = createMockStoragePort();
+    const storage2 = createMockStoragePort();
+
+    expect(storage1.upload).not.toBe(storage2.upload);
+  });
+
+  it("stubs start with zero call count", () => {
+    const storage = createMockStoragePort();
+
+    expect(vi.mocked(storage.upload).mock.calls).toHaveLength(0);
+    expect(vi.mocked(storage.download).mock.calls).toHaveLength(0);
+    expect(vi.mocked(storage.delete).mock.calls).toHaveLength(0);
+    expect(vi.mocked(storage.getSignedUrl).mock.calls).toHaveLength(0);
+    expect(vi.mocked(storage.getPublicUrl).mock.calls).toHaveLength(0);
+    expect(vi.mocked(storage.listFiles).mock.calls).toHaveLength(0);
+  });
+});

--- a/packages/core/src/services/__tests__/mocks/storage-port.mock.ts
+++ b/packages/core/src/services/__tests__/mocks/storage-port.mock.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+import type { StoragePort } from "../../ports/storage-port";
+
+/**
+ * createMockStoragePort — returns a fully-typed StoragePort where every method
+ * is a `vi.fn()` stub with no default implementation.
+ *
+ * Usage in test files:
+ *
+ * ```typescript
+ * import { createMockStoragePort } from "./__tests__/mocks/storage-port.mock";
+ *
+ * const storage = createMockStoragePort();
+ * vi.mocked(storage.upload).mockResolvedValue({
+ *   success: true,
+ *   data: { path: "avatars/file.webp", fullPath: "avatars/tenant-1/file.webp" },
+ * });
+ * ```
+ *
+ * All methods conform to the StoragePort interface, so TypeScript will catch
+ * any drift between the mock and the live interface at compile time.
+ */
+export function createMockStoragePort(): StoragePort {
+  return {
+    upload: vi.fn(),
+    download: vi.fn(),
+    delete: vi.fn(),
+    getSignedUrl: vi.fn(),
+    getPublicUrl: vi.fn(),
+    listFiles: vi.fn(),
+  };
+}


### PR DESCRIPTION
## Summary

- Completes the Backend Provider Decoupling (#16): shared port mock helpers, .env docs, migration guide for adopters, and AGENTS.md updates
- Supersedes #118 (retarget didn't trigger CI); rebased clean onto main after #122 merged

## Changes

| File | Change |
|------|--------|
| `packages/core/src/services/__tests__/mocks/*` | Reusable createMockAuthPort/Storage/Session helpers + tests |
| `docs/developer-guide/backend-provider-migration.md` | 7-section migration guide |
| `packages/core/AGENTS.md` | Port/adapter architecture + QA checklist |
| `.env.example` | Backend Provider Configuration section |

## Verification

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `@enterprise/core`: 187 tests passed
- [ ] Playwright E2E: known-flaky notifications test unrelated to this change