### PR TITLE
docs(roadmap): close brand-isolation #15, archive SDD specs

### DIFF
--- a/docs/features/roadmap.md
+++ b/docs/features/roadmap.md
@@ -36,7 +36,7 @@ Define the canonical implementation priority for planned features in this templa
 | 12 | P1 | Webhooks | Planned | Completes outbound integration workflows for technical adopters. |
 | 13 | P1 | Usage limits and quotas | Planned | Enforces plan value and protects shared resources. |
 | 14 | P1 | Brand abstraction layer | Done | Enables multi-brand support from a single codebase with provider-agnostic branding. |
-| 15 | P1 | Brand isolation package | Planned | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
+| 15 | P1 | Brand isolation package | Done | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
 | 16 | P1 | Backend provider decoupling | Done | Introduces port/adapter interfaces to decouple @enterprise/core from Supabase. |
 | 17 | P1 | Test and CI stability hardening | Planned | Removes flaky E2E (notifications timing/delay), closes test-coverage gaps, and enforces lockfile/build checks so future feature PRDs don't break the pipeline. |
 | 18 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |

--- a/openspec/changes/archive/2026-06-01-brand-isolation/archive-report.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/archive-report.md
@@ -1,0 +1,89 @@
+# Archive Report: brand-isolation
+
+**Archived**: 2026-06-01
+**Roadmap item**: #15 — Brand Isolation Package
+**Status**: COMPLETE — merged to main @ 92fcf6b
+
+## PRs Merged
+
+| PR | Title | Merge commit |
+|---|---|---|
+| #125 | feat(brand): scaffold @enterprise/brand package + wire config | 3b67b75 |
+| #126 | feat(brand): migrate brand source + tests; switch layout.tsx consumer | ba2ba2a |
+| #127 | refactor(ui): remove brand exports from @enterprise/ui; enforce boundary | 92fcf6b |
+
+## Engram Artifact IDs
+
+| Artifact | Observation ID | Topic key |
+|---|---|---|
+| Proposal | #2771 | sdd/brand-isolation/proposal |
+| Spec | #2773 | sdd/brand-isolation/spec |
+| Design | #2772 | sdd/brand-isolation/design |
+| Tasks | #2774 | sdd/brand-isolation/tasks |
+| Apply Progress | #2775 | sdd/brand-isolation/apply-progress |
+| Status | #2777 | sdd/brand-isolation/status |
+| Archive Report | (see Engram) | sdd/brand-isolation/archive-report |
+
+## Specs Promoted to Canonical
+
+Both domains were NEW — no prior canonical spec existed. Delta specs promoted verbatim.
+
+| Domain | Action | Canonical path |
+|---|---|---|
+| brand-boundary | Created (4 requirements, 12 scenarios) | `openspec/specs/brand-boundary/spec.md` |
+| brand-behavior | Created (5 requirements, 12 scenarios) | `openspec/specs/brand-behavior/spec.md` |
+
+## What Changed in Production
+
+### New: @enterprise/brand package (`packages/brand/`)
+
+- 8 source files + 6 test files + 2 brand config files = 16 files total
+- No bundler — exports TypeScript source via tsc (same as @enterprise/ui)
+- Subpath exports: `.`, `./context`, `./provider`, `./resolve`, `./registry`, `./metadata`, `./brand-logo`, `./brand-footer`
+- Dependencies: `@enterprise/contracts` + `@enterprise/ui` (workspace:*); peers: `next`, `react`, `react-dom`
+
+### Modified: @enterprise/ui — zero brand references
+
+- Removed brand barrel exports from `packages/ui/src/index.ts`
+- Removed 7 `./brand/*` subpath entries from `packages/ui/package.json`
+- Deleted `packages/ui/src/brand/` (8 src + 6 test files) and `packages/ui/src/brands/` (2 files)
+- vitest `ui` project: 209 → 164 tests (45 migrated to @enterprise/brand — not lost)
+
+### Modified: Consumer rewire
+
+- `ui/app/layout.tsx`: 3 imports `@enterprise/ui/brand/*` → `@enterprise/brand/*`
+
+### Modified: Config + tooling wiring
+
+- `vitest.config.ts` — new `brand` project block (45 tests, 6 files)
+- root `tsconfig.json` — @enterprise/brand + subpath path aliases
+- `ui/next.config.ts` — added `@enterprise/brand` to `transpilePackages`
+- `scripts/check-boundaries.mjs` — FORBID ui→brand; ALLOW brand→[contracts,ui]; ALLOW web→brand
+- `skills/skill-sync/assets/sync.sh` — `packages/brand` case in `get_agents_path()`
+- `.env.example` — updated brand config comment path
+
+## Final Verification Results
+
+| Gate | Result |
+|---|---|
+| `pnpm install --frozen-lockfile` | ✅ Pass |
+| `pnpm typecheck` (7/7 projects) | ✅ Pass |
+| `pnpm lint` (345 files) | ✅ Pass |
+| `pnpm test` (brand 45, ui 164, core 187, contracts 323, web 115) | ✅ Pass |
+| `node scripts/check-boundaries.mjs` | ✅ Pass (zero violations) |
+| `pnpm e2e --grep brand` (4 tests) | ✅ Pass |
+| Negative gate: TS2307 on old `@enterprise/ui/brand/provider` | ✅ Confirmed |
+
+## Key Learnings (apply to future changes)
+
+1. `vitest passWithNoTests` MUST be in the package `test` script, NOT global vitest config
+2. `check-boundaries.mjs` allowlist array must stay within Biome 100-char line width — format error not caught without lint
+3. `build:theme` (triggered by turbo typecheck) rewrites `packages/ui/src/styles/theme-generated.css` + `packages/ui/src/tokens/index.ts` with timestamp drift — always revert before committing
+4. `packages/ui` has NO local tsconfig; new packages that need one (like `packages/brand`) must create their own
+5. `vi.mock` paths in test files may need rewriting to absolute paths when tests move to a new package directory
+6. `tsconfig.json` needs `composite: false` override to avoid TS6307 for non-composite packages
+7. Root and ui tsconfigs need explicit subpath path mappings (e.g., `@enterprise/brand/*`) when files live under `src/brand/*`
+
+## Next Roadmap Item
+
+P1 #17 — Test and CI stability hardening (flaky E2E: theme×4 + notifications always fail; team-management/workspace-admin/password-reset rotate by timing)

