### PR TITLE
test(e2e): isolate stateful specs with afterEach restores [e2e-stability 2/3]

### DIFF
--- a/ui/e2e/helpers/supabase-rest.ts
+++ b/ui/e2e/helpers/supabase-rest.ts
@@ -118,3 +118,21 @@ export async function deleteRows(table: string, filters: Record<string, string>)
     params: filters,
   });
 }
+
+/**
+ * PATCHes rows in a table matching the given PostgREST filter params.
+ * Used for idempotent E2E state restoration in afterEach hooks.
+ * Uses the service-role key — bypasses RLS. Safe only in E2E teardown.
+ */
+export async function updateRows(
+  table: string,
+  filters: Record<string, string>,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  await supabaseRequest(table, {
+    method: "PATCH",
+    params: filters,
+    headers: { Prefer: "return=minimal" },
+    body: patch,
+  });
+}

--- a/ui/e2e/notifications/notifications-page.ts
+++ b/ui/e2e/notifications/notifications-page.ts
@@ -100,6 +100,15 @@ export class NotificationsPage {
     await expect(this.page.locator('[role="status"]').first()).toBeVisible({ timeout: 10_000 });
   }
 
+  /**
+   * Asserts exactly n unread dots are visible.
+   * Use instead of waitForTimeout after marking a notification as read —
+   * this waits for the optimistic update to settle rather than a fixed delay.
+   */
+  async expectUnreadDotCount(n: number): Promise<void> {
+    await expect(this.page.locator('[role="status"]')).toHaveCount(n, { timeout: 10_000 });
+  }
+
   // ─── Mark all read ─────────────────────────────────────────────────────────
 
   async clickMarkAllAsRead(): Promise<void> {

--- a/ui/e2e/notifications/notifications.spec.ts
+++ b/ui/e2e/notifications/notifications.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { login } from "../helpers/auth";
 import { ROUTES } from "../helpers/routes";
+import { updateRows } from "../helpers/supabase-rest";
 import { NotificationPreferencesPage, NotificationsPage } from "./notifications-page";
 
 // ─── Credentials ──────────────────────────────────────────────────────────────
@@ -19,6 +20,20 @@ const PASSWORD = "password123";
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test.describe("Notifications", () => {
+  // ─── Cross-describe isolation ─────────────────────────────────────────────
+  // Reset both member notification rows to unread after every test.
+  // Prevents the "mark as read" mutation in one test from contaminating
+  // the unread-filter assertion in another describe block.
+  test.afterEach(async () => {
+    await updateRows(
+      "notifications",
+      {
+        id: "in.(c0000001-0000-0000-0000-000000000001,c0000001-0000-0000-0000-000000000005)",
+      },
+      { is_read: false, read_at: null },
+    );
+  });
+
   // ─── Bell visibility ─────────────────────────────────────────────────────
 
   test.describe("Notification bell", () => {
@@ -69,13 +84,11 @@ test.describe("Notifications", () => {
       await notificationsPage.clickFirstUnreadNotification();
 
       // After the optimistic update the unread dot for that item should be gone.
-      // Allow a moment for optimistic update to apply.
-      await page.waitForTimeout(500);
+      // State-based wait: member starts with 2 unread, marking one leaves 1.
+      // toHaveCount retries up to 10 s — no fixed sleep needed.
+      await notificationsPage.expectUnreadDotCount(1);
 
-      // Seed has 2 unread items for member; after marking one the list may still
-      // show 1 unread dot (the other item). We verify the action triggered a refresh
-      // by checking the bell aria-label updated or there are fewer unread dots.
-      // The safest assertion is that the page remains on /notifications.
+      // Verify we remain on the notifications page (no unexpected navigation)
       await expect(page).toHaveURL(new RegExp(ROUTES.notifications));
     });
 

--- a/ui/e2e/notifications/notifications.spec.ts
+++ b/ui/e2e/notifications/notifications.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { login } from "../helpers/auth";
 import { ROUTES } from "../helpers/routes";
-import { updateRows } from "../helpers/supabase-rest";
+import { supabaseRequest, updateRows } from "../helpers/supabase-rest";
 import { NotificationPreferencesPage, NotificationsPage } from "./notifications-page";
 
 // ─── Credentials ──────────────────────────────────────────────────────────────
@@ -21,19 +21,50 @@ const PASSWORD = "password123";
 
 test.describe("Notifications", () => {
   // ─── Cross-describe isolation ─────────────────────────────────────────────
-  // Reset both member notification rows to unread after every test.
-  // Prevents the "mark as read" mutation in one test from contaminating
-  // the unread-filter assertion in another describe block.
+  // After every test:
+  //   1. Reset the two seeded member notification rows back to unread=false.
+  //   2. Delete any extra notifications created by other spec runs (e.g., the
+  //      "team_role_changed" notifications emitted by team-management.spec tests
+  //      when they change member@enterprise.dev's role). These accumulate across
+  //      suite runs and skew the unread-dot count in subsequent tests.
   // Best-effort: teardown failures must not mask actual test outcomes.
+  //
+  // Seeded notification IDs for member@enterprise.dev:
+  //   c0000001-0000-0000-0000-000000000001  (team_invited — unread)
+  //   c0000001-0000-0000-0000-000000000005  (team_role_changed — unread)
+  // All other seeded IDs (owner + admin user notifications) are left untouched.
+
+  // All 5 seeded notification IDs (owner, admin, member) — nothing else should exist.
+  const SEEDED_NOTIFICATION_IDS =
+    "c0000001-0000-0000-0000-000000000001," +
+    "c0000001-0000-0000-0000-000000000002," +
+    "c0000001-0000-0000-0000-000000000003," +
+    "c0000001-0000-0000-0000-000000000004," +
+    "c0000001-0000-0000-0000-000000000005";
+
+  // member@enterprise.dev user id (from seed.sql)
+  const MEMBER_USER_ID = "b1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
   test.afterEach(async () => {
     try {
+      // 1. Reset seeded member notifications to unread
       await updateRows(
         "notifications",
         {
-          id: "in.(c0000001-0000-0000-0000-000000000001,c0000001-0000-0000-0000-000000000005)",
+          id: `in.(c0000001-0000-0000-0000-000000000001,c0000001-0000-0000-0000-000000000005)`,
         },
         { is_read: false, read_at: null },
       );
+
+      // 2. Delete any non-seeded notifications for the member (e.g., created
+      //    by team-management tests that change the member's role)
+      await supabaseRequest("notifications", {
+        method: "DELETE",
+        params: {
+          user_id: `eq.${MEMBER_USER_ID}`,
+          id: `not.in.(${SEEDED_NOTIFICATION_IDS})`,
+        },
+      });
     } catch (err) {
       // Log but do not rethrow — a teardown failure must not fail the test itself.
       // In CI the schema cache is always fresh; locally reload with:
@@ -91,9 +122,12 @@ test.describe("Notifications", () => {
       // Click the first unread notification to mark it as read
       await notificationsPage.clickFirstUnreadNotification();
 
-      // After the optimistic update the unread dot for that item should be gone.
-      // State-based wait: member starts with 2 unread, marking one leaves 1.
-      // toHaveCount retries up to 10 s — no fixed sleep needed.
+      // Wait for the RSC router.refresh() round-trip to complete so the
+      // component tree is stable before we assert the exact dot count.
+      await page.waitForLoadState("networkidle");
+
+      // After the optimistic update + server refresh the unread dot for that
+      // item should be gone. Member has 2 unread → marking one leaves 1.
       await notificationsPage.expectUnreadDotCount(1);
 
       // Verify we remain on the notifications page (no unexpected navigation)

--- a/ui/e2e/notifications/notifications.spec.ts
+++ b/ui/e2e/notifications/notifications.spec.ts
@@ -24,14 +24,22 @@ test.describe("Notifications", () => {
   // Reset both member notification rows to unread after every test.
   // Prevents the "mark as read" mutation in one test from contaminating
   // the unread-filter assertion in another describe block.
+  // Best-effort: teardown failures must not mask actual test outcomes.
   test.afterEach(async () => {
-    await updateRows(
-      "notifications",
-      {
-        id: "in.(c0000001-0000-0000-0000-000000000001,c0000001-0000-0000-0000-000000000005)",
-      },
-      { is_read: false, read_at: null },
-    );
+    try {
+      await updateRows(
+        "notifications",
+        {
+          id: "in.(c0000001-0000-0000-0000-000000000001,c0000001-0000-0000-0000-000000000005)",
+        },
+        { is_read: false, read_at: null },
+      );
+    } catch (err) {
+      // Log but do not rethrow — a teardown failure must not fail the test itself.
+      // In CI the schema cache is always fresh; locally reload with:
+      //   supabase db reset  OR  NOTIFY pgrst, 'reload schema';
+      console.warn("[afterEach] notifications restore failed (schema cache?):", err);
+    }
   });
 
   // ─── Bell visibility ─────────────────────────────────────────────────────

--- a/ui/e2e/tenant-team-management/team-management-page.ts
+++ b/ui/e2e/tenant-team-management/team-management-page.ts
@@ -7,6 +7,11 @@ export class TeamManagementPage {
   async goto(): Promise<void> {
     await this.page.goto(ROUTES.team);
     await this.page.waitForURL(new RegExp(ROUTES.team));
+    // Content-ready guard: ensures the Members heading is rendered before
+    // any test interaction, preventing flaky selector misses on slow CI.
+    await expect(this.page.getByRole("heading", { name: "Members" })).toBeVisible({
+      timeout: 30_000,
+    });
   }
 
   // ─── Invite Member ─────────────────────────────────────────────────────────

--- a/ui/e2e/tenant-team-management/team-management.spec.ts
+++ b/ui/e2e/tenant-team-management/team-management.spec.ts
@@ -77,7 +77,12 @@ test.describe("Team Management", () => {
     test.afterEach(async () => {
       // Restore member@enterprise.dev role to its seeded value after every test,
       // even on failure — prevents role contamination across tests.
-      await updateRows("profiles", { email: "eq.member@enterprise.dev" }, { role: "member" });
+      // Best-effort: teardown failures must not mask actual test outcomes.
+      try {
+        await updateRows("profiles", { email: "eq.member@enterprise.dev" }, { role: "member" });
+      } catch (err) {
+        console.warn("[afterEach] team-management role restore failed:", err);
+      }
     });
 
     test("admin can view team members list", async ({ page }) => {

--- a/ui/e2e/tenant-team-management/team-management.spec.ts
+++ b/ui/e2e/tenant-team-management/team-management.spec.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { expect, test } from "@playwright/test";
 import { login } from "../helpers/auth";
 import { ROUTES } from "../helpers/routes";
-import { deleteRows, seedRows, supabaseRequest } from "../helpers/supabase-rest";
+import { deleteRows, seedRows, supabaseRequest, updateRows } from "../helpers/supabase-rest";
 import { TeamManagementPage } from "./team-management-page";
 
 // ─── Seed helpers ─────────────────────────────────────────────────────────────
@@ -74,6 +74,12 @@ test.describe("Team Management", () => {
       await teardownTestMembers();
     });
 
+    test.afterEach(async () => {
+      // Restore member@enterprise.dev role to its seeded value after every test,
+      // even on failure — prevents role contamination across tests.
+      await updateRows("profiles", { email: "eq.member@enterprise.dev" }, { role: "member" });
+    });
+
     test("admin can view team members list", async ({ page }) => {
       const teamPage = new TeamManagementPage(page);
 
@@ -143,12 +149,7 @@ test.describe("Team Management", () => {
           .filter({ hasText: "member@enterprise.dev" })
           .getByText("Guest"),
       ).toBeVisible({ timeout: 30_000 });
-
-      // Restore original role
-      await teamPage.openChangeRoleDialog("member@enterprise.dev");
-      await teamPage.selectNewRole("Member");
-      await teamPage.submitChangeRole();
-      await expect(page.getByRole("dialog")).toHaveCount(0);
+      // Role restoration handled by test.afterEach (PATCH profiles via service-role)
     });
 
     test("admin can remove a member", async ({ page }) => {

--- a/ui/e2e/workspace-admin/workspace-admin-page.ts
+++ b/ui/e2e/workspace-admin/workspace-admin-page.ts
@@ -9,6 +9,11 @@ export class WorkspaceAdminPage {
   async goto(): Promise<void> {
     await this.page.goto(ROUTES.settings);
     await this.page.waitForURL(new RegExp(ROUTES.settings), { timeout: 10_000 });
+    // Content-ready guard: ensures the Settings heading is rendered before
+    // any test interaction, preventing flaky selector misses on slow CI.
+    await expect(this.page.getByRole("heading", { name: "Settings" })).toBeVisible({
+      timeout: 30_000,
+    });
   }
 
   async expectRedirectedToDashboard(): Promise<void> {

--- a/ui/e2e/workspace-admin/workspace-admin.spec.ts
+++ b/ui/e2e/workspace-admin/workspace-admin.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from "@playwright/test";
 import { AuthPage } from "../auth/auth-page";
 import { login } from "../helpers/auth";
 import { ROUTES } from "../helpers/routes";
+import { supabaseRequest, updateRows } from "../helpers/supabase-rest";
 import { WorkspaceAdminPage } from "./workspace-admin-page";
 
 // ─── Credentials ──────────────────────────────────────────────────────────────
@@ -47,6 +48,20 @@ test.describe("Workspace Admin Settings", () => {
   // ─── Owner flows ────────────────────────────────────────────────────────────
 
   test.describe("Owner flows", () => {
+    test.afterEach(async () => {
+      // Restore slug and allow_admin_invites to their seeded values after every
+      // owner test, even on failure — prevents state contamination across runs.
+      const [profile] = await supabaseRequest<Array<{ tenant_id: string }>>("profiles", {
+        params: { email: "eq.admin@enterprise.dev", select: "tenant_id", limit: "1" },
+      });
+      if (!profile?.tenant_id) return;
+      await updateRows(
+        "tenants",
+        { id: `eq.${profile.tenant_id}` },
+        { slug: "enterprise-demo", allow_admin_invites: true },
+      );
+    });
+
     test("settings tabs keep stable URL and no secondary sidebar", async ({ page }) => {
       const settingsPage = new WorkspaceAdminPage(page);
 
@@ -100,13 +115,7 @@ test.describe("Workspace Admin Settings", () => {
       await settingsPage.confirmSlugDialog();
 
       await settingsPage.expectSlugSaved();
-
-      // Restore original slug so subsequent test runs work correctly
-      await settingsPage.fillSlug("enterprise-demo");
-      await settingsPage.saveProfile();
-      await settingsPage.expectSlugDialogVisible();
-      await settingsPage.confirmSlugDialog();
-      await settingsPage.expectSlugSaved();
+      // Slug restoration handled by test.afterEach (PATCH tenants via service-role)
     });
 
     test("owner cancels slug change", async ({ page }) => {
@@ -163,11 +172,7 @@ test.describe("Workspace Admin Settings", () => {
       await settingsPage.saveSecurity();
 
       await settingsPage.expectSecuritySaved();
-
-      // Toggle back to restore original state for subsequent test runs
-      await settingsPage.toggleSecurity();
-      await settingsPage.saveSecurity();
-      await settingsPage.expectSecuritySaved();
+      // Security flag restoration handled by test.afterEach (PATCH tenants via service-role)
     });
   });
 

--- a/ui/e2e/workspace-admin/workspace-admin.spec.ts
+++ b/ui/e2e/workspace-admin/workspace-admin.spec.ts
@@ -51,15 +51,20 @@ test.describe("Workspace Admin Settings", () => {
     test.afterEach(async () => {
       // Restore slug and allow_admin_invites to their seeded values after every
       // owner test, even on failure — prevents state contamination across runs.
-      const [profile] = await supabaseRequest<Array<{ tenant_id: string }>>("profiles", {
-        params: { email: "eq.admin@enterprise.dev", select: "tenant_id", limit: "1" },
-      });
-      if (!profile?.tenant_id) return;
-      await updateRows(
-        "tenants",
-        { id: `eq.${profile.tenant_id}` },
-        { slug: "enterprise-demo", allow_admin_invites: true },
-      );
+      // Best-effort: teardown failures must not mask actual test outcomes.
+      try {
+        const [profile] = await supabaseRequest<Array<{ tenant_id: string }>>("profiles", {
+          params: { email: "eq.admin@enterprise.dev", select: "tenant_id", limit: "1" },
+        });
+        if (!profile?.tenant_id) return;
+        await updateRows(
+          "tenants",
+          { id: `eq.${profile.tenant_id}` },
+          { slug: "enterprise-demo", allow_admin_invites: true },
+        );
+      } catch (err) {
+        console.warn("[afterEach] workspace-admin restore failed:", err);
+      }
     });
 
     test("settings tabs keep stable URL and no secondary sidebar", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Slice 2 of 3** for `e2e-stability-hardening` (roadmap P1 #17). Makes the stateful E2E specs order-independent and failure-safe. Test-only — no production code.
- Fixes the post-Slice-1 CI failures: `notifications.spec.ts:131` (unread filter contaminated by prior mark-read tests) and `team-management.spec.ts:104/123` + `workspace-admin` (inline state restores that didn't run on failure + Server Component render timing).

## Changes

| File | Change |
|------|--------|
| `ui/e2e/helpers/supabase-rest.ts` | New idempotent `updateRows(table, filters, patch)` PATCH helper |
| `ui/e2e/tenant-team-management/team-management.spec.ts` | Move role restore to best-effort `afterEach` (runs on failure) |
| `ui/e2e/tenant-team-management/team-management-page.ts` | `goto()` waits for "Members" heading (content-ready, no `waitForTimeout`) |
| `ui/e2e/workspace-admin/workspace-admin.spec.ts` | Move slug + `allow_admin_invites` restore to `afterEach` |
| `ui/e2e/workspace-admin/workspace-admin-page.ts` | `goto()` waits for Settings heading |
| `ui/e2e/notifications/notifications.spec.ts` | Top-level `afterEach`: reset seeded rows to unread + purge member's non-seeded notifications; replace `waitForTimeout(500)` with state-based wait |
| `ui/e2e/notifications/notifications-page.ts` | New `expectUnreadDotCount(n)` (`toHaveCount`) |

## Verification

- [x] `pnpm typecheck` (7/7)
- [x] `pnpm lint` (348 files, 0 errors)
- [x] `pnpm test` (all unit projects green)
- [x] `node scripts/check-boundaries.mjs` passes
- [x] `pnpm install --frozen-lockfile` passes
- [x] `notifications.spec` 11/11, `team-management.spec` 9/9, `workspace-admin.spec` 12/12 — each isolated **twice**
- [x] Full-suite order 32/32 **twice consecutively**
- [x] Slice 1 theme spec stays green (8/8)

## Notes for reviewers

- GATE-2 confirmed against `supabase/seed.sql`: `profiles.role` (member@enterprise.dev → `member`), `tenants.slug` (→ `enterprise-demo`) + `tenants.allow_admin_invites` (→ `true`), `notifications.is_read` (rows …-0001/…-0005).
- The notifications purge `DELETE` is scoped to `user_id=eq.{member}` AND `id=not.in.(seeded ids)` — it never touches seeded or other users' rows.
- `afterEach` restores are wrapped in try-catch so a teardown hiccup can't fail an otherwise-passing test. CI runs `supabase db reset` per run, so seed state is always fresh.
- Slice 3 (next) handles password-reset/Mailpit timeout + CI readiness pre-flight. Remaining baseline failures in this PR's CI (password-reset) are Slice 3 scope.
