### PR TITLE
fix(theme): derive SSR data-theme from brand, fix theme E2E [e2e-stability 1/3]

### DIFF
--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -11,7 +11,8 @@
     "./registry": "./src/brand/registry.ts",
     "./metadata": "./src/brand/metadata.ts",
     "./brand-logo": "./src/brand/brand-logo.tsx",
-    "./brand-footer": "./src/brand/brand-footer.tsx"
+    "./brand-footer": "./src/brand/brand-footer.tsx",
+    "./theme-mode": "./src/brand/theme-mode.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/brand/src/brand/__tests__/theme-mode.test.ts
+++ b/packages/brand/src/brand/__tests__/theme-mode.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveThemeMode } from "../theme-mode";
+
+describe("deriveThemeMode", () => {
+  it("returns 'light' when themeRef is exactly 'light'", () => {
+    expect(deriveThemeMode("light")).toBe("light");
+  });
+
+  it("returns 'dark' when themeRef is exactly 'dark'", () => {
+    expect(deriveThemeMode("dark")).toBe("dark");
+  });
+
+  it("returns 'light' when themeRef ends with 'light' (e.g. 'acme-light')", () => {
+    expect(deriveThemeMode("acme-light")).toBe("light");
+  });
+
+  it("returns 'dark' when themeRef does NOT end with 'light' (e.g. 'acme-dark')", () => {
+    expect(deriveThemeMode("acme-dark")).toBe("dark");
+  });
+});

--- a/packages/brand/src/brand/provider.tsx
+++ b/packages/brand/src/brand/provider.tsx
@@ -4,6 +4,7 @@ import type { BrandConfig } from "@enterprise/contracts";
 import { ThemeProvider } from "@enterprise/ui/theme/provider";
 import { useContext } from "react";
 import { BrandContext } from "./context";
+import { deriveThemeMode } from "./theme-mode";
 
 // ============================================================================
 // BrandProvider
@@ -25,9 +26,10 @@ export interface BrandProviderProps {
 }
 
 export function BrandProvider({ children, brand, defaultMode }: BrandProviderProps) {
-  // Derive initial theme mode from themeRef if not explicitly provided
-  const resolvedDefaultMode: "light" | "dark" =
-    defaultMode ?? (brand.themeRef.endsWith("light") ? "light" : "dark");
+  // Derive initial theme mode from themeRef if not explicitly provided.
+  // Uses the shared deriveThemeMode helper so layout.tsx and BrandProvider
+  // always apply the same rule.
+  const resolvedDefaultMode: "light" | "dark" = defaultMode ?? deriveThemeMode(brand.themeRef);
 
   return (
     <BrandContext value={{ brand }}>

--- a/packages/brand/src/brand/theme-mode.ts
+++ b/packages/brand/src/brand/theme-mode.ts
@@ -1,0 +1,19 @@
+/**
+ * Theme mode utilities.
+ *
+ * Pure functions — no React, no next/headers, no side-effects.
+ * Safe to import in Server Components, Client Components, AND Playwright helpers.
+ */
+
+export type ThemeMode = "light" | "dark";
+
+/**
+ * Derives the initial theme mode from a brand's `themeRef`.
+ *
+ * Rule (mirrors BrandProvider + layout.tsx SSR):
+ *   themeRef.endsWith("light") → "light"
+ *   otherwise                 → "dark"
+ */
+export function deriveThemeMode(themeRef: string): ThemeMode {
+  return themeRef.endsWith("light") ? "light" : "dark";
+}

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -20,3 +20,5 @@ export {
   getDefaultBrand,
 } from "./brand/registry";
 export { resolveBrand, resolveBrandFromRegistry } from "./brand/resolve";
+export type { ThemeMode } from "./brand/theme-mode";
+export { deriveThemeMode } from "./brand/theme-mode";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
       "@enterprise/brand/metadata": ["packages/brand/src/brand/metadata"],
       "@enterprise/brand/brand-logo": ["packages/brand/src/brand/brand-logo"],
       "@enterprise/brand/brand-footer": ["packages/brand/src/brand/brand-footer"],
+      "@enterprise/brand/theme-mode": ["packages/brand/src/brand/theme-mode"],
       "@enterprise/brand/*": ["packages/brand/src/*"],
       "@/*": ["ui/*"]
     }

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,6 +1,7 @@
 import { generateBrandMetadata } from "@enterprise/brand/metadata";
 import { BrandProvider } from "@enterprise/brand/provider";
 import { resolveBrand } from "@enterprise/brand/resolve";
+import { deriveThemeMode } from "@enterprise/brand/theme-mode";
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono, Plus_Jakarta_Sans, Space_Grotesk } from "next/font/google";
 import { Toaster } from "sonner";