--- a/openspec/changes/archive/2026-06-01-brand-isolation/design.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/design.md
@@ -1,0 +1,126 @@
+# Design: brand-isolation
+
+> NOTE: Live codebase and Engram artifact reads were blocked by an environment
+> tool-output failure during this phase. This design is built from the
+> orchestrator brief (proposal + exploration summary). The exact 7 subpath names
+> and the 11 src / 6 test file list MUST be reconciled against the exploration
+> artifact and `packages/ui/package.json` `exports` during sdd-tasks/sdd-apply.
+
+## Technical Approach
+
+Extract all brand code from `@enterprise/ui` into a new `@enterprise/brand`
+package. Approach A dependency graph:
+
+    @enterprise/web   → @enterprise/brand   (only prod consumer: layout.tsx, 3 imports)
+    @enterprise/brand → @enterprise/contracts, @enterprise/ui  (+ react/react-dom peer)
+    @enterprise/ui    → brand-agnostic (no brand exports)
+
+No cycle: `ui` stops depending on brand; `brand` depends on `ui`. Build never
+breaks if we create+wire first, move with both paths valid, then strip old.
+
+## Architecture Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Direction | brand → ui (Approach A) | UI is the lower primitive; brand composes it. Keeps `ui` reusable/brand-free. |
+| Move vs copy-first | Copy into brand, keep ui exports until consumer switched | Keeps repo green mid-migration; clean revert. |
+| Build tooling | Mirror `packages/ui` exactly (same bundler/scripts) | Consistency; zero new tooling decisions. |
+| registry dynamic require | Keep `require("../brands/index")` relative | `brand/` and `brands/` move together → relative path still resolves post-move. Verify resolved path in apply. |
+| Subpath exports | Mirror the existing 7 `@enterprise/ui` brand subpaths 1:1 under `@enterprise/brand` | Drop-in import rename for consumer. |
+
+## Package Scaffold — `packages/brand/`
+
+- **package.json**: `name: "@enterprise/brand"`, `private: true`, `type: module`,
+  `version` matching workspace convention. `exports` map mirroring the 7 brand
+  subpaths (verify against `packages/ui` brand exports). `dependencies`:
+  `@enterprise/contracts: workspace:*`, `@enterprise/ui: workspace:*`.
+  `peerDependencies`: `react`, `react-dom`. `devDependencies` + `scripts`
+  (`build`, `typecheck`, `lint`) copied from `packages/ui`.
+- **tsconfig.json**: extend the same base as `packages/ui`; add path/composite
+  settings to match.
+- **build config**: identical bundler config to `packages/ui` (same entry-per-
+  subpath pattern).
+
+## File Move Map (reconcile exact names with exploration)
+
+| Source (`@enterprise/ui`) | Destination (`@enterprise/brand`) |
+|---|---|
+| `src/brand/**` (registry.ts, provider, config, …) | `packages/brand/src/brand/**` |
+| `src/brands/**` (index.ts + brand defs) | `packages/brand/src/brands/**` |
+| brand test files (`*.test.ts(x)`) | colocated under `packages/brand/src/**` |
+
+11 src + 6 test files total. **Import rewrites inside moved files:**
+
+- `../theme/provider` → `@enterprise/ui/theme/provider`
+- `../lib/utils` → `@enterprise/ui/lib/utils`
+- (any other `../<ui-internal>` relative → matching `@enterprise/ui/<subpath>`)
+- `registry.ts`: keep `require("../brands/index")` (both dirs move together);
+  confirm it resolves from `packages/brand/src/brand/registry.ts`.
+- Update hardcoded error string referencing the old package/path.
+- Update `biome-ignore` comment if it names the old location.
+- Update `.env.example` brand comment to point at `@enterprise/brand`.
+
+## `@enterprise/ui` Cleanup
+
+1. Remove brand barrel exports from the `ui` root index.
+2. Remove the `BrandConfig` re-export (consumers import it from
+   `@enterprise/contracts` or `@enterprise/brand`).
+3. Remove the 7 brand subpath entries from `packages/ui/package.json` `exports`.
+4. Delete the moved `src/brand/` and `src/brands/` dirs.
+
+## Consumer Rewrite — `ui/app/layout.tsx`
+
+3 import lines: `@enterprise/ui/brand…` → `@enterprise/brand…` (same subpath
+suffixes). No logic change.
+
+## Config / Tooling Wiring
+
+| Target | Change |
+|---|---|
+| `vitest.config.ts` | New `brand` project block mirroring the `ui` block, root `packages/brand`. |
+| root `tsconfig.json` paths | Add `@enterprise/brand` + 7 subpath aliases. |
+| `ui/next.config.ts` | Add `@enterprise/brand` to `transpilePackages`. |
+| `scripts/check-boundaries.mjs` | Allow `web→brand`, `brand→[contracts,ui]`; FORBID `ui→brand`. |
+| `skills/skill-sync/assets/sync.sh` | Add `@enterprise/brand` case to `get_agents_path()`. |
+
+## Testing Strategy / TDD Sequencing (for apply)
+
+| Layer | Approach |
+|---|---|
+| Unit | Move tests alongside code; run under new vitest `brand` project. For a move-refactor, RED = migrated tests can't resolve from `@enterprise/brand` until files+exports land; GREEN = same assertions pass from new package. |
+| Integration | Keep the existing brand E2E as the integration gate — must stay green across the whole migration. |
+
+Meaningful RED→GREEN: add the `brand` vitest project + a failing import test
+first, then move files to satisfy it. No assertion logic changes — behavior is
+preserved, location moves.
+
+## Migration Ordering (build never breaks)
+
+1. **Create + wire**: scaffold `packages/brand`, add all config wiring (vitest,
+   tsconfig paths, transpilePackages, check-boundaries allowances, sync.sh).
+2. **Copy + rewrite**: copy brand files into `packages/brand`, rewrite imports,
+   add `@enterprise/brand` deps. Old (`@enterprise/ui/brand`) AND new paths both
+   valid. Typecheck/test green.
+3. **Switch consumer**: repoint `layout.tsx` to `@enterprise/brand`. Verify
+   typecheck + unit + E2E green.
+4. **Strip old**: remove brand exports/dirs from `@enterprise/ui`; tighten
+   `check-boundaries` to forbid `ui→brand`. Verify green.
+
+## Risk / Rollback
+
+| Risk | Mitigation |
+|---|---|
+| Dependency cycle (ui↔brand) | Step 4 strips `ui` brand code; `ui` never imports `brand`. Boundary check enforces. |
+| Dynamic `require` breaks post-move | `brand/`+`brands/` move together; verify resolution in step 2 before stripping. |
+| Mid-migration red build | Steps 1–3 keep both import paths valid; nothing deleted until consumer switched. |
+| Stale `pnpm-lock.yaml` | Run `pnpm install` after step 1 (new workspace pkg); commit lockfile. |
+
+**Rollback**: until step 4, revert = drop `packages/brand` + revert `layout.tsx`
+(ui still ships brand). After step 4, revert the cleanup commit to restore ui
+exports.
+
+## Open Questions (BLOCKING precision, not approach)
+
+- [ ] Confirm the exact 7 brand subpath names from `packages/ui/package.json`.
+- [ ] Confirm the exact 11 src + 6 test file paths from the exploration artifact.
+- [ ] Confirm `packages/ui` bundler (tsdown/tsup/tsc) to copy build config verbatim.

