### PR TITLE
feat(brand): migrate brand source + tests to @enterprise/brand [PR 2/3]

### DIFF
--- a/packages/brand/src/brand/__tests__/brand-footer.test.ts
+++ b/packages/brand/src/brand/__tests__/brand-footer.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+/**
+ * BrandFooter component tests — RED phase
+ *
+ * Tests cover:
+ * - Renders copyright line with displayName and current year
+ * - Legal links rendered when privacyUrl and termsUrl are non-empty
+ * - Legal links omitted when privacyUrl/termsUrl are empty string
+ * - Social links rendered when brand.social is present
+ * - "Powered by" text rendered when features.showPoweredBy is true
+ * - "Powered by" text omitted when features.showPoweredBy is false
+ * - className prop applied to root <footer>
+ */
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================================
+// Mock dependencies
+// ============================================================================
+
+vi.mock("../provider", () => ({
+  useBrand: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+const baseLogo = {
+  light: { src: "/logo-light.svg", alt: "Logo", width: 160, height: 32 },
+  dark: { src: "/logo-dark.svg", alt: "Logo", width: 160, height: 32 },
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: {
+      titleTemplate: "%s | Enterprise Platform",
+      defaultTitle: "Enterprise Platform",
+      description: "Enterprise Platform template.",
+      ogImage: "/images/enterprise/og-image.png",
+    },
+    legal: {
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    },
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): {
+  container: HTMLDivElement;
+  root: ReactDOM.Root;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandFooter", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("renders copyright line with displayName", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const footer = container.querySelector("footer");
+    expect(footer?.textContent).toContain("Enterprise Platform");
+  });
+
+  it("renders the current year in the copyright line", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const currentYear = new Date().getFullYear().toString();
+    const footer = container.querySelector("footer");
+    expect(footer?.textContent).toContain(currentYear);
+  });
+
+  it("renders privacy and terms links when URLs are non-empty", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: {
+          privacyUrl: "https://example.com/privacy",
+          termsUrl: "https://example.com/terms",
+        },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = container.querySelectorAll("a");
+    const hrefs = Array.from(links).map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://example.com/privacy");
+    expect(hrefs).toContain("https://example.com/terms");
+  });
+
+  it("omits privacy link when privacyUrl is empty string", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: { privacyUrl: "", termsUrl: "https://example.com/terms" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).not.toContain("");
+    // terms link still present
+    expect(hrefs).toContain("https://example.com/terms");
+  });
+
+  it("omits terms link when termsUrl is empty string", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        legal: { privacyUrl: "https://example.com/privacy", termsUrl: "" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://example.com/privacy");
+    // terms link should NOT be present
+    expect(hrefs.every((h) => h !== "")).toBe(true);
+    expect(links).toHaveLength(1); // only privacy
+  });
+
+  it("renders GitHub social link when brand.social.github is present", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(
+      makeBrand({
+        social: { github: "https://github.com/your-org" },
+      }),
+    );
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const links = Array.from(container.querySelectorAll("a"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    expect(hrefs).toContain("https://github.com/your-org");
+  });
+
+  it("renders 'Powered by' when features.showPoweredBy is true", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand({ features: { showPoweredBy: true } }));
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.textContent).toContain("Powered by");
+  });
+
+  it("omits 'Powered by' when features.showPoweredBy is false", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand({ features: { showPoweredBy: false } }));
+
+    const { container, root } = renderTree(createElement(BrandFooter, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.textContent).not.toContain("Powered by");
+  });
+
+  it("applies className prop to root <footer>", async () => {
+    const { useBrand } = await import("../provider");
+    const { BrandFooter } = await import("../brand-footer");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+
+    const { container, root } = renderTree(
+      createElement(BrandFooter, { className: "py-8 border-t" }),
+    );
+    cleanup.push(() => act(() => root.unmount()));
+
+    const footer = container.querySelector("footer");
+    expect(footer?.className).toContain("py-8");
+    expect(footer?.className).toContain("border-t");
+  });
+});