@@ -33,11 +34,15 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const brand = await resolveBrand();
+  // Derive the initial theme from the brand so SSR and client-side hydration
+  // always agree.  ThemeProvider reads the same brand.themeRef via deriveThemeMode,
+  // so on a fresh visit (empty localStorage) there is no post-hydration flip.
+  const initialThemeMode = deriveThemeMode(brand.themeRef);
 
   return (
     <html
       lang="en"
-      data-theme="dark"
+      data-theme={initialThemeMode}
       suppressHydrationWarning
       className={`${inter.variable} ${jetbrainsMono.variable} ${plusJakartaSans.variable} ${spaceGrotesk.variable}`}
     >

--- a/ui/e2e/helpers/theme.ts
+++ b/ui/e2e/helpers/theme.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared theme constants for Playwright E2E helpers.
+ *
+ * GATE-1 decision: getBrandRegistry() uses a dynamic require() that fails in the
+ * Playwright Node.js runtime (ESM context).  We use the direct import fallback:
+ * import the default enterprise brand config and call deriveThemeMode() on its
+ * themeRef.  This is type-safe, deterministic, and tracks brand.themeRef changes.
+ */
+
+// Direct brand config import — avoids getBrandRegistry() require() in ESM runtime.
+// Resolved via tsconfig paths: @enterprise/brand/* → packages/brand/src/*
+import enterpriseBrand from "@enterprise/brand/brands/enterprise.brand";
+// "type": "module" + @enterprise/brand/theme-mode is a pure function (no React,
+// no next/headers) — safe in Playwright runtime once the tsconfig path is wired.
+import { deriveThemeMode } from "@enterprise/brand/theme-mode";
+
+/**
+ * The expected data-theme value for a fresh (empty localStorage) page load.
+ * Derived from the default brand's themeRef so it stays in sync with brand config.
+ *
+ * Enterprise brand:  themeRef = "light"  →  EXPECTED_DEFAULT_THEME = "light"
+ */
+export const EXPECTED_DEFAULT_THEME: "light" | "dark" = deriveThemeMode(enterpriseBrand.themeRef);

--- a/ui/e2e/theme/theme.spec.ts
+++ b/ui/e2e/theme/theme.spec.ts
@@ -1,27 +1,45 @@
 import { expect, test } from "@playwright/test";
 import { login } from "../helpers/auth";
 import { ROUTES } from "../helpers/routes";
+import { EXPECTED_DEFAULT_THEME } from "../helpers/theme";
 
 /**
  * Theme E2E Tests — T4.10
  *
  * Tests:
- * - Page loads with data-theme="dark" by default
+ * - SSR emits data-theme matching brand default (no-flash, no hydration mismatch)
  * - Theme toggle button is visible in the dashboard header
- * - Theme toggle switches to light mode (data-theme changes)
- * - Theme toggle switches back to dark
- * - Theme preference persists across navigation (localStorage)
+ * - Theme toggle switches between modes (light ↔ dark)
+ * - Theme preference persists via localStorage
  *
  * Note: The ThemeToggle is rendered in the dashboard header (requires auth).
- * The default data-theme check is verifiable without auth (see layout.tsx).
+ * The SSR data-theme checks are verifiable without auth (see layout.tsx).
  */
 
 test.describe("Theme System", () => {
-  test("sign-in page loads with data-theme=dark by default", async ({ page }) => {
-    await page.goto("/sign-in");
+  /**
+   * SSR no-flash — proves layout.tsx derives data-theme from brand.themeRef,
+   * not a hard-coded literal.  RED: layout.tsx still has data-theme="dark".
+   */
+  test("SSR HTML contains brand-derived data-theme (no hard-coded literal)", async ({ page }) => {
+    // Raw HTTP — no JS execution, proves SSR rendered the correct value.
+    const response = await page.request.get("/sign-in");
+    const html = await response.text();
+    expect(html).toContain(`data-theme="${EXPECTED_DEFAULT_THEME}"`);
+  });
 
-    const htmlElement = page.locator("html");
-    await expect(htmlElement).toHaveAttribute("data-theme", "dark");
+  test("sign-in page data-theme matches brand default and is stable after hydration", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await page.waitForLoadState("networkidle");
+
+    const htmlEl = page.locator("html");
+    await expect(htmlEl).toHaveAttribute("data-theme", EXPECTED_DEFAULT_THEME);
+
+    // Attribute must not flip after ~1 s (no-flash guarantee).
+    await page.waitForTimeout(1000);
+    await expect(htmlEl).toHaveAttribute("data-theme", EXPECTED_DEFAULT_THEME);
   });
 
   test("html element has suppressHydrationWarning (no mismatch errors)", async ({ page }) => {
@@ -44,6 +62,11 @@ test.describe("Theme System", () => {
     test.beforeEach(async ({ page }) => {
       await login(page);
       await page.waitForURL(new RegExp(ROUTES.dashboard));
+      // Clear localStorage so each test starts from the brand default theme.
+      // This prevents prior test runs from leaking a stored preference.
+      await page.evaluate(() => localStorage.clear());
+      await page.reload();
+      await page.waitForLoadState("networkidle");
     });
 
     test("theme toggle button is visible in dashboard header", async ({ page }) => {
@@ -51,52 +74,56 @@ test.describe("Theme System", () => {
       await expect(toggleButton).toBeVisible();
     });
 
-    test("clicking theme toggle switches from dark to light mode", async ({ page }) => {
-      // Ensure we start in dark mode
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    test("clicking theme toggle switches from default to opposite mode", async ({ page }) => {
+      // Confirm we start at the brand default.
+      await expect(page.locator("html")).toHaveAttribute("data-theme", EXPECTED_DEFAULT_THEME);
 
       const toggleButton = page.getByRole("button", { name: "Toggle theme" });
       await toggleButton.click();
 
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+      // After one click we are on the opposite mode.
+      const opposite = EXPECTED_DEFAULT_THEME === "light" ? "dark" : "light";
+      await expect(page.locator("html")).toHaveAttribute("data-theme", opposite);
     });
 
-    test("clicking theme toggle again switches back to dark mode", async ({ page }) => {
+    test("clicking theme toggle twice returns to default mode", async ({ page }) => {
       const toggleButton = page.getByRole("button", { name: "Toggle theme" });
 
-      // Switch to light
+      // Toggle to opposite.
       await toggleButton.click();
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+      const opposite = EXPECTED_DEFAULT_THEME === "light" ? "dark" : "light";
+      await expect(page.locator("html")).toHaveAttribute("data-theme", opposite);
 
-      // Switch back to dark
+      // Toggle back to default.
       await toggleButton.click();
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+      await expect(page.locator("html")).toHaveAttribute("data-theme", EXPECTED_DEFAULT_THEME);
     });
 
     test("theme preference persists to localStorage", async ({ page }) => {
       const toggleButton = page.getByRole("button", { name: "Toggle theme" });
 
-      // Switch to light mode
+      // Toggle once — localStorage must reflect the new (opposite) mode.
       await toggleButton.click();
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+      const opposite = EXPECTED_DEFAULT_THEME === "light" ? "dark" : "light";
+      await expect(page.locator("html")).toHaveAttribute("data-theme", opposite);
 
-      // Verify localStorage was updated
       const storedTheme = await page.evaluate(() => localStorage.getItem("enterprise-theme-mode"));
-      expect(storedTheme).toBe("light");
+      expect(storedTheme).toBe(opposite);
     });
 
     test("theme preference is restored from localStorage on navigation", async ({ page }) => {
-      // Set localStorage to light before navigation
-      await page.evaluate(() => {
-        localStorage.setItem("enterprise-theme-mode", "light");
-      });
+      // Seed localStorage with the opposite theme.
+      const opposite = EXPECTED_DEFAULT_THEME === "light" ? "dark" : "light";
+      await page.evaluate((mode) => {
+        localStorage.setItem("enterprise-theme-mode", mode);
+      }, opposite);
 
-      // Navigate to another dashboard page
+      // Navigate to another dashboard page.
       await page.goto(ROUTES.settings);
       await page.waitForLoadState("networkidle");
 
-      // data-theme should be restored to light from localStorage
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+      // data-theme should be restored from localStorage.
+      await expect(page.locator("html")).toHaveAttribute("data-theme", opposite);
     });
   });
 });

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -28,6 +28,7 @@
       "@enterprise/brand/metadata": ["../packages/brand/src/brand/metadata"],
       "@enterprise/brand/brand-logo": ["../packages/brand/src/brand/brand-logo"],
       "@enterprise/brand/brand-footer": ["../packages/brand/src/brand/brand-footer"],
+      "@enterprise/brand/theme-mode": ["../packages/brand/src/brand/theme-mode"],
       "@enterprise/brand/*": ["../packages/brand/src/*"]
     },
     "noEmit": true,


### PR DESCRIPTION
## Summary

- **Slice 1 of 3** for `e2e-stability-hardening` (roadmap P1 #17, flaky-E2E leg). Fixes the always-failing `theme.spec.ts` (4 tests) AND removes the real dark→light hydration flash.
- **Root cause**: the brand-abstraction change (#14) made the enterprise brand default to `themeRef: "light"`, but `ui/app/layout.tsx` still hard-coded `data-theme="dark"`. The client re-set it to "light" after hydration → visible flash, and the theme E2E (asserting "dark") failed deterministically.
- **Fix (Option B, approved)**: derive the SSR `data-theme` from the resolved brand via a new shared pure helper `deriveThemeMode(themeRef)` used by BOTH `layout.tsx` (server) and `BrandProvider` (client) — single source of truth, no flash for any brand.

## Changes

| File | Change |
|------|--------|
| `packages/brand/src/brand/theme-mode.ts` | **New** pure `deriveThemeMode(themeRef): "light" \| "dark"` (`endsWith("light")` rule) |
| `packages/brand/src/brand/__tests__/theme-mode.test.ts` | **New** 4 unit tests |
| `packages/brand/src/brand/provider.tsx` | Use `deriveThemeMode()` instead of inline ternary (behavior unchanged) |
| `packages/brand/package.json`, `src/index.ts` | `./theme-mode` subpath export + barrel re-export |
| `tsconfig.json`, `ui/tsconfig.json` | `@enterprise/brand/theme-mode` path mapping |
| `ui/app/layout.tsx` | `data-theme={deriveThemeMode(brand.themeRef)}` — no more literal "dark" |
| `ui/e2e/helpers/theme.ts` | **New** `EXPECTED_DEFAULT_THEME` (derived, not a magic string) |
| `ui/e2e/theme/theme.spec.ts` | Assertions use `EXPECTED_DEFAULT_THEME`; SSR no-flash test; corrected light→dark→light toggle; `localStorage.clear()` in beforeEach |

## Verification

- [x] `pnpm typecheck` (7/7)
- [x] `pnpm lint` (348 files, 0 errors)
- [x] `pnpm test` (brand 49 incl. new theme-mode tests + all projects green)
- [x] `node scripts/check-boundaries.mjs` passes
- [x] `pnpm install --frozen-lockfile` passes
- [x] Theme E2E: 8/8 passed, run isolated **twice consecutively**
- [x] No `any` types

> Strict TDD: `deriveThemeMode` unit test RED→GREEN; SSR no-flash E2E RED (html was "dark") → GREEN (derived). `BrandProvider` refactor keeps all brand tests green.
>
> Scope: this slice fixes ONLY the theme specs + the SSR flash. The other pre-existing flaky specs (notifications, team-management, workspace-admin, password-reset) are addressed in Slice 2 (#determinism) and Slice 3 (Mailpit/CI). Their failures in this PR's CI run are the same pre-existing P1 #17 baseline.

## Notes for reviewers

- `deriveThemeMode` is a pure function (no React / no `next/headers`) so it is safe in Server Components, Client Components, and the Playwright runtime.
- GATE-1: `getBrandRegistry()`'s dynamic `require()` does not resolve in the Playwright ESM runtime, so the E2E helper imports the brand config directly + `deriveThemeMode` rather than going through the registry.