--- a/openspec/changes/archive/2026-06-01-brand-isolation/proposal.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/proposal.md
@@ -1,0 +1,138 @@
+# Proposal: Brand Isolation Package (#15)
+
+## Intent
+
+Feature #14 landed all brand code inside `@enterprise/ui` (merged @ dd81fd5). That couples the design-system package to a specific identity: any adopter who wants a different brand must edit the shared UI library, and `@enterprise/ui` cannot be published as a neutral, brand-agnostic primitives package. This change extracts ALL brand code into a new workspace package `@enterprise/brand` (`packages/brand/`), leaving `@enterprise/ui` with ZERO brand references. Roadmap feature #15 "Brand Isolation Package"; depends on #14 (Done).
+
+## Scope
+
+### In Scope
+- Create new workspace package `@enterprise/brand` at `packages/brand/`.
+- Move 11 source files + 6 unit test files out of `packages/ui/src/brand` and `packages/ui/src/brands`.
+- Rewire the single production consumer: 3 import lines in `ui/app/layout.tsx` (`@enterprise/ui/brand/*` → `@enterprise/brand/*`).
+- Remove all brand exports from `packages/ui/src/index.ts` and the 7 `./brand/*` subpath exports from `packages/ui/package.json`.
+- Wire config: `vitest.config.ts` (new `brand` project), root `tsconfig.json` paths, `ui/next.config.ts` `transpilePackages`, `scripts/check-boundaries.mjs`, `.env.example` comment, `skills/skill-sync/assets/sync.sh`.
+- Keep all 6 migrated unit tests and the `ui/e2e/brand/brand.spec.ts` E2E suite green.
+
+### Out of Scope
+- Fixing the flaky `ui/e2e/notifications/` E2E suite — DO NOT touch.
+- Converting `registry.ts` dynamic `require("../brands/index")` to static ESM import — noted as a follow-up, NOT blocking.
+- Any new brand features, runtime brand switching, or visual brand editor.
+- `@enterprise/db` schema, RLS, or any DB change (none required).
+- Approach B (standalone brand package) — exploration rejected it; we keep the brand↔theme coupling.
+
+## Capabilities
+
+> Pure structural refactor. No spec-level behavior changes — the public brand API (symbols, subpath shape, runtime behavior) is byte-identical, only the package boundary moves.
+
+### New Capabilities
+- None — no new behavior is introduced.
+
+### Modified Capabilities
+- None — `openspec/specs/` is empty and no requirement-level behavior changes. The brand contract is preserved verbatim; only its hosting package changes.
+
+## Approach
+
+**Approach A** (validated in exploration): `@enterprise/brand` depends on `@enterprise/ui` for primitives (`cn` from `@enterprise/ui/lib/utils`, `ThemeProvider`/`useTheme` from `@enterprise/ui/theme/provider`). `BrandProvider` keeps wrapping `ThemeProvider` (brand dictates initial theme mode via `themeRef`). The only code delta inside moved files is relative imports (`../lib/utils`, `../theme/provider`) becoming workspace imports (`@enterprise/ui/*`). Zero duplication; brand–theme coupling preserved.
+
+Migration order: scaffold package → move sources + tests → fix imports inside moved files → strip brand from `@enterprise/ui` → rewire `layout.tsx` → wire config/tooling → typecheck/lint/test/e2e green.
+
+## Dependency Rule (ENFORCED)
+
+```
+@enterprise/contracts → zod ONLY
+@enterprise/ui        → @enterprise/contracts + clsx + cva + lucide + radix   (ZERO brand refs)
+@enterprise/brand     → @enterprise/contracts + @enterprise/ui
+@enterprise/web       → @enterprise/contracts + @enterprise/core + @enterprise/ui + @enterprise/db + @enterprise/brand (NEW)
+```
+
+FORBIDDEN: `@enterprise/ui → @enterprise/brand` (would reintroduce coupling; enforced via `scripts/check-boundaries.mjs`). `@enterprise/contracts` STAYS a dep of `@enterprise/ui` (form components, theme, hooks need it — unrelated to brand).
+
+## New Package Contract
+
+`packages/brand/package.json` exports (mirror current `@enterprise/ui` brand subpaths, dropping the `brand/` prefix):
+
+```json
+{
+  ".": "./src/index.ts",
+  "./context": "./src/brand/context.ts",
+  "./provider": "./src/brand/provider.tsx",
+  "./resolve": "./src/brand/resolve.ts",
+  "./registry": "./src/brand/registry.ts",
+  "./metadata": "./src/brand/metadata.ts",
+  "./brand-logo": "./src/brand/brand-logo.tsx",
+  "./brand-footer": "./src/brand/brand-footer.tsx"
+}
+```
+
+- deps: `@enterprise/contracts` (workspace:*), `@enterprise/ui` (workspace:*)
+- devDeps: `next`, `@types/react`, `@types/react-dom`, `tsx`, `typescript`, `zod`
+- peerDeps: `next`, `react`, `react-dom`
+
+## File Inventory
+
+### CREATE
+| Path | Purpose |
+|------|---------|
+| `packages/brand/package.json` | New workspace package manifest + subpath exports |
+| `packages/brand/tsconfig.json` | Extends root tsconfig |
+| `packages/brand/src/index.ts` | Barrel (moved brand exports) |
+| `packages/brand/AGENTS.md` | Package guidance + dependency rule |
+
+### MOVE (`packages/ui/src/brand|brands` → `packages/brand/src/brand|brands`)
+`context.ts`, `provider.tsx`, `resolve.ts`, `registry.ts`, `brand-logo.tsx`, `brand-footer.tsx`, `metadata.ts`, `index.ts`, `brands/enterprise.brand.ts`, `brands/index.ts`, plus 6 test files in `__tests__/` (registry, resolve, provider, brand-logo, brand-footer, metadata).
+
+### EDIT
+| Path | Change |
+|------|--------|
+| Moved files (`provider.tsx`, `brand-logo.tsx`, `brand-footer.tsx`) | Relative imports → `@enterprise/ui/lib/utils`, `@enterprise/ui/theme/provider` |
+| `registry.ts` | Update hardcoded error-message path `packages/ui/src/brands/` → `packages/brand/src/brands/`; keep relative `require("../brands/index")` |
+| `brand-logo.tsx` | Update `biome-ignore`/comment referencing `packages/ui` → `packages/brand` |
+| `packages/ui/src/index.ts` | Remove `BrandConfig` re-export + 10 brand symbols |
+| `packages/ui/package.json` | Remove 7 `./brand/*` subpath exports (keep `@enterprise/contracts` dep) |
+| `ui/app/layout.tsx` | 3 imports `@enterprise/ui/brand/*` → `@enterprise/brand/*` |
+| `vitest.config.ts` | Add `brand` project (root `./packages/brand`, env node, include `src/**/*.test.ts`) |
+| `tsconfig.json` (root) | Add `@enterprise/brand` + subpath paths |
+| `ui/next.config.ts` | Add `@enterprise/brand` to `transpilePackages` |
+| `scripts/check-boundaries.mjs` | Add `packages/brand` allowlist; add `@enterprise/brand` to `ui` allowlist |
+| `.env.example` | Update comment `packages/ui/src/brands/` → `packages/brand/src/brands/` |
+| `skills/skill-sync/assets/sync.sh` | Add `packages/brand` case to `get_agents_path()` |
+
+## Feature Readiness (Traceability Decision)
+
+Per `feature-readiness` decision tree: this is a **structural refactor — no CUD operations, no external provider**. The full traceability checklist therefore **does not apply**. Explicit statements for reviewers:
+
+- **Audit events**: none added or changed (no mutations).
+- **Sentry**: no new `SentryArea`, no Server Actions touched.
+- **Seed data**: unchanged; `supabase db reset` unaffected.
+- **External adapters**: none.
+- **Env vars**: `BRAND_SLUG` behavior is UNCHANGED — `resolveBrand()` logic moves verbatim; the variable is read identically, only from the new package.
+- **E2E**: the brand flow already exists (`ui/e2e/brand/brand.spec.ts`) and MUST stay green; no new flows required.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Import-path migration misses a consumer | Low | Grep verified only 3 imports in `layout.tsx`; no other consumers exist |
+| `registry.ts` dynamic `require` fails after move | Medium | Relative `../brands/index` resolves post-move (brands/ moves with it); flagged for static-ESM follow-up, not blocking |
+| `BrandConfig` barrel re-export removal breaks an importer | Low | Verified no `import { BrandConfig } from "@enterprise/ui"` exists; all consumers use `@enterprise/contracts` directly |
+| Boundary check lets `ui → brand` slip in | Low | Add explicit FORBID rule to `check-boundaries.mjs`; CI fails on violation |
+| Stale hardcoded `packages/ui/src/brands/` path in error message | Low | Explicit edit + assert via migrated `registry.test.ts` |
+| E2E regression from `layout.tsx` rewire | Low | `ui/e2e/brand/brand.spec.ts` (4 tests) must pass before merge |
+
+## Rollback Plan
+
+Single-PR refactor with no DB/RLS/data changes — revert the merge commit to fully restore brand code into `@enterprise/ui`. No migrations to unwind, no env changes to roll back, no data state. `pnpm install` after revert restores the prior workspace graph.
+
+## Dependencies
+
+- Feature #14 (brand in `@enterprise/ui`) — Done, merged @ dd81fd5 (prerequisite satisfied).
+
+## Success Criteria
+
+- [ ] `@enterprise/brand` package exists at `packages/brand/` with all 11 source files + 6 tests.
+- [ ] `grep -r "brand" packages/ui/src` returns ZERO brand references; no `./brand/*` exports remain in `packages/ui/package.json`.
+- [ ] `ui/app/layout.tsx` imports brand exclusively from `@enterprise/brand/*`.
+- [ ] `scripts/check-boundaries.mjs` enforces `@enterprise/brand → contracts + ui` and FORBIDS `ui → brand`.
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test` (incl. new `brand` vitest project), and `pnpm e2e` brand suite all pass.
+- [ ] `BRAND_SLUG` resolution behaves identically to pre-change (verified by migrated `resolve.test.ts`).

--- a/openspec/changes/archive/2026-06-01-brand-isolation/specs/brand-behavior/spec.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/specs/brand-behavior/spec.md
@@ -1,0 +1,167 @@
+# Delta for brand-behavior
+
+> These capabilities were established in change #14 (brand-and-decoupling).
+> This delta records that ALL behavior is PRESERVED after the package move.
+> The only difference: import source changes from `@enterprise/ui/brand/*`
+> to `@enterprise/brand/*`. No logic, signatures, or outputs change.
+>
+> Labels: **[CARRIED]** = behavior unchanged from #14; **[NEW]** = structural constraint added here.
+
+---
+
+## ADDED Requirements
+
+### Requirement: resolveBrand() Resolution Strategy [CARRIED from #14]
+
+`resolveBrand()` exported from `@enterprise/brand/resolve` MUST implement the
+priority chain in the same order as the source it was moved from:
+
+1. `BRAND_SLUG` env var — match registered brand slug or throw with available slugs listed
+2. Subdomain detection: `host.split(".").length > 2` → first segment matched against registry
+3. Path prefix: first path segment matched against registry (skip segments containing ".")
+4. `getDefaultBrand()` fallback — never throws on fallback; warns via `console.warn` on unrecognized slug
+
+`resolveBrand()` is server-only (uses `next/headers`).
+
+#### Scenario: BRAND_SLUG env override forces brand
+
+- GIVEN `process.env.BRAND_SLUG = "acme"` and `acme` is registered
+- WHEN `resolveBrand()` is called
+- THEN it returns the `acme` BrandConfig
+
+#### Scenario: Unknown BRAND_SLUG throws descriptively
+
+- GIVEN `process.env.BRAND_SLUG = "ghost-brand"`
+- WHEN `resolveBrand()` is called
+- THEN it throws an error that includes the list of available brand slugs
+
+#### Scenario: Default brand resolves when no env override
+
+- GIVEN `BRAND_SLUG` is unset and `enterprise` brand has `isDefault: true`
+- WHEN `resolveBrand()` is called without a subdomain or path match
+- THEN it returns the `enterprise` BrandConfig
+
+#### Scenario: Unrecognized subdomain warns and falls back
+
+- GIVEN request host is `unknown.example.com`
+- WHEN `resolveBrand()` is called
+- THEN `console.warn` is called once and `getDefaultBrand()` result is returned (no throw)
+
+#### Scenario: Static asset paths do not trigger brand detection
+
+- GIVEN request path is `/_next/static/chunk.js`
+- WHEN `resolveBrand()` is called
+- THEN path-prefix resolution is skipped (segment contains ".")
+- AND default brand is returned
+
+---
+
+### Requirement: BrandProvider Wraps ThemeProvider [CARRIED from #14]
+
+`BrandProvider` exported from `@enterprise/brand/provider` MUST:
+- Accept `brand: BrandConfig` and `children: ReactNode` props
+- Seed `BrandContext` with the provided `brand`
+- Wrap children in `ThemeProvider` (imported from `@enterprise/ui`)
+- Derive `defaultMode`: `themeRef` ending in `"light"` → `"light"`, otherwise → `"dark"`
+
+#### Scenario: useBrand() returns brand inside provider
+
+- GIVEN `BrandProvider` is rendered with `brand={enterpriseBrand}`
+- WHEN a descendant calls `useBrand()`
+- THEN it receives `enterpriseBrand`
+
+#### Scenario: ThemeProvider receives derived mode
+
+- GIVEN `brand.themeRef = "enterprise-dark"`
+- WHEN `BrandProvider` renders
+- THEN `ThemeProvider` is mounted with `defaultMode="dark"`
+
+#### Scenario: useBrand() throws outside provider
+
+- GIVEN a component calls `useBrand()` with no ancestor `BrandProvider`
+- WHEN the component renders
+- THEN it throws an error containing the string `"<BrandProvider>"`
+
+---
+
+### Requirement: BrandLogo Renders Correct Theme Variant [CARRIED from #14]
+
+`BrandLogo` exported from `@enterprise/brand/brand-logo` MUST:
+- Read `useBrand().logo` and `useTheme().mode`
+- Render `<img src alt>` for the active mode variant
+- Render `<span>{brand.displayName}</span>` when the active variant `src` is empty
+- Forward `className` to the root element
+
+#### Scenario: Dark mode renders dark logo src
+
+- GIVEN theme mode is `"dark"` and `brand.logo.dark.src = "/logo-dark.svg"`
+- WHEN `BrandLogo` renders
+- THEN `<img src="/logo-dark.svg">` appears in the DOM
+
+#### Scenario: Empty src renders displayName fallback
+
+- GIVEN `brand.logo.light.src = ""` and theme mode is `"light"`
+- WHEN `BrandLogo` renders
+- THEN a `<span>` containing `brand.displayName` is rendered (no `<img>`)
+
+---
+
+### Requirement: BrandFooter Renders Legal and Social Links [CARRIED from #14]
+
+`BrandFooter` exported from `@enterprise/brand/brand-footer` MUST:
+- Render `© {year} {brand.displayName}` copyright notice
+- Render legal `<a>` links only when the URL string is non-empty
+- Render social links when `brand.social` is defined
+- Render "Powered by" attribution when `brand.features?.showPoweredBy === true`
+
+#### Scenario: Non-empty legal URL renders link
+
+- GIVEN `brand.legal.privacyUrl = "https://example.com/privacy"`
+- WHEN `BrandFooter` renders
+- THEN `<a href="https://example.com/privacy">` is present in the DOM
+
+#### Scenario: Empty legal URL omits link
+
+- GIVEN `brand.legal.termsUrl = ""`
+- WHEN `BrandFooter` renders
+- THEN no `<a>` anchor with an empty or terms-related href is rendered
+
+---
+
+### Requirement: generateBrandMetadata() Maps to Next.js Metadata [CARRIED from #14]
+
+`generateBrandMetadata(brand: BrandConfig)` exported from `@enterprise/brand/metadata`
+MUST return a Next.js `Metadata` object with the following field mapping:
+
+| Output field | Source |
+|---|---|
+| `title.template` | `"%s \| " + brand.metadata.titleTemplate` |
+| `title.default` | `brand.metadata.titleTemplate` |
+| `description` | `brand.metadata.description` |
+| `icons.icon` | `brand.favicon` |
+| `openGraph.images` | `[brand.metadata.ogImage]` when non-empty, else `[]` |
+
+#### Scenario: All metadata fields mapped correctly
+
+- GIVEN a BrandConfig with all metadata fields populated
+- WHEN `generateBrandMetadata(brand)` is called
+- THEN `title.default`, `description`, `icons.icon`, and `openGraph.images` match the mapping table
+
+#### Scenario: Empty ogImage yields empty array
+
+- GIVEN `brand.metadata.ogImage = ""`
+- WHEN `generateBrandMetadata(brand)` is called
+- THEN `openGraph.images` is `[]`
+
+---
+
+## Test Coverage Map
+
+| Requirement | Unit test file (post-move) | E2E coverage |
+|---|---|---|
+| resolveBrand() | `packages/brand/src/__tests__/resolve.test.ts` | brand.spec.ts — BRAND_SLUG scenario |
+| BrandProvider / useBrand | `packages/brand/src/__tests__/provider.test.ts` | brand.spec.ts — provider wraps |
+| BrandLogo | `packages/brand/src/__tests__/brand-logo.test.ts` | brand.spec.ts — logo renders |
+| BrandFooter | `packages/brand/src/__tests__/brand-footer.test.ts` | brand.spec.ts — footer renders |
+| generateBrandMetadata | `packages/brand/src/__tests__/metadata.test.ts` | brand.spec.ts — metadata check |
+| registry | `packages/brand/src/__tests__/registry.test.ts` | — |

--- a/openspec/changes/archive/2026-06-01-brand-isolation/specs/brand-boundary/spec.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/specs/brand-boundary/spec.md
@@ -1,0 +1,133 @@
+# Delta for brand-boundary
+
+> All capabilities in this domain are NEW (no existing main spec for brand-boundary in openspec/specs/).
+> This change introduces the @enterprise/brand package boundary as a structural constraint.
+
+---
+
+## ADDED Requirements
+
+### Requirement: @enterprise/brand Package Export Contract
+
+The `@enterprise/brand` package MUST expose the following public subpath exports
+via `packages/brand/package.json`:
+
+| Export key | Purpose |
+|---|---|
+| `.` | Root barrel: BrandProvider, useBrand, BrandContext |
+| `./context` | BrandContext |
+| `./provider` | BrandProvider, useBrand |
+| `./resolve` | resolveBrand |
+| `./registry` | getBrand, getAllBrands, getDefaultBrand |
+| `./metadata` | generateBrandMetadata |
+| `./brand-logo` | BrandLogo |
+| `./brand-footer` | BrandFooter |
+
+Each export MUST resolve to a compiled ESM entry and a `.d.ts` declaration.
+
+#### Scenario: Root barrel import resolves
+
+- GIVEN a consumer in `@enterprise/web`
+- WHEN it executes `import { BrandProvider, useBrand } from "@enterprise/brand"`
+- THEN both symbols resolve without TypeScript errors
+
+#### Scenario: Subpath import resolves
+
+- GIVEN a consumer in `@enterprise/web`
+- WHEN it executes `import { resolveBrand } from "@enterprise/brand/resolve"`
+- THEN the symbol resolves without TypeScript errors
+
+#### Scenario: Old @enterprise/ui brand subpath is gone
+
+- GIVEN a consumer
+- WHEN it attempts `import { BrandProvider } from "@enterprise/ui/brand/provider"`
+- THEN TypeScript reports an error (no matching key in `@enterprise/ui/package.json`)
+
+#### Scenario: Brand configs remain importable
+
+- GIVEN a consumer
+- WHEN it executes `import { enterpriseBrand } from "@enterprise/brand"`
+  (or `@enterprise/brand/registry`)
+- THEN the config object resolves without errors
+
+---
+
+### Requirement: @enterprise/ui Zero Brand References
+
+`packages/ui/src/` MUST contain zero imports or re-exports of brand symbols.
+`packages/ui/package.json` MUST NOT declare any `./brand/*` subpath export keys.
+
+#### Scenario: ui package.json has no brand export keys
+
+- GIVEN `packages/ui/package.json`
+- WHEN all `exports` keys are listed
+- THEN no key matches the pattern `./brand/*`
+
+#### Scenario: ui source files have no brand imports
+
+- GIVEN all `.ts` and `.tsx` files under `packages/ui/src/`
+- WHEN scanned for references to brand module names
+  (`brand-provider`, `brand-logo`, `brand-footer`, `resolveBrand`, `BrandContext`, `useBrand`, `generateBrandMetadata`)
+- THEN zero matches are found
+
+#### Scenario: ui barrel (index.ts) does not re-export brand symbols
+
+- GIVEN `packages/ui/src/index.ts`
+- WHEN compiled
+- THEN it does not export `BrandProvider`, `useBrand`, `BrandLogo`, `BrandFooter`
+
+---
+
+### Requirement: Dependency Boundary Enforcement
+
+`scripts/check-boundaries.mjs` MUST statically enforce the following import rules:
+
+| Rule | From | To | Verdict |
+|---|---|---|---|
+| FORBID | `@enterprise/ui` | `@enterprise/brand` | Exit non-zero |
+| ALLOW | `@enterprise/brand` | `@enterprise/ui` | Exit zero |
+| ALLOW | `@enterprise/brand` | `@enterprise/contracts` | Exit zero |
+| ALLOW | `@enterprise/web` | `@enterprise/brand` | Exit zero |
+
+#### Scenario: ui→brand import is blocked
+
+- GIVEN a file in `packages/ui/src/` contains `import ... from "@enterprise/brand"`
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with a non-zero code and logs the offending file path
+
+#### Scenario: brand→ui import is allowed
+
+- GIVEN `packages/brand/src/` imports from `@enterprise/ui` (e.g., `cn`, `ThemeProvider`)
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with code 0
+
+#### Scenario: web→brand import is allowed
+
+- GIVEN `ui/app/layout.tsx` contains `import { BrandProvider } from "@enterprise/brand"`
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with code 0
+
+#### Scenario: Clean baseline — no violations at merge
+
+- GIVEN the brand-isolation PR branch is fully applied
+- WHEN `node scripts/check-boundaries.mjs` runs on the entire monorepo
+- THEN it exits with code 0 and reports zero violations
+
+---
+
+### Requirement: Root Layout Import Rewire
+
+`ui/app/layout.tsx` MUST import brand symbols exclusively from `@enterprise/brand`.
+No `@enterprise/ui/brand/*` import path MAY remain in the file.
+
+#### Scenario: layout.tsx uses new package
+
+- GIVEN `ui/app/layout.tsx`
+- WHEN its import declarations are read
+- THEN every brand-related import references `@enterprise/brand` (not `@enterprise/ui`)
+
+#### Scenario: Layout still renders with BrandProvider
+
+- GIVEN the root layout is loaded in a Next.js server render
+- WHEN the page is requested
+- THEN `BrandProvider` is present in the React tree wrapping all children

--- a/openspec/changes/archive/2026-06-01-brand-isolation/tasks.md
+++ b/openspec/changes/archive/2026-06-01-brand-isolation/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: brand-isolation
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~950–1050 (additions + deletions) |
+| 800-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR1 → PR2 → PR3 |
+| Delivery strategy | auto-chain |
+| Chain strategy | pending |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: pending
+800-line budget risk: High
+
+### Live Repo Verification (resolved in task planning)
+
+| Open question | Answer |
+|---|---|
+| Exact 7 subpath keys in packages/ui/package.json | `./brand/context`, `./brand/provider`, `./brand/resolve`, `./brand/registry`, `./brand/metadata`, `./brand/brand-logo`, `./brand/brand-footer` |
+| Exact file count under src/brand + src/brands | 8 src files + 6 test files + 2 brands files = **16 files** |
+| Bundler packages/ui uses | **None (tsc-only)** — `tsc --noEmit` + `tsx` for scripts; exports TypeScript source directly, no dist build |
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Lines | Notes |
+|------|------|-----------|-------|-------|
+| 1 | Scaffold packages/brand + wire all config | PR 1 | ~165 | Base: main; pnpm lockfile committed |
+| 2 | Copy brand files + rewrite imports + RED→GREEN + switch layout.tsx | PR 2 | ~635 | Base: PR1 branch; both old+new paths valid; step 3 included |
+| 3 | Strip packages/ui brand exports + enforce boundary | PR 3 | ~250 | Base: PR2 branch; integration gate: E2E brand tests |
+
+## Phase 1: Scaffold + Config (PR 1)
+
+- [ ] 1.1 Create `packages/brand/package.json` — name `@enterprise/brand`, `"type": "module"`, deps: `@enterprise/contracts` + `@enterprise/ui` (`workspace:*`), peers: `next` + `react` + `react-dom` + `tailwindcss`, devDeps: `next` + `@types/react` + `@types/react-dom` + `tsx` + `typescript` + `zod`; 8 subpath exports: `.`, `./context`, `./provider`, `./resolve`, `./registry`, `./metadata`, `./brand-logo`, `./brand-footer` → `./src/brand/*.{ts,tsx}`; scripts: `typecheck`, `test`, `clean`
+- [ ] 1.2 Create `packages/brand/tsconfig.json` — `extends: "../../tsconfig.json"`, include `src`
+- [ ] 1.3 Create `packages/brand/src/index.ts` — empty barrel (filled in Phase 2)
+- [ ] 1.4 Create `packages/brand/AGENTS.md` — package purpose, boundary rules, auto-invoke table (mirror packages/core template)
+- [ ] 1.5 Add `brand` project block to `vitest.config.ts` — `{ name: "brand", root: "./packages/brand", environment: "node", include: ["src/**/*.test.ts"] }`; add `"packages/brand/src/**/*.ts"` to `coverage.include`
+- [ ] 1.6 Add `@enterprise/brand` + `@enterprise/brand/*` path entries to root `tsconfig.json` — resolve to `packages/brand/src` / `packages/brand/src/*`
+- [ ] 1.7 Add `"@enterprise/brand"` to `ui/next.config.ts` `transpilePackages` array
+- [ ] 1.8 Update `scripts/check-boundaries.mjs` — add `"packages/brand": ["@enterprise/contracts", "@enterprise/ui"]` entry; add `"@enterprise/brand"` to `ui` allowlist
+- [ ] 1.9 Add `packages/brand)` case to `skills/skill-sync/assets/sync.sh` `get_agents_path()` → `echo "$REPO_ROOT/packages/brand/AGENTS.md"`
+- [ ] 1.10 Run `pnpm install` — verify `pnpm-lock.yaml` updated; commit lockfile with scaffold
+- [ ] 1.11 Verify: `pnpm typecheck` passes; `node scripts/check-boundaries.mjs` passes; `vitest run --project brand` exits 0 (0 tests = clean scaffold)
+
+## Phase 2: Copy + Rewrite + RED → GREEN (PR 2)
+
+- [ ] 2.1 **[RED]** Copy 6 test files `packages/ui/src/brand/__tests__/*.test.ts` → `packages/brand/src/brand/__tests__/` verbatim (relative imports `../provider`, `../context` etc. unchanged — directory structure mirrored). Confirm `vitest run --project brand` **fails** (source files absent).
+- [ ] 2.2 Copy `packages/ui/src/brands/index.ts` → `packages/brand/src/brands/index.ts` (verbatim)
+- [ ] 2.3 Copy `packages/ui/src/brands/enterprise.brand.ts` → `packages/brand/src/brands/enterprise.brand.ts` (verbatim)
+- [ ] 2.4 Copy `packages/ui/src/brand/context.ts` → `packages/brand/src/brand/context.ts` (verbatim — no `@enterprise/*` imports)
+- [ ] 2.5 Copy `packages/ui/src/brand/resolve.ts` → `packages/brand/src/brand/resolve.ts` (verbatim — no relative `@enterprise/*` imports)
+- [ ] 2.6 Copy `packages/ui/src/brand/metadata.ts` → `packages/brand/src/brand/metadata.ts` (verbatim)
+- [ ] 2.7 Copy `packages/ui/src/brand/registry.ts` → `packages/brand/src/brand/registry.ts`; update hardcoded error string: `packages/ui/src/brands/` → `packages/brand/src/brands/`
+- [ ] 2.8 Copy `packages/ui/src/brand/brand-footer.tsx` → `packages/brand/src/brand/brand-footer.tsx`; rewrite: `../lib/utils` → `@enterprise/ui/lib/utils`; update any `biome-ignore` comment referencing `packages/ui` → `packages/brand`
+- [ ] 2.9 Copy `packages/ui/src/brand/provider.tsx` → `packages/brand/src/brand/provider.tsx`; rewrite: `../theme/provider` → `@enterprise/ui/theme/provider`
+- [ ] 2.10 Copy `packages/ui/src/brand/brand-logo.tsx` → `packages/brand/src/brand/brand-logo.tsx`; rewrite: `../lib/utils` → `@enterprise/ui/lib/utils`; `../theme/provider` → `@enterprise/ui/theme/provider`; update `biome-ignore` comment `packages/ui` → `packages/brand`
+- [ ] 2.11 Copy `packages/ui/src/brand/index.ts` → `packages/brand/src/brand/index.ts` (verbatim); fill `packages/brand/src/index.ts` barrel with re-exports from `./brand/index`
+- [ ] 2.12 **[GREEN]** Verify: `vitest run --project brand` **passes** (6 tests green); `vitest run --project ui` still green (ui brand tests still present)
+- [ ] 2.13 Rewrite `ui/app/layout.tsx` lines 1–3: `@enterprise/ui/brand/metadata` → `@enterprise/brand/metadata`; `@enterprise/ui/brand/provider` → `@enterprise/brand/provider`; `@enterprise/ui/brand/resolve` → `@enterprise/brand/resolve`
+- [ ] 2.14 Verify: `pnpm typecheck` passes; `vitest run` (all projects) green; `node scripts/check-boundaries.mjs` passes; both old `@enterprise/ui/brand/*` and new `@enterprise/brand/*` imports resolve
+
+## Phase 3: UI Cleanup + Boundary Enforcement (PR 3)
+
+- [ ] 3.1 Remove brand section (lines 1–13) from `packages/ui/src/index.ts` — `BrandConfig` re-export + 10 brand symbol exports
+- [ ] 3.2 Remove 7 `./brand/*` entries from `packages/ui/package.json` exports map
+- [ ] 3.3 Delete `packages/ui/src/brand/` directory (8 src + 6 test files = 14 files)
+- [ ] 3.4 Delete `packages/ui/src/brands/` directory (2 files)
+- [ ] 3.5 Update `.env.example`: replace path comment `packages/ui/src/brands/` → `packages/brand/src/brands/`
+- [ ] 3.6 Verify final state: `pnpm typecheck` passes; `vitest run` (all projects) green; `node scripts/check-boundaries.mjs` passes (ui→brand forbidden by omission — `packages/ui` allowlist has no `@enterprise/brand`); `pnpm e2e --grep brand` **green** (integration gate); confirm TS error on `import from "@enterprise/ui/brand/provider"` (no matching export)