--- a/packages/brand/src/brand/__tests__/brand-logo.test.ts
+++ b/packages/brand/src/brand/__tests__/brand-logo.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment happy-dom
+/**
+ * BrandLogo component tests — RED phase
+ *
+ * Tests cover:
+ * - Renders light variant <img> in light mode
+ * - Renders dark variant <img> in dark mode
+ * - alt attribute matches active variant
+ * - Empty src renders displayName text fallback (no <img>)
+ * - width and height passed to <img> when provided
+ * - className prop applied to root element
+ */
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================================
+// Mock dependencies
+// NOTE: mock paths updated from relative "../../theme/provider" to the package
+// path used by the source file after its import rewrite.
+// ============================================================================
+
+// Mock useBrand() to inject test brand configs
+vi.mock("../provider", () => ({
+  useBrand: vi.fn(),
+}));
+
+// Mock useTheme() to inject test mode
+vi.mock("@enterprise/ui/theme/provider", () => ({
+  useTheme: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+const baseLightVariant = {
+  src: "/images/enterprise/logo-light.svg",
+  alt: "Enterprise Platform Light",
+  width: 160,
+  height: 32,
+};
+
+const baseDarkVariant = {
+  src: "/images/enterprise/logo-dark.svg",
+  alt: "Enterprise Platform Dark",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLightVariant,
+  dark: baseDarkVariant,
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: {
+      titleTemplate: "%s | Enterprise Platform",
+      defaultTitle: "Enterprise Platform",
+      description: "Enterprise Platform template.",
+      ogImage: "/images/enterprise/og-image.png",
+    },
+    legal: {
+      privacyUrl: "https://example.com/privacy",
+      termsUrl: "https://example.com/terms",
+    },
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Render helper
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): {
+  container: HTMLDivElement;
+  root: ReactDOM.Root;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandLogo", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(async () => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("renders <img> with light variant src in light mode", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/images/enterprise/logo-light.svg");
+  });
+
+  it("renders <img> with dark variant src in dark mode", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "dark",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/images/enterprise/logo-dark.svg");
+  });
+
+  it("alt attribute matches the active variant", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("alt")).toBe("Enterprise Platform Light");
+  });
+
+  it("renders displayName text fallback when light src is empty", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    const brand = makeBrand({
+      logo: {
+        light: { src: "", alt: "Enterprise Platform", width: 160, height: 32 },
+        dark: baseDarkVariant,
+      },
+    });
+    vi.mocked(useBrand).mockReturnValue(brand);
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(container.querySelector("img")).toBeNull();
+    const span = container.querySelector("span");
+    expect(span?.textContent).toBe("Enterprise Platform");
+  });
+
+  it("passes width and height to <img> when provided", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "dark",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, {}));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("width")).toBe("160");
+    expect(img?.getAttribute("height")).toBe("32");
+  });
+
+  it("applies className prop to the root <img>", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    vi.mocked(useBrand).mockReturnValue(makeBrand());
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, { className: "h-8 w-auto" }));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const img = container.querySelector("img");
+    expect(img?.className).toContain("h-8");
+    expect(img?.className).toContain("w-auto");
+  });
+
+  it("applies className prop to the text fallback <span>", async () => {
+    const { useBrand } = await import("../provider");
+    const { useTheme } = await import("@enterprise/ui/theme/provider");
+    const { BrandLogo } = await import("../brand-logo");
+
+    const brand = makeBrand({
+      logo: {
+        light: { src: "", alt: "Enterprise Platform" },
+        dark: baseDarkVariant,
+      },
+    });
+    vi.mocked(useBrand).mockReturnValue(brand);
+    vi.mocked(useTheme).mockReturnValue({
+      mode: "light",
+      setMode: vi.fn(),
+      toggleMode: vi.fn(),
+    });
+
+    const { container, root } = renderTree(createElement(BrandLogo, { className: "text-primary" }));
+    cleanup.push(() => act(() => root.unmount()));
+
+    const span = container.querySelector("span");
+    expect(span?.className).toContain("text-primary");
+  });
+});

--- a/packages/brand/src/brand/__tests__/metadata.test.ts
+++ b/packages/brand/src/brand/__tests__/metadata.test.ts
@@ -1,0 +1,99 @@
+import type { BrandConfig } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
+import { generateBrandMetadata } from "../metadata";
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const validMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: validMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("generateBrandMetadata", () => {
+  it("maps all fields correctly from a full BrandConfig", () => {
+    const brand = makeBrand();
+    const result = generateBrandMetadata(brand);
+
+    expect(result.title).toEqual({
+      template: "%s | Enterprise Platform",
+      default: "Enterprise Platform",
+    });
+    expect(result.description).toBe("The enterprise-grade SaaS platform template.");
+    expect(result.icons).toEqual({ icon: "/images/enterprise/favicon.svg" });
+    expect(result.openGraph).toMatchObject({
+      title: "Enterprise Platform",
+      description: "The enterprise-grade SaaS platform template.",
+      images: ["/images/enterprise/og-image.png"],
+    });
+  });
+
+  it("sets openGraph.images = [] when ogImage is empty string", () => {
+    const brand = makeBrand({
+      metadata: { ...validMetadata, ogImage: "" },
+    });
+    const result = generateBrandMetadata(brand);
+    expect(result.openGraph?.images).toEqual([]);
+  });
+
+  it("uses titleTemplate and defaultTitle for title object", () => {
+    const brand = makeBrand({
+      metadata: {
+        ...validMetadata,
+        titleTemplate: "%s | Acme",
+        defaultTitle: "Acme Platform",
+      },
+    });
+    const result = generateBrandMetadata(brand);
+    expect(result.title).toEqual({
+      template: "%s | Acme",
+      default: "Acme Platform",
+    });
+  });
+
+  it("uses brand favicon for icons.icon", () => {
+    const brand = makeBrand({ favicon: "/acme/favicon.ico" });
+    const result = generateBrandMetadata(brand);
+    expect(result.icons).toEqual({ icon: "/acme/favicon.ico" });
+  });
+});

--- a/packages/brand/src/brand/__tests__/provider.test.ts
+++ b/packages/brand/src/brand/__tests__/provider.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+/**
+ * BrandProvider + useBrand() tests
+ *
+ * Tests cover:
+ * - useBrand() returns the brand config inside BrandProvider
+ * - useBrand() throws with guidance when called outside BrandProvider
+ * - ThemeProvider receives the correct defaultMode derived from themeRef
+ */
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { act, createElement } from "react";
+import * as ReactDOM from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================================
+// Mock ThemeProvider to capture the defaultMode prop passed to it
+// NOTE: mock path updated from relative "../../theme/provider" to the package
+// path used by the source file after its import rewrite.
+// ============================================================================
+
+let capturedDefaultMode: string | undefined;
+
+vi.mock("@enterprise/ui/theme/provider", () => ({
+  ThemeProvider: ({
+    children,
+    defaultMode,
+  }: {
+    children: React.ReactNode;
+    defaultMode?: string;
+  }) => {
+    capturedDefaultMode = defaultMode;
+    return children;
+  },
+}));
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "Enterprise Platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function renderTree(tree: React.ReactElement): { container: HTMLDivElement; root: ReactDOM.Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = ReactDOM.createRoot(container);
+  act(() => {
+    root.render(tree);
+  });
+  return { container, root };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("BrandProvider + useBrand", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanup) fn();
+    cleanup.length = 0;
+    capturedDefaultMode = undefined;
+  });
+
+  it("useBrand() returns the brand config inside BrandProvider", async () => {
+    const { BrandProvider, useBrand } = await import("../provider");
+    const brand = makeBrand();
+    let captured: BrandConfig | null = null;
+
+    function Consumer() {
+      captured = useBrand();
+      return null;
+    }
+
+    const tree = createElement(BrandProvider, { brand }, createElement(Consumer));
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as BrandConfig).slug).toBe("enterprise");
+  });
+
+  it("useBrand() throws outside BrandProvider with guidance", async () => {
+    const { useBrand } = await import("../provider");
+
+    // Simulate what useBrand does: reads null context and throws
+    const ctx: BrandConfig | null = null;
+    expect(() => {
+      if (ctx === null) {
+        throw new Error(
+          "useBrand() must be called inside a <BrandProvider>. " +
+            "Ensure the root layout wraps its children with <BrandProvider brand={...}>.",
+        );
+      }
+    }).toThrow(/BrandProvider/);
+
+    // Also test the actual hook behavior by rendering outside a provider
+    const { BrandContext } = await import("../context");
+    let threwError = false;
+    function OutsideConsumer() {
+      try {
+        // biome-ignore lint/correctness/useHookAtTopLevel: deliberately calling the hook outside a provider to assert it throws
+        useBrand();
+      } catch {
+        threwError = true;
+      }
+      return null;
+    }
+
+    const contextValue = null;
+    const tree = createElement(
+      BrandContext,
+      { value: contextValue },
+      createElement(OutsideConsumer),
+    );
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+    expect(threwError).toBe(true);
+  });
+
+  it("ThemeProvider receives 'light' defaultMode when themeRef ends in 'light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "light" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("light");
+  });
+
+  it("ThemeProvider receives 'dark' defaultMode when themeRef does not end in 'light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "dark" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("dark");
+  });
+
+  it("ThemeProvider receives 'dark' for custom themeRef like 'acme-dark'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "acme-dark" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("dark");
+  });
+
+  it("ThemeProvider receives 'light' for custom themeRef like 'acme-light'", async () => {
+    const { BrandProvider } = await import("../provider");
+    const brand = makeBrand({ themeRef: "acme-light" });
+
+    const tree = createElement(BrandProvider, { brand }, null);
+    const { root } = renderTree(tree);
+    cleanup.push(() => act(() => root.unmount()));
+
+    expect(capturedDefaultMode).toBe("light");
+  });
+});

--- a/packages/brand/src/brand/__tests__/registry.test.ts
+++ b/packages/brand/src/brand/__tests__/registry.test.ts
@@ -1,0 +1,137 @@
+import type { BrandConfig } from "@enterprise/contracts";
+import { describe, expect, it } from "vitest";
+
+// ============================================================================
+// Fixture brand configs
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests for buildRegistry() and related helpers
+// ============================================================================
+
+describe("buildRegistry", () => {
+  it("builds a registry with a single valid brand", async () => {
+    const { buildRegistry } = await import("../registry");
+    const brand = makeBrand();
+    const registry = buildRegistry([brand]);
+    expect(registry.size).toBe(1);
+    expect(registry.get("enterprise")).toEqual(brand);
+  });
+
+  it("builds a registry with multiple valid brands", async () => {
+    const { buildRegistry } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const enterprise = makeBrand();
+    const registry = buildRegistry([enterprise, acme]);
+    expect(registry.size).toBe(2);
+    expect(registry.has("acme")).toBe(true);
+  });
+
+  it("throws on duplicate slug", async () => {
+    const { buildRegistry } = await import("../registry");
+    const brand1 = makeBrand();
+    const brand2 = makeBrand({ name: "enterprise-copy" });
+    expect(() => buildRegistry([brand1, brand2])).toThrow(/duplicate/i);
+  });
+});
+
+describe("getDefaultBrand", () => {
+  it("returns the brand with isDefault=true", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const enterprise = makeBrand({ isDefault: true });
+    const registry = new Map<string, BrandConfig>([
+      ["acme", acme],
+      ["enterprise", enterprise],
+    ]);
+    expect(getDefaultBrand(registry).slug).toBe("enterprise");
+  });
+
+  it("falls back to 'enterprise' slug when no isDefault is declared", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const enterprise = makeBrand({ isDefault: undefined });
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+    expect(getDefaultBrand(registry).slug).toBe("enterprise");
+  });
+
+  it("throws when no brands are registered", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const empty = new Map<string, BrandConfig>();
+    expect(() => getDefaultBrand(empty)).toThrow();
+  });
+
+  it("throws when no isDefault and no 'enterprise' slug", async () => {
+    const { getDefaultBrand } = await import("../registry");
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: undefined });
+    const registry = new Map<string, BrandConfig>([["acme", acme]]);
+    expect(() => getDefaultBrand(registry)).toThrow(/enterprise/i);
+  });
+});
+
+describe("getBrandBySlug", () => {
+  it("returns brand for matching slug", async () => {
+    const { getBrandBySlug } = await import("../registry");
+    const brand = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", brand]]);
+    expect(getBrandBySlug(registry, "enterprise")).toEqual(brand);
+  });
+
+  it("returns undefined for unknown slug", async () => {
+    const { getBrandBySlug } = await import("../registry");
+    const registry = new Map<string, BrandConfig>();
+    expect(getBrandBySlug(registry, "unknown")).toBeUndefined();
+  });
+});
+
+describe("getAllBrands", () => {
+  it("returns all registered brands as array", async () => {
+    const { getAllBrands } = await import("../registry");
+    const brand = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", brand],
+      ["acme", acme],
+    ]);
+    expect(getAllBrands(registry)).toHaveLength(2);
+  });
+});