--- a/openspec/specs/brand-behavior/spec.md
+++ b/openspec/specs/brand-behavior/spec.md
@@ -1,0 +1,167 @@
+# Spec: brand-behavior
+
+> **Domain**: brand-behavior
+> **Introduced by**: change #14 — brand-and-decoupling (behavior first established)
+> **Promoted to canonical by**: change #15 — brand-isolation (PRs #125, #126, #127; merged to main @ 92fcf6b)
+> **Status**: canonical — all requirements are ACTIVE
+>
+> Note: All behavior is implemented in `@enterprise/brand` (post-isolation).
+> Import paths changed from `@enterprise/ui/brand/*` to `@enterprise/brand/*` in change #15.
+> Logic, signatures, and outputs are unchanged from #14.
+
+---
+
+## Requirement: resolveBrand() Resolution Strategy
+
+`resolveBrand()` exported from `@enterprise/brand/resolve` MUST implement the
+priority chain in this order:
+
+1. `BRAND_SLUG` env var — match registered brand slug or throw with available slugs listed
+2. Subdomain detection: `host.split(".").length > 2` → first segment matched against registry
+3. Path prefix: first path segment matched against registry (skip segments containing ".")
+4. `getDefaultBrand()` fallback — never throws on fallback; warns via `console.warn` on unrecognized slug
+
+`resolveBrand()` is server-only (uses `next/headers`).
+
+### Scenario: BRAND_SLUG env override forces brand
+
+- GIVEN `process.env.BRAND_SLUG = "acme"` and `acme` is registered
+- WHEN `resolveBrand()` is called
+- THEN it returns the `acme` BrandConfig
+
+### Scenario: Unknown BRAND_SLUG throws descriptively
+
+- GIVEN `process.env.BRAND_SLUG = "ghost-brand"`
+- WHEN `resolveBrand()` is called
+- THEN it throws an error that includes the list of available brand slugs
+
+### Scenario: Default brand resolves when no env override
+
+- GIVEN `BRAND_SLUG` is unset and `enterprise` brand has `isDefault: true`
+- WHEN `resolveBrand()` is called without a subdomain or path match
+- THEN it returns the `enterprise` BrandConfig
+
+### Scenario: Unrecognized subdomain warns and falls back
+
+- GIVEN request host is `unknown.example.com`
+- WHEN `resolveBrand()` is called
+- THEN `console.warn` is called once and `getDefaultBrand()` result is returned (no throw)
+
+### Scenario: Static asset paths do not trigger brand detection
+
+- GIVEN request path is `/_next/static/chunk.js`
+- WHEN `resolveBrand()` is called
+- THEN path-prefix resolution is skipped (segment contains ".")
+- AND default brand is returned
+
+---
+
+## Requirement: BrandProvider Wraps ThemeProvider
+
+`BrandProvider` exported from `@enterprise/brand/provider` MUST:
+- Accept `brand: BrandConfig` and `children: ReactNode` props
+- Seed `BrandContext` with the provided `brand`
+- Wrap children in `ThemeProvider` (imported from `@enterprise/ui`)
+- Derive `defaultMode`: `themeRef` ending in `"light"` → `"light"`, otherwise → `"dark"`
+
+### Scenario: useBrand() returns brand inside provider
+
+- GIVEN `BrandProvider` is rendered with `brand={enterpriseBrand}`
+- WHEN a descendant calls `useBrand()`
+- THEN it receives `enterpriseBrand`
+
+### Scenario: ThemeProvider receives derived mode
+
+- GIVEN `brand.themeRef = "enterprise-dark"`
+- WHEN `BrandProvider` renders
+- THEN `ThemeProvider` is mounted with `defaultMode="dark"`
+
+### Scenario: useBrand() throws outside provider
+
+- GIVEN a component calls `useBrand()` with no ancestor `BrandProvider`
+- WHEN the component renders
+- THEN it throws an error containing the string `"<BrandProvider>"`
+
+---
+
+## Requirement: BrandLogo Renders Correct Theme Variant
+
+`BrandLogo` exported from `@enterprise/brand/brand-logo` MUST:
+- Read `useBrand().logo` and `useTheme().mode`
+- Render `<img src alt>` for the active mode variant
+- Render `<span>{brand.displayName}</span>` when the active variant `src` is empty
+- Forward `className` to the root element
+
+### Scenario: Dark mode renders dark logo src
+
+- GIVEN theme mode is `"dark"` and `brand.logo.dark.src = "/logo-dark.svg"`
+- WHEN `BrandLogo` renders
+- THEN `<img src="/logo-dark.svg">` appears in the DOM
+
+### Scenario: Empty src renders displayName fallback
+
+- GIVEN `brand.logo.light.src = ""` and theme mode is `"light"`
+- WHEN `BrandLogo` renders
+- THEN a `<span>` containing `brand.displayName` is rendered (no `<img>`)
+
+---
+
+## Requirement: BrandFooter Renders Legal and Social Links
+
+`BrandFooter` exported from `@enterprise/brand/brand-footer` MUST:
+- Render `© {year} {brand.displayName}` copyright notice
+- Render legal `<a>` links only when the URL string is non-empty
+- Render social links when `brand.social` is defined
+- Render "Powered by" attribution when `brand.features?.showPoweredBy === true`
+
+### Scenario: Non-empty legal URL renders link
+
+- GIVEN `brand.legal.privacyUrl = "https://example.com/privacy"`
+- WHEN `BrandFooter` renders
+- THEN `<a href="https://example.com/privacy">` is present in the DOM
+
+### Scenario: Empty legal URL omits link
+
+- GIVEN `brand.legal.termsUrl = ""`
+- WHEN `BrandFooter` renders
+- THEN no `<a>` anchor with an empty or terms-related href is rendered
+
+---
+
+## Requirement: generateBrandMetadata() Maps to Next.js Metadata
+
+`generateBrandMetadata(brand: BrandConfig)` exported from `@enterprise/brand/metadata`
+MUST return a Next.js `Metadata` object with the following field mapping:
+
+| Output field | Source |
+|---|---|
+| `title.template` | `"%s \| " + brand.metadata.titleTemplate` |
+| `title.default` | `brand.metadata.titleTemplate` |
+| `description` | `brand.metadata.description` |
+| `icons.icon` | `brand.favicon` |
+| `openGraph.images` | `[brand.metadata.ogImage]` when non-empty, else `[]` |
+
+### Scenario: All metadata fields mapped correctly
+
+- GIVEN a BrandConfig with all metadata fields populated
+- WHEN `generateBrandMetadata(brand)` is called
+- THEN `title.default`, `description`, `icons.icon`, and `openGraph.images` match the mapping table
+
+### Scenario: Empty ogImage yields empty array
+
+- GIVEN `brand.metadata.ogImage = ""`
+- WHEN `generateBrandMetadata(brand)` is called
+- THEN `openGraph.images` is `[]`
+
+---
+
+## Test Coverage Map
+
+| Requirement | Unit test file | E2E coverage |
+|---|---|---|
+| resolveBrand() | `packages/brand/src/brand/__tests__/resolve.test.ts` | `ui/e2e/brand/brand.spec.ts` — BRAND_SLUG scenario |
+| BrandProvider / useBrand | `packages/brand/src/brand/__tests__/provider.test.ts` | `ui/e2e/brand/brand.spec.ts` — provider wraps |
+| BrandLogo | `packages/brand/src/brand/__tests__/brand-logo.test.ts` | `ui/e2e/brand/brand.spec.ts` — logo renders |
+| BrandFooter | `packages/brand/src/brand/__tests__/brand-footer.test.ts` | `ui/e2e/brand/brand.spec.ts` — footer renders |
+| generateBrandMetadata | `packages/brand/src/brand/__tests__/metadata.test.ts` | `ui/e2e/brand/brand.spec.ts` — metadata check |
+| registry | `packages/brand/src/brand/__tests__/registry.test.ts` | — |

--- a/openspec/specs/brand-boundary/spec.md
+++ b/openspec/specs/brand-boundary/spec.md
@@ -1,0 +1,143 @@
+# Spec: brand-boundary
+
+> **Domain**: brand-boundary
+> **Introduced by**: change #15 — brand-isolation (PRs #125, #126, #127; merged to main @ 92fcf6b)
+> **Status**: canonical — all requirements are ACTIVE
+
+---
+
+## Requirement: @enterprise/brand Package Export Contract
+
+The `@enterprise/brand` package MUST expose the following public subpath exports
+via `packages/brand/package.json`:
+
+| Export key | Purpose |
+|---|---|
+| `.` | Root barrel: BrandProvider, useBrand, BrandContext |
+| `./context` | BrandContext |
+| `./provider` | BrandProvider, useBrand |
+| `./resolve` | resolveBrand |
+| `./registry` | getBrand, getAllBrands, getDefaultBrand |
+| `./metadata` | generateBrandMetadata |
+| `./brand-logo` | BrandLogo |
+| `./brand-footer` | BrandFooter |
+
+Each export MUST resolve to a compiled ESM entry and a `.d.ts` declaration.
+
+### Scenario: Root barrel import resolves
+
+- GIVEN a consumer in `@enterprise/web`
+- WHEN it executes `import { BrandProvider, useBrand } from "@enterprise/brand"`
+- THEN both symbols resolve without TypeScript errors
+
+### Scenario: Subpath import resolves
+
+- GIVEN a consumer in `@enterprise/web`
+- WHEN it executes `import { resolveBrand } from "@enterprise/brand/resolve"`
+- THEN the symbol resolves without TypeScript errors
+
+### Scenario: Old @enterprise/ui brand subpath is gone
+
+- GIVEN a consumer
+- WHEN it attempts `import { BrandProvider } from "@enterprise/ui/brand/provider"`
+- THEN TypeScript reports an error (no matching key in `@enterprise/ui/package.json`)
+
+### Scenario: Brand configs remain importable
+
+- GIVEN a consumer
+- WHEN it executes `import { enterpriseBrand } from "@enterprise/brand"`
+  (or `@enterprise/brand/registry`)
+- THEN the config object resolves without errors
+
+---
+
+## Requirement: @enterprise/ui Zero Brand References
+
+`packages/ui/src/` MUST contain zero imports or re-exports of brand symbols.
+`packages/ui/package.json` MUST NOT declare any `./brand/*` subpath export keys.
+
+### Scenario: ui package.json has no brand export keys
+
+- GIVEN `packages/ui/package.json`
+- WHEN all `exports` keys are listed
+- THEN no key matches the pattern `./brand/*`
+
+### Scenario: ui source files have no brand imports
+
+- GIVEN all `.ts` and `.tsx` files under `packages/ui/src/`
+- WHEN scanned for references to brand module names
+  (`brand-provider`, `brand-logo`, `brand-footer`, `resolveBrand`, `BrandContext`, `useBrand`, `generateBrandMetadata`)
+- THEN zero matches are found
+
+### Scenario: ui barrel (index.ts) does not re-export brand symbols
+
+- GIVEN `packages/ui/src/index.ts`
+- WHEN compiled
+- THEN it does not export `BrandProvider`, `useBrand`, `BrandLogo`, `BrandFooter`
+
+---
+
+## Requirement: Dependency Boundary Enforcement
+
+`scripts/check-boundaries.mjs` MUST statically enforce the following import rules:
+
+| Rule | From | To | Verdict |
+|---|---|---|---|
+| FORBID | `@enterprise/ui` | `@enterprise/brand` | Exit non-zero |
+| ALLOW | `@enterprise/brand` | `@enterprise/ui` | Exit zero |
+| ALLOW | `@enterprise/brand` | `@enterprise/contracts` | Exit zero |
+| ALLOW | `@enterprise/web` | `@enterprise/brand` | Exit zero |
+
+### Scenario: ui→brand import is blocked
+
+- GIVEN a file in `packages/ui/src/` contains `import ... from "@enterprise/brand"`
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with a non-zero code and logs the offending file path
+
+### Scenario: brand→ui import is allowed
+
+- GIVEN `packages/brand/src/` imports from `@enterprise/ui` (e.g., `cn`, `ThemeProvider`)
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with code 0
+
+### Scenario: web→brand import is allowed
+
+- GIVEN `ui/app/layout.tsx` contains `import { BrandProvider } from "@enterprise/brand"`
+- WHEN `node scripts/check-boundaries.mjs` runs
+- THEN it exits with code 0
+
+### Scenario: Clean baseline — no violations at merge
+
+- GIVEN the brand-isolation PR branch is fully applied
+- WHEN `node scripts/check-boundaries.mjs` runs on the entire monorepo
+- THEN it exits with code 0 and reports zero violations
+
+---
+
+## Requirement: Root Layout Import Rewire
+
+`ui/app/layout.tsx` MUST import brand symbols exclusively from `@enterprise/brand`.
+No `@enterprise/ui/brand/*` import path MAY remain in the file.
+
+### Scenario: layout.tsx uses new package
+
+- GIVEN `ui/app/layout.tsx`
+- WHEN its import declarations are read
+- THEN every brand-related import references `@enterprise/brand` (not `@enterprise/ui`)
+
+### Scenario: Layout still renders with BrandProvider
+
+- GIVEN the root layout is loaded in a Next.js server render
+- WHEN the page is requested
+- THEN `BrandProvider` is present in the React tree wrapping all children
+
+---
+
+## Test Coverage Map
+
+| Requirement | Verification method |
+|---|---|
+| Package export contract | `pnpm typecheck` (no TS errors); negative gate — TS2307 on old path |
+| Zero ui brand refs | `grep -r brand packages/ui/src` returns zero matches |
+| Dependency boundary enforcement | `node scripts/check-boundaries.mjs` exits 0 |
+| Root layout import rewire | `pnpm typecheck` + `pnpm e2e --grep brand` |