--- a/packages/brand/src/brand/__tests__/resolve.test.ts
+++ b/packages/brand/src/brand/__tests__/resolve.test.ts
@@ -1,0 +1,213 @@
+import type { BrandConfig } from "@enterprise/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ============================================================================
+// Mock next/headers before importing resolve
+// ============================================================================
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+// ============================================================================
+// Fixture factories
+// ============================================================================
+
+const baseLogoVariant = {
+  src: "/images/enterprise/logo.svg",
+  alt: "Enterprise Platform",
+  width: 160,
+  height: 32,
+};
+
+const baseLogo = {
+  light: baseLogoVariant,
+  dark: { ...baseLogoVariant, src: "/images/enterprise/logo-dark.svg" },
+};
+
+const baseMetadata = {
+  titleTemplate: "%s | Enterprise Platform",
+  defaultTitle: "Enterprise Platform",
+  description: "Enterprise Platform template.",
+  ogImage: "/images/enterprise/og-image.png",
+};
+
+const baseLegal = {
+  privacyUrl: "https://example.com/privacy",
+  termsUrl: "https://example.com/terms",
+};
+
+function makeBrand(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return {
+    slug: "enterprise",
+    name: "enterprise",
+    displayName: "Enterprise Platform",
+    description: "Enterprise Platform template.",
+    logo: baseLogo,
+    favicon: "/images/enterprise/favicon.svg",
+    metadata: baseMetadata,
+    legal: baseLegal,
+    themeRef: "light",
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests for resolveBrand()
+// ============================================================================
+
+describe("resolveBrand", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("BRAND_SLUG env var forces the matching brand", async () => {
+    process.env["BRAND_SLUG"] = "enterprise";
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/" });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("BRAND_SLUG env var overrides subdomain context", async () => {
+    process.env["BRAND_SLUG"] = "enterprise";
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    // even though host has acme subdomain, env var wins
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "acme.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("unknown BRAND_SLUG throws with available slugs listed", async () => {
+    process.env["BRAND_SLUG"] = "unknown-brand";
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    await expect(
+      resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/" }),
+    ).rejects.toThrow(/enterprise/);
+  });
+
+  it("subdomain resolves to matching brand", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "acme.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("acme");
+  });
+
+  it("unrecognized subdomain warns and falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "unknown.platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("host with only 2 segments (no qualifying subdomain) falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "platform.com",
+      pathname: "/",
+    });
+    expect(result.slug).toBe("enterprise");
+  });
+
+  it("path prefix resolves to matching brand", async () => {
+    delete process.env["BRAND_SLUG"];
+
+    const enterprise = makeBrand();
+    const acme = makeBrand({ slug: "acme", name: "acme", isDefault: false });
+    const registry = new Map<string, BrandConfig>([
+      ["enterprise", enterprise],
+      ["acme", acme],
+    ]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "localhost",
+      pathname: "/acme/dashboard",
+    });
+    expect(result.slug).toBe("acme");
+  });
+
+  it("static asset path /favicon.ico does not emit brand warning", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    await resolveBrandFromRegistry(registry, { host: "localhost", pathname: "/favicon.ico" });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("unknown path prefix emits warn and falls back to default", async () => {
+    delete process.env["BRAND_SLUG"];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const enterprise = makeBrand();
+    const registry = new Map<string, BrandConfig>([["enterprise", enterprise]]);
+
+    const { resolveBrandFromRegistry } = await import("../resolve");
+    const result = await resolveBrandFromRegistry(registry, {
+      host: "localhost",
+      pathname: "/unknown-brand/page",
+    });
+    expect(result.slug).toBe("enterprise");
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown-brand"));
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/brand/src/brand/brand-footer.tsx
+++ b/packages/brand/src/brand/brand-footer.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { cn } from "@enterprise/ui/lib/utils";
+import { useBrand } from "./provider";
+
+// ============================================================================
+// BrandFooter
+// ============================================================================
+
+export interface BrandFooterProps {
+  /**
+   * Optional Tailwind class(es) to apply to the root <footer> element.
+   */
+  className?: string;
+}
+
+/**
+ * BrandFooter — renders the brand's copyright, legal links, social links,
+ * and optional "Powered by" attribution.
+ *
+ * - Copyright: © {year} {brand.displayName}
+ * - Legal links: only rendered when privacyUrl/termsUrl are non-empty strings
+ * - Social links: only rendered when brand.social is present
+ * - "Powered by": only rendered when brand.features?.showPoweredBy === true
+ *
+ * Must be rendered inside a BrandProvider.
+ */
+export function BrandFooter({ className }: BrandFooterProps) {
+  const brand = useBrand();
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={cn(className)}>
+      <p>
+        © {currentYear} {brand.displayName}
+      </p>
+
+      <nav aria-label="Legal links">
+        {brand.legal.privacyUrl && (
+          <a href={brand.legal.privacyUrl} rel="noopener noreferrer">
+            Privacy Policy
+          </a>
+        )}
+        {brand.legal.termsUrl && (
+          <a href={brand.legal.termsUrl} rel="noopener noreferrer">
+            Terms of Service
+          </a>
+        )}
+      </nav>
+
+      {brand.social && (
+        <nav aria-label="Social links">
+          {brand.social.twitter && (
+            <a href={brand.social.twitter} rel="noopener noreferrer" aria-label="Twitter">
+              Twitter
+            </a>
+          )}
+          {brand.social.linkedin && (
+            <a href={brand.social.linkedin} rel="noopener noreferrer" aria-label="LinkedIn">
+              LinkedIn
+            </a>
+          )}
+          {brand.social.github && (
+            <a href={brand.social.github} rel="noopener noreferrer" aria-label="GitHub">
+              GitHub
+            </a>
+          )}
+        </nav>
+      )}
+
+      {brand.features?.["showPoweredBy"] === true && (
+        <p>
+          <small>Powered by Enterprise Platform</small>
+        </p>
+      )}
+    </footer>
+  );
+}

--- a/packages/brand/src/brand/brand-logo.tsx
+++ b/packages/brand/src/brand/brand-logo.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "@enterprise/ui/lib/utils";
+import { useTheme } from "@enterprise/ui/theme/provider";
+import { useBrand } from "./provider";
+
+// ============================================================================
+// BrandLogo
+// ============================================================================
+
+export interface BrandLogoProps {
+  /**
+   * Optional Tailwind class(es) to apply to the root element.
+   * Applied to both the <img> and the text fallback <span>.
+   */
+  className?: string;
+}
+
+/**
+ * BrandLogo — renders the correct logo variant for the active theme mode.
+ *
+ * - In "light" mode: renders brand.logo.light
+ * - In "dark" mode: renders brand.logo.dark
+ * - When the active variant's src is empty: renders a <span> with displayName as text fallback
+ *
+ * Must be rendered inside a BrandProvider (inherits from useBrand()) and a
+ * ThemeProvider (inherits from useTheme()).
+ */
+export function BrandLogo({ className }: BrandLogoProps) {
+  const brand = useBrand();
+  const { mode } = useTheme();
+
+  const logoVariant = mode === "light" ? brand.logo.light : brand.logo.dark;
+
+  // Text fallback when src is empty or undefined
+  if (!logoVariant.src) {
+    return (
+      // role="img" allows aria-label on the text fallback container
+      <span role="img" className={cn(className)} aria-label={logoVariant.alt}>
+        {brand.displayName}
+      </span>
+    );
+  }
+
+  return (
+    // biome-ignore lint/performance/noImgElement: packages/brand cannot use next/image (no Next.js dep in source)
+    <img
+      src={logoVariant.src}
+      alt={logoVariant.alt}
+      width={logoVariant.width}
+      height={logoVariant.height}
+      className={cn(className)}
+    />
+  );
+}

--- a/packages/brand/src/brand/context.ts
+++ b/packages/brand/src/brand/context.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { createContext } from "react";
+
+export interface BrandContextValue {
+  brand: BrandConfig;
+}
+
+export const BrandContext = createContext<BrandContextValue | null>(null);

--- a/packages/brand/src/brand/index.ts
+++ b/packages/brand/src/brand/index.ts
@@ -1,0 +1,12 @@
+// Brand module barrel — re-exports for consumers that prefer the index import.
+// For server-only utilities (resolveBrand), import from the specific subpath.
+
+export type { BrandFooterProps } from "./brand-footer";
+export { BrandFooter } from "./brand-footer";
+export type { BrandLogoProps } from "./brand-logo";
+export { BrandLogo } from "./brand-logo";
+export type { BrandContextValue } from "./context";
+export { BrandContext } from "./context";
+export { generateBrandMetadata } from "./metadata";
+export type { BrandProviderProps } from "./provider";
+export { BrandProvider, useBrand } from "./provider";

--- a/packages/brand/src/brand/metadata.ts
+++ b/packages/brand/src/brand/metadata.ts
@@ -1,0 +1,30 @@
+import type { BrandConfig } from "@enterprise/contracts";
+import type { Metadata } from "next";
+
+/**
+ * Generates a Next.js Metadata object from a resolved BrandConfig.
+ * Call this from generateMetadata() in ui/app/layout.tsx.
+ *
+ * @example
+ * export async function generateMetadata() {
+ *   const brand = await resolveBrand();
+ *   return generateBrandMetadata(brand);
+ * }
+ */
+export function generateBrandMetadata(brand: BrandConfig): Metadata {
+  return {
+    title: {
+      template: brand.metadata.titleTemplate,
+      default: brand.metadata.defaultTitle,
+    },
+    description: brand.metadata.description,
+    icons: {
+      icon: brand.favicon,
+    },
+    openGraph: {
+      title: brand.metadata.defaultTitle,
+      description: brand.metadata.description,
+      images: brand.metadata.ogImage ? [brand.metadata.ogImage] : [],
+    },
+  };
+}

--- a/packages/brand/src/brand/provider.tsx
+++ b/packages/brand/src/brand/provider.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { ThemeProvider } from "@enterprise/ui/theme/provider";
+import { useContext } from "react";
+import { BrandContext } from "./context";
+
+// ============================================================================
+// BrandProvider
+// ============================================================================
+
+export interface BrandProviderProps {
+  children?: React.ReactNode;
+  /**
+   * The resolved BrandConfig — provided by the server boundary (root layout).
+   * BrandProvider does NOT resolve the brand; resolution happens in resolveBrand().
+   */
+  brand: BrandConfig;
+  /**
+   * Initial theme mode before localStorage hydration.
+   * Derived from the brand's themeRef: "light" or "dark" suffix.
+   * Falls back to "dark" if themeRef does not end in "light".
+   */
+  defaultMode?: "light" | "dark";
+}
+
+export function BrandProvider({ children, brand, defaultMode }: BrandProviderProps) {
+  // Derive initial theme mode from themeRef if not explicitly provided
+  const resolvedDefaultMode: "light" | "dark" =
+    defaultMode ?? (brand.themeRef.endsWith("light") ? "light" : "dark");
+
+  return (
+    <BrandContext value={{ brand }}>
+      <ThemeProvider defaultMode={resolvedDefaultMode}>{children}</ThemeProvider>
+    </BrandContext>
+  );
+}
+
+// ============================================================================
+// useBrand hook
+// ============================================================================
+
+/**
+ * Returns the resolved BrandConfig from context.
+ * Must be called inside a BrandProvider — throws with actionable guidance otherwise.
+ */
+export function useBrand(): BrandConfig {
+  const ctx = useContext(BrandContext);
+  if (ctx === null) {
+    throw new Error(
+      "useBrand() must be called inside a <BrandProvider>. " +
+        "Ensure the root layout wraps its children with <BrandProvider brand={...}>.",
+    );
+  }
+  return ctx.brand;
+}

--- a/packages/brand/src/brand/registry.ts
+++ b/packages/brand/src/brand/registry.ts
@@ -1,0 +1,113 @@
+// Brand registry — validates and stores all registered brand configs.
+// This module is imported at server startup; any validation errors throw immediately,
+// preventing the server from starting with invalid brand configuration.
+
+import type { BrandConfig } from "@enterprise/contracts";
+
+// ============================================================================
+// Registry builder — pure function used by both module init and tests
+// ============================================================================
+
+/**
+ * Builds an immutable Map<slug, BrandConfig> from an array of raw brand objects.
+ * Throws on duplicate slugs.
+ */
+export function buildRegistry(brands: BrandConfig[]): Map<string, BrandConfig> {
+  const registry = new Map<string, BrandConfig>();
+
+  for (const brand of brands) {
+    if (registry.has(brand.slug)) {
+      throw new Error(
+        `[brand] Duplicate brand slug "${brand.slug}" detected. ` +
+          `Each brand must have a unique slug.`,
+      );
+    }
+    registry.set(brand.slug, brand);
+  }
+
+  return registry;
+}
+
+// ============================================================================
+// Registry helpers — operate on a Map parameter (testable, pure)
+// ============================================================================
+
+/**
+ * Returns the brand with isDefault=true.
+ * Falls back to the "enterprise" slug if no isDefault is declared.
+ * Throws if neither is available.
+ */
+export function getDefaultBrand(registry: Map<string, BrandConfig>): BrandConfig {
+  for (const brand of registry.values()) {
+    if (brand.isDefault) return brand;
+  }
+
+  // Fallback: return the "enterprise" brand if no isDefault is declared
+  const enterprise = registry.get("enterprise");
+  if (!enterprise) {
+    throw new Error(
+      '[brand] No default brand found and no "enterprise" brand registered. ' +
+        "Ensure at least one brand config exists in packages/brand/src/brands/.",
+    );
+  }
+  return enterprise;
+}
+
+/**
+ * Returns the brand for the given slug, or undefined if not found.
+ */
+export function getBrandBySlug(
+  registry: Map<string, BrandConfig>,
+  slug: string,
+): BrandConfig | undefined {
+  return registry.get(slug);
+}
+
+/**
+ * Returns all registered brands as an array.
+ */
+export function getAllBrands(registry: Map<string, BrandConfig>): BrandConfig[] {
+  return Array.from(registry.values());
+}
+
+// ============================================================================
+// Module-level registry — populated at startup from brands/index.ts
+// ============================================================================
+
+// Lazy-import to avoid circular deps and allow testing registry helpers in isolation.
+// The actual populated registry is exported below for server-side use.
+let _registry: Map<string, BrandConfig> | null = null;
+
+/**
+ * Returns the singleton brand registry, initializing it on first access.
+ * The registry is populated from all brand configs exported by brands/index.ts.
+ */
+export function getBrandRegistry(): Map<string, BrandConfig> {
+  if (_registry !== null) return _registry;
+
+  // Dynamic require to allow test isolation without triggering the real import chain.
+  // In production builds, Next.js statically resolves this.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const brandsModule = require("../brands/index") as Record<string, unknown>;
+  const configs: BrandConfig[] = [];
+
+  for (const [, mod] of Object.entries(brandsModule)) {
+    const raw = (mod as { default?: unknown }).default ?? mod;
+    configs.push(raw as BrandConfig);
+  }
+
+  _registry = buildRegistry(configs);
+  return _registry;
+}
+
+// Named re-export of the singleton for server-side access (used by resolve.ts)
+export const brandRegistry: Map<string, BrandConfig> = new Map();
+
+/**
+ * Re-initialize the singleton — intended for testing only.
+ * Do NOT call this in production code.
+ */
+export function _resetRegistryForTesting(): void {
+  _registry = null;
+  brandRegistry.clear();
+}

--- a/packages/brand/src/brand/resolve.ts
+++ b/packages/brand/src/brand/resolve.ts
@@ -1,0 +1,95 @@
+// Brand resolution — server-only utility.
+// Determines which brand to render based on: env var → subdomain → path prefix → default.
+// This file MUST only be imported from Server Components or Server Actions.
+
+import type { BrandConfig } from "@enterprise/contracts";
+import { getBrandBySlug, getBrandRegistry, getDefaultBrand } from "./registry";
+
+// ============================================================================
+// Internal resolution logic (pure, testable)
+// ============================================================================
+
+interface ResolutionContext {
+  host: string;
+  pathname: string;
+}
+
+/**
+ * Pure resolution function that operates on an explicit registry Map.
+ * This signature is exported for testing without real next/headers.
+ */
+export async function resolveBrandFromRegistry(
+  registry: Map<string, BrandConfig>,
+  ctx: ResolutionContext,
+): Promise<BrandConfig> {
+  // Priority 1: BRAND_SLUG environment variable
+  const envSlug = process.env["BRAND_SLUG"];
+  if (envSlug) {
+    const brand = getBrandBySlug(registry, envSlug);
+    if (!brand) {
+      const available = Array.from(registry.keys()).join(", ");
+      throw new Error(
+        `[brand] BRAND_SLUG="${envSlug}" does not match any registered brand. ` +
+          `Available slugs: ${available}`,
+      );
+    }
+    return brand;
+  }
+
+  const { host, pathname } = ctx;
+
+  // Priority 2: Subdomain matching
+  // Strip port from host, split by ".", take first segment if > 2 parts
+  const hostWithoutPort = host.split(":")[0] ?? "";
+  const subdomainSegments = hostWithoutPort.split(".");
+  if (subdomainSegments.length > 2) {
+    const subdomainSlug = subdomainSegments[0] ?? "";
+    const brand = getBrandBySlug(registry, subdomainSlug);
+    if (brand) return brand;
+    console.warn(
+      `[brand] Unrecognized subdomain slug: "${subdomainSlug}". Falling back to default brand.`,
+    );
+  }
+
+  // Priority 3: Path prefix matching
+  const firstPathSegment = pathname.split("/")[1] ?? "";
+  if (firstPathSegment) {
+    const brand = getBrandBySlug(registry, firstPathSegment);
+    if (brand) return brand;
+    // Only warn if the segment looks like an intentional brand slug (no dots → not a file extension)
+    if (!firstPathSegment.includes(".")) {
+      console.warn(
+        `[brand] Path prefix "${firstPathSegment}" did not match any brand slug. ` +
+          `Falling back to default brand.`,
+      );
+    }
+  }
+
+  // Priority 4: Default brand
+  return getDefaultBrand(registry);
+}
+
+// ============================================================================
+// Public server-side API
+// ============================================================================
+
+/**
+ * Resolves the active brand for the current request.
+ * Reads env vars and Next.js request headers.
+ * Server-only — do NOT import in Client Components.
+ *
+ * Resolution priority:
+ * 1. BRAND_SLUG env var
+ * 2. Subdomain matching (acme.platform.com → "acme")
+ * 3. Path prefix matching (/acme/dashboard → "acme")
+ * 4. Default brand (isDefault=true or "enterprise" slug)
+ */
+export async function resolveBrand(): Promise<BrandConfig> {
+  const { headers } = await import("next/headers");
+  const headerList = await headers();
+  const host = headerList.get("host") ?? "";
+  const pathname = headerList.get("x-invoke-path") ?? "/";
+
+  const registry = getBrandRegistry();
+  return resolveBrandFromRegistry(registry, { host, pathname });
+}

--- a/packages/brand/src/brands/enterprise.brand.ts
+++ b/packages/brand/src/brands/enterprise.brand.ts
@@ -1,0 +1,44 @@
+import type { BrandConfig } from "@enterprise/contracts";
+
+const enterpriseBrand: BrandConfig = {
+  slug: "enterprise",
+  name: "enterprise",
+  displayName: "Enterprise Platform",
+  description: "The enterprise-grade SaaS platform template.",
+  logo: {
+    light: {
+      src: "/images/enterprise/logo-light.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+    dark: {
+      src: "/images/enterprise/logo-dark.svg",
+      alt: "Enterprise Platform",
+      width: 160,
+      height: 32,
+    },
+  },
+  favicon: "/images/enterprise/favicon.svg",
+  metadata: {
+    titleTemplate: "%s | Enterprise Platform",
+    defaultTitle: "Enterprise Platform",
+    description: "The enterprise-grade SaaS platform template for modern teams.",
+    ogImage: "/images/enterprise/og-image.png",
+  },
+  legal: {
+    // Replace these placeholder URLs with your actual legal pages before go-live
+    privacyUrl: "#",
+    termsUrl: "#",
+  },
+  social: {
+    github: "https://github.com/your-org",
+  },
+  themeRef: "light",
+  features: {
+    showPoweredBy: true,
+  },
+  isDefault: true,
+};
+
+export default enterpriseBrand;

--- a/packages/brand/src/brands/index.ts
+++ b/packages/brand/src/brands/index.ts
@@ -1,0 +1,8 @@
+// Brand config barrel — export all brand configs for registry consumption.
+// Add new *.brand.ts files here to register them with the brand registry.
+// Each exported value must be a default export from its module.
+
+export { default as enterprise } from "./enterprise.brand";
+
+// Example: Uncomment to register a second brand
+// export { default as acme } from "./acme.brand";

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -12,5 +12,11 @@ export { BrandContext } from "./brand/context";
 export { generateBrandMetadata } from "./brand/metadata";
 export type { BrandProviderProps } from "./brand/provider";
 export { BrandProvider, useBrand } from "./brand/provider";
-export { buildRegistry, getAllBrands, getBrandBySlug, getBrandRegistry, getDefaultBrand } from "./brand/registry";
+export {
+  buildRegistry,
+  getAllBrands,
+  getBrandBySlug,
+  getBrandRegistry,
+  getDefaultBrand,
+} from "./brand/registry";
 export { resolveBrand, resolveBrandFromRegistry } from "./brand/resolve";

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -1,1 +1,16 @@
-export {};
+// @enterprise/brand — public barrel export
+// For tree-shaking and subpath imports, prefer specific subpaths:
+//   import { BrandProvider } from "@enterprise/brand/provider"
+//   import { resolveBrand }   from "@enterprise/brand/resolve"
+
+export type { BrandFooterProps } from "./brand/brand-footer";
+export { BrandFooter } from "./brand/brand-footer";
+export type { BrandLogoProps } from "./brand/brand-logo";
+export { BrandLogo } from "./brand/brand-logo";
+export type { BrandContextValue } from "./brand/context";
+export { BrandContext } from "./brand/context";
+export { generateBrandMetadata } from "./brand/metadata";
+export type { BrandProviderProps } from "./brand/provider";
+export { BrandProvider, useBrand } from "./brand/provider";
+export { buildRegistry, getAllBrands, getBrandBySlug, getBrandRegistry, getDefaultBrand } from "./brand/registry";
+export { resolveBrand, resolveBrandFromRegistry } from "./brand/resolve";

--- a/packages/brand/tsconfig.json
+++ b/packages/brand/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,13 @@
       "@enterprise/ui": ["packages/ui/src"],
       "@enterprise/ui/*": ["packages/ui/src/*"],
       "@enterprise/brand": ["packages/brand/src"],
+      "@enterprise/brand/context": ["packages/brand/src/brand/context"],
+      "@enterprise/brand/provider": ["packages/brand/src/brand/provider"],
+      "@enterprise/brand/resolve": ["packages/brand/src/brand/resolve"],
+      "@enterprise/brand/registry": ["packages/brand/src/brand/registry"],
+      "@enterprise/brand/metadata": ["packages/brand/src/brand/metadata"],
+      "@enterprise/brand/brand-logo": ["packages/brand/src/brand/brand-logo"],
+      "@enterprise/brand/brand-footer": ["packages/brand/src/brand/brand-footer"],
       "@enterprise/brand/*": ["packages/brand/src/*"],
       "@/*": ["ui/*"]
     }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,6 +1,6 @@
-import { generateBrandMetadata } from "@enterprise/ui/brand/metadata";
-import { BrandProvider } from "@enterprise/ui/brand/provider";
-import { resolveBrand } from "@enterprise/ui/brand/resolve";
+import { generateBrandMetadata } from "@enterprise/brand/metadata";
+import { BrandProvider } from "@enterprise/brand/provider";
+import { resolveBrand } from "@enterprise/brand/resolve";
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono, Plus_Jakarta_Sans, Space_Grotesk } from "next/font/google";
 import { Toaster } from "sonner";

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -19,7 +19,16 @@
       "@enterprise/core": ["../packages/core/src"],
       "@enterprise/core/*": ["../packages/core/src/*"],
       "@enterprise/db": ["../packages/db/src"],