### PR DESCRIPTION
## Summary

- Closes the `brand-isolation` change (roadmap #15) now that all 3 implementation PRs (#125, #126, #127) are merged to main.
- Marks roadmap item #15 **Done**.
- Promotes the `brand-boundary` and `brand-behavior` delta specs to canonical `openspec/specs/` and archives the change folder under `openspec/changes/archive/2026-06-01-brand-isolation/`.

## Changes

| File | Change |
|------|--------|
| `docs/features/roadmap.md` | #15 Brand isolation package → Done |
| `openspec/specs/brand-boundary/spec.md` | New canonical spec (package export contract, zero-brand-refs-in-ui, dependency boundary) |
| `openspec/specs/brand-behavior/spec.md` | New canonical spec (resolveBrand, BrandProvider/useBrand, BrandLogo/BrandFooter, generateBrandMetadata) |
| `openspec/changes/archive/2026-06-01-brand-isolation/**` | Archived proposal/design/tasks/specs + archive-report |

## Verification

- [x] Docs-only change (no code) — `Detect Changes` will skip build/test/E2E
- [x] All code already merged and verified across #125–#127

## Notes

- Next roadmap item: **P1 #17 — Test and CI stability hardening** (the pre-existing flaky E2E baseline that all 3 brand-isolation PRs merged past).