-      "@enterprise/db/*": ["../packages/db/src/*"]
+      "@enterprise/db/*": ["../packages/db/src/*"],
+      "@enterprise/brand": ["../packages/brand/src"],
+      "@enterprise/brand/context": ["../packages/brand/src/brand/context"],
+      "@enterprise/brand/provider": ["../packages/brand/src/brand/provider"],
+      "@enterprise/brand/resolve": ["../packages/brand/src/brand/resolve"],
+      "@enterprise/brand/registry": ["../packages/brand/src/brand/registry"],
+      "@enterprise/brand/metadata": ["../packages/brand/src/brand/metadata"],
+      "@enterprise/brand/brand-logo": ["../packages/brand/src/brand/brand-logo"],
+      "@enterprise/brand/brand-footer": ["../packages/brand/src/brand/brand-footer"],
+      "@enterprise/brand/*": ["../packages/brand/src/*"]
     },
     "noEmit": true,
     "incremental": true


### PR DESCRIPTION
## Summary

- **PR 2 of 3** (stacked-to-main) for the `brand-isolation` change (roadmap #15). Moves all brand source + tests OUT of `@enterprise/ui` and into `@enterprise/brand`, then rewires the only consumer (`ui/app/layout.tsx`).
- Pure move-refactor: behavior preserved. Source files are copied verbatim except mechanical import rewrites (`../theme/provider` → `@enterprise/ui/theme/provider`, `../lib/utils` → `@enterprise/ui/lib/utils`). Strict TDD: 6 test files migrated, RED (source absent) → GREEN (45/45).
- `@enterprise/ui` brand code is NOT deleted yet — both `@enterprise/ui/brand/*` and `@enterprise/brand/*` resolve in this slice so the build never breaks. The old exports are stripped in **PR3**.

## Changes

| File | Change |
|------|--------|
| `packages/brand/src/brand/*` (8 files) | Brand source migrated; `provider.tsx`/`brand-logo.tsx`/`brand-footer.tsx` import `cn`/`useTheme` from `@enterprise/ui` subpaths; `registry.ts` error string updated |
| `packages/brand/src/brands/*` (2 files) | Brand config + barrel migrated verbatim |
| `packages/brand/src/brand/__tests__/*` (6 files) | Test suite migrated; `provider`/`brand-logo` `vi.mock` retargeted to `@enterprise/ui/theme/provider` |
| `packages/brand/src/index.ts` | Public barrel filled |
| `tsconfig.json`, `ui/tsconfig.json` | Explicit `@enterprise/brand/*` subpath path mappings (files live under `src/brand/`) |
| `packages/brand/tsconfig.json` | `composite: false` override (root sets it true; brand imports cross-package source) |
| `ui/app/layout.tsx` | 3 brand imports switched to `@enterprise/brand/*` |

## Verification

- [x] `pnpm typecheck` passes (7/7)
- [x] `pnpm lint` passes (361 files)
- [x] `pnpm test` passes (brand 45, ui 209, core 187, contracts)
- [x] `node scripts/check-boundaries.mjs` passes
- [x] `pnpm install --frozen-lockfile` passes (no new deps — landed in PR1)
- [x] No `any` types introduced
- [x] Both old and new brand import paths resolve (no breakage this slice)

> E2E note: the repo's Playwright suite has a pre-existing flaky baseline (`5 failed / 2 flaky` — theme, notifications, team-management, workspace-admin) tracked as P1 #17, identical to the last merged code PRs. This slice touches no E2E and the brand E2E (`ui/e2e/brand/brand.spec.ts`) passes.

## Notes for reviewers

- `vi.mock` retarget is required (not optional): the migrated source imports `useTheme` from `@enterprise/ui/theme/provider`, so the mock must intercept that module specifier. Tests still assert real rendering behavior.
- Next in the stack: **PR3** removes the brand barrel + 7 subpath exports from `@enterprise/ui`, deletes the old `src/brand`/`src/brands` dirs, updates `.env.example`, and locks the `ui ✗→ brand` boundary (a TS error on `@enterprise/ui/brand/*` becomes the regression gate).
