### PR TITLE
feat(contracts): tenant-onboarding DTOs + planning docs [1/6]

### DIFF
--- a/docs/features/tenant-onboarding/prd.md
+++ b/docs/features/tenant-onboarding/prd.md
@@ -2,75 +2,323 @@
 title: "Tenant onboarding PRD"
 description: "Defines product requirements for first-time tenant setup and activation flow."
 owner: "Engineering"
-lastUpdated: "2026-05-07"
+lastUpdated: "2026-06-05"
 ---
 
 # Tenant onboarding PRD
 
 ## Purpose
 
-Define roadmap-level requirements for onboarding a new tenant from account creation to first successful workspace activation.
+Define implementation-ready product requirements for the guided onboarding experience that takes a new tenant from account creation to first meaningful workspace activation.
 
 ## Scope
 
-- Included: initial setup flow, default configuration, and first-use guidance.
-- Excluded: long-term user education programs and advanced success automation.
+- Included: onboarding checklist lifecycle, baseline workspace setup, first-teammate invite (reusing tenant-team-management), starter-data seeding, activation tracking, dismissal/resume behavior, UX flows, and traceability.
+- Excluded: adaptive/behavioral onboarding scoring, multi-tenant migration tools, onboarding consultant workflows, and custom activation criteria builders. The invitation subsystem is owned by the tenant-team-management feature — this feature reuses it without modification.
 
 ---
 
 ## Problem
 
-New tenants drop off when setup steps are unclear, fragmented, or require support intervention.
+New tenants drop off when setup steps are unclear, fragmented, or require support intervention. Without a guided flow, owners skip critical configuration, workspaces lack identity and locale settings, and "activation" — the first signal of genuine engagement — cannot be measured or optimized.
 
 ## Users and stakeholders
 
 | Role | Need |
 |------|------|
-| New tenant owner | Fast path to a usable workspace |
-| Tenant admin | Clear next actions after activation |
-| Product team | Higher activation and retention baseline |
+| Tenant owner | Fast, resumable path from creation to a usable workspace |
+| Tenant admin | Clear next actions after joining an in-progress tenant |
+| Member | Landing directly at the dashboard after accepting an invitation during onboarding |
+| Product team | Measurable activation rate and first-week retention baseline |
+| Platform engineering | Consistent progress-tracking and audit model across tenant lifecycle |
 
 ## Goals
 
-- Reduce time-to-value for new tenants.
-- Standardize initial tenant configuration.
-- Provide clear progression through setup milestones.
+- Reduce time-to-value for new tenants by making required steps explicit and completable in one session.
+- Standardize baseline configuration (name, locale) across all tenant activations.
+- Provide a resumable, low-friction checklist that adapts to the owner's pace.
+- Make activation measurable via a discrete `tenant.activated` audit event.
 
 ---
 
 ## MVP scope
 
-- Guided onboarding checklist.
-- Baseline workspace setup (name, locale, initial settings).
-- Invite first teammate flow.
-- Initial sample data or starter state for key modules.
+### Checklist lifecycle
 
-## Out of scope
+| Step | Type | Description |
+|------|------|-------------|
+| Baseline workspace setup | **Mandatory** | Set workspace name and locale; required before activation can fire |
+| Invite first teammate | Optional | Reuses tenant-team-management invitation service; no new invite logic |
+| Load sample data | Optional | Idempotent starter records for key modules |
+
+Rules:
+- Progress persists per tenant in `tenant_onboarding_progress` table.
+- Checklist auto-shows on first authenticated owner access; dismissed state persists.
+- Dismissed checklist collapses to a persistent launcher chip with completion fraction.
+- Activation fires when mandatory baseline is complete AND ≥1 value step is done.
+
+### Checklist states
+
+| State | Description |
+|-------|-------------|
+| `not_started` | No steps completed; checklist shown immediately on first load |
+| `in_progress` | At least one step complete; checklist may be dismissed |
+| `activated` | Activation criteria met; `tenant.activated` event emitted once |
+
+### Invite step reuse contract
+
+The "Invite first teammate" step MUST:
+- Open the existing invite dialog from tenant-team-management.
+- Create invitations via the existing `InvitationService` — no new invite logic or adapters.
+- Mark the onboarding step complete when a valid invitation is successfully created.
+
+### Out of scope
 
 - Adaptive onboarding based on behavioral scoring.
-- Multi-tenant migration/import tools.
+- Multi-tenant migration or import tools.
 - Dedicated onboarding consultant workflows.
+- New invitation system (reuse existing from tenant-team-management).
+- Custom activation criteria builders.
+- Bulk sample data import.
+- Resend or repeat sample data steps (idempotent only).
+
+---
+
+## UX specification
+
+### Routes
+
+| Route | Description |
+|-------|-------------|
+| `/onboarding` | Full checklist view; auto-shown on first owner login, accessible via launcher chip |
+| App shell (sidebar) | Persistent launcher chip (collapsed state); visible until activation or permanent dismiss |
+
+Routes registered in `ui/lib/routes.ts` (ROUTES object). Pages under `ui/app/(protected)/onboarding/`.
+
+### Page layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Header: "Get started" + progress bar (N/M steps)    │
+├─────────────────────────────────────────────────────┤
+│ Step list:                                           │
+│   ✅ Baseline workspace setup     [Complete]        │
+│   ○  Invite first teammate        [Start →]         │
+│   ○  Load sample data             [Start →]         │
+├─────────────────────────────────────────────────────┤
+│ Footer: [Dismiss checklist]                         │
+│   (Activation banner when criteria met:             │
+│    "Your workspace is ready")                       │
+└─────────────────────────────────────────────────────┘
+
+Dismissed / launcher chip state (sidebar):
+┌──────────────────────────┐
+│  Setup  ·  1/3 complete  │  ← click to restore
+└──────────────────────────┘
+```
+
+### Components and interactions
+
+| Component | Behavior |
+|-----------|----------|
+| **Checklist panel** | Lists all steps with status icons and a CTA per step. Progress bar at top shows completion fraction. Dismiss button in footer. |
+| **Baseline setup form** | Inline form: workspace name input (min 2 chars) + locale selector. Validates client-side. Submits via Server Action. Error shown inline on failure. |
+| **Invite step trigger** | Clicking "Start" opens the existing tenant-team-management invite dialog. Step marked complete on successful invitation creation. |
+| **Sample data step** | Single CTA "Load sample data". Shows loading state while seeding. On success, step marked complete. On failure, toast error and step stays pending. |
+| **Launcher chip** | Persistent element in sidebar. Shows "Setup · N/M". Click navigates to `/onboarding` and restores the full checklist. |
+| **Activation banner** | Shown at top of checklist when `tenant.activated` is emitted. "Your workspace is ready — here's what's next." |
+| **Dismiss dialog** | Confirmation: "Hide this checklist? You can reopen it from the sidebar." Confirms → collapses to launcher chip. |
+
+### UI states
+
+| State | Behavior |
+|-------|----------|
+| **Loading** | Skeleton rows for steps, skeleton progress bar |
+| **Not started** | All steps unchecked; baseline step highlighted as first action |
+| **In progress** | Completed steps checked; next incomplete step highlighted |
+| **Dismissed** | Checklist hidden; launcher chip visible in sidebar with progress fraction |
+| **Activated** | Activation banner shown at top of checklist; launcher chip remains until permanent dismiss |
+| **Error — baseline** | Inline form validation error; toast on server-side failure |
+| **Error — seeding** | Toast: "Sample data could not be loaded. Try again." Step remains pending. |
+| **Step complete** | CTA replaced with "Done" badge; no re-trigger for non-idempotent steps |
+
+### Role-specific visibility
+
+| Element | Owner | Admin | Member | Guest |
+|---------|-------|-------|--------|-------|
+| Full checklist at `/onboarding` | Yes | No (redirect to dashboard) | No (redirect to dashboard) | No (redirect to dashboard) |
+| Launcher chip in sidebar | Yes | No | No | No |
+| Baseline setup form | Yes | No | No | No |
+| Invite step | Yes | No | No | No |
+| Sample data step | Yes | No | No | No |
+| Activation banner | Yes | No | No | No |
+
+> **Important**: Onboarding is owner-only in MVP. Admins, members, and guests land directly at the dashboard. Any direct navigation to `/onboarding` by non-owners redirects to `/dashboard`.
+
+---
+
+## User stories and acceptance criteria
+
+### US-1: Owner completes baseline setup
+
+**As** a tenant owner, **I want** to set my workspace name and locale so my workspace has a clear identity.
+
+Acceptance criteria:
+- The baseline step is highlighted as the first required action in the checklist.
+- Submitting a valid name (≥2 chars) and locale marks the step complete immediately.
+- An empty or whitespace-only name shows an inline validation error; submission is blocked.
+- `tenant_onboarding.step_completed` is emitted with `{ stepId: "baseline" }`.
+- The progress bar increments and the step shows a completion checkmark.
+
+### US-2: Owner invites first teammate from onboarding
+
+**As** a tenant owner, **I want** to invite a teammate directly from the checklist so I do not have to navigate away.
+
+Acceptance criteria:
+- Clicking "Start" on the invite step opens the existing invite dialog from tenant-team-management.
+- Submitting a valid invitation creates it via the existing `InvitationService`.
+- The invite step is marked complete after a successful invitation creation.
+- No new invitation logic, table, or adapter is introduced by this feature.
+- `tenant_onboarding.step_completed` is emitted with `{ stepId: "first-invite" }`.
+
+### US-3: User resumes a partially-complete checklist
+
+**As** a tenant owner, **I want** my checklist progress to be saved so I can return and continue where I left off.
+
+Acceptance criteria:
+- After completing one or more steps, navigating away and returning to `/onboarding` shows the same completion state.
+- Progress survives page reloads and re-authentication.
+- The progress bar reflects the correct completion fraction on load.
+
+### US-4: Owner dismisses and re-opens the launcher
+
+**As** a tenant owner, **I want** to hide the checklist and bring it back later so it does not block my workflow.
+
+Acceptance criteria:
+- Clicking "Dismiss checklist" shows a confirmation dialog.
+- Confirming collapses the checklist and shows a launcher chip in the sidebar.
+- The launcher chip shows current progress (e.g., "Setup · 1/3").
+- Clicking the launcher chip navigates to `/onboarding` and restores the full checklist.
+- `tenant_onboarding.dismissed` is emitted on confirm with `{ completedSteps }`.
+
+### US-5: Tenant reaches activation
+
+**As** a tenant owner, **I want** to know when my workspace is fully activated so I am confident it is ready to use.
+
+Acceptance criteria:
+- `tenant.activated` fires exactly once when baseline is complete AND at least one value step (invite or sample data) is complete.
+- An activation banner appears at the top of the checklist after the event fires.
+- Completing the baseline step alone does NOT trigger activation.
+- Completing additional steps after activation does NOT re-fire the event.
+
+### US-6: Member sees limited onboarding
+
+**As** a tenant member, **I want** to land directly at the dashboard after accepting an invitation so I am not shown an owner-only checklist.
+
+Acceptance criteria:
+- Members and admins are redirected to `/dashboard` on login; `/onboarding` is inaccessible to them.
+- No launcher chip is shown for non-owner roles.
+- If a member manually navigates to `/onboarding`, they are redirected to `/dashboard`.
 
 ---
 
 ## Success metrics
 
-- Activation rate (tenant reaches first meaningful action).
-- Median onboarding completion time.
-- First-week retention for newly activated tenants.
+- Activation rate: percentage of new tenants reaching `tenant.activated` within 7 days (target: > 60%).
+- Median onboarding completion time: first login to activation (target: < 30 minutes).
+- Checklist dismissal-without-completion rate (target: < 30%).
+- First-week retention baseline for activated tenants (track; no MVP target).
+- Zero cross-tenant progress record leaks confirmed via RLS audit.
 
 ## Risks
 
-- Too many setup steps create early abandonment.
-- Missing defaults can cause setup dead-ends.
-- Unclear progress indicators reduce completion rates.
-
-## Open questions
-
-- Which checklist steps are mandatory vs optional?
-- Should onboarding be dismissible and resumable by default?
-- What qualifies as “first meaningful action” across template adopters?
+| Risk | Mitigation |
+|------|------------|
+| Too many setup steps cause early abandonment | Only baseline is mandatory; all other steps are optional and skippable |
+| Sample data collides with real tenant data | Idempotent seeding with clearly-labeled starter records; re-run safe |
+| Activation criteria mismatch for template adopters | Activation rule centralized in `onboarding-service.ts` and documented as an explicit override point |
+| Coupling to invitation service internals | Consume invitation service through its public interface only; no internal imports |
+| Onboarding state out of sync with actual workspace state | Step completions write through service layer; no client-side state used as source of truth |
+| Unclear progress indicators reduce completion rates | Progress bar + step status icons; completion fraction in launcher chip |
 
 ---
 
-*Last updated: 2026-05-07*
+## Traceability
+
+### Audit events
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `tenant_onboarding.started` | First checklist record created on initial tenant access | `{ tenantId, ownerId }` |
+| `tenant_onboarding.step_completed` | A checklist step is marked complete | `{ tenantId, ownerId, stepId }` |
+| `tenant_onboarding.dismissed` | Owner confirms checklist dismissal | `{ tenantId, ownerId, completedSteps }` |
+| `tenant_onboarding.sample_data_seeded` | Starter data is seeded successfully | `{ tenantId, ownerId, seededModules }` |
+| `tenant.activated` | Activation criteria met for the first time | `{ tenantId, activatedAt, completedSteps }` |
+
+> **Note**: Invitation events (`tenant_member.invited`) remain owned by tenant-team-management. The onboarding feature listens for a successful invitation creation to mark its own step complete.
+
+### Sentry
+
+- Area: `onboarding`
+- Instrumented actions: `completeBaselineStepAction`, `dismissChecklistAction`, `seedSampleDataAction`, `completeInviteStepAction`
+- Captured errors: DB failures (progress save, step update), seeding failures, activation evaluation failures
+- PII exclusions: workspace name (form input), email addresses, invitation tokens
+- Allowed metadata: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `stepId`
+
+### Seed data
+
+| Entity | State | Details |
+|--------|-------|---------|
+| Tenant + onboarding progress | `not_started` | Deterministic new-tenant UUID; no steps completed; maps to `seed-new@enterprise.dev` |
+| Tenant + onboarding progress | `in_progress` | Baseline complete; invite step pending; maps to existing admin seed tenant |
+| Tenant + onboarding progress | `activated` | All steps complete; `tenant.activated` already emitted; maps to `admin@enterprise.dev` tenant |
+
+> Use deterministic UUIDs for all seed records so Playwright tests can reference them without dynamic lookup. Add to `supabase/seed.sql`.
+
+### E2E flows
+
+| Scenario | Actor | Expected outcome |
+|----------|-------|------------------|
+| Owner completes baseline setup | Owner | Step marked complete, progress bar increments, audit event emitted |
+| Owner completes full activation path | Owner | `tenant.activated` emitted, activation banner shown |
+| Owner dismisses and resumes checklist | Owner | Launcher chip shows correct fraction; click restores checklist with same state |
+| Owner skips optional steps | Owner | Steps remain pending; no blocking error; progress continues |
+| Owner invites teammate via checklist | Owner | Invite created via existing service; step marked complete |
+| Owner loads sample data | Owner | Seed runs idempotently; step marked complete |
+| Member accesses `/onboarding` directly | Member | Redirect to `/dashboard` |
+| Guest accesses `/onboarding` directly | Guest | Redirect to `/dashboard` or access denied |
+| Baseline validation — empty workspace name | Owner | Inline validation error; submission blocked |
+
+### External adapters
+
+| Provider | Interface | Local mode | Production mode | Env var |
+|----------|-----------|------------|-----------------|---------|
+| Email (invitations) | `InvitationEmailPort` (reused from tenant-team-management) | Console adapter — logs invite URL | Resend adapter | `RESEND_API_KEY` |
+
+> No new external adapters are introduced. Onboarding delegates entirely to the invitation email adapter already defined in tenant-team-management.
+
+### Production readiness
+
+- [ ] All audit events verified in `audit_log` table
+- [ ] Sentry area `onboarding` registered and Server Actions instrumented
+- [ ] Unit tests pass for `packages/core/src/services/onboarding-service.ts`
+- [ ] E2E tests pass for all defined flows in `ui/e2e/tenant-onboarding/`
+- [ ] RLS policies verified — no cross-tenant `tenant_onboarding_progress` leaks
+- [ ] Seed data committed and `supabase db reset` works cleanly
+- [ ] `tenant.activated` fires at most once per tenant (idempotency verified in service tests)
+- [ ] Activation rule documented as an override point in `onboarding-service.ts`
+- [ ] `/onboarding` route registered in `ui/lib/routes.ts` (ROUTES object)
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| Mandatory vs optional steps | Baseline (name + locale) is MANDATORY; invite teammate and load sample data are OPTIONAL | Forcing collaboration or seed steps raises abandonment; a usable workspace requires identity and locale at minimum |
+| Dismissible and resumable | YES to both; dismissed state persists in DB; launcher chip in sidebar shows live progress | Respects owner autonomy, reduces friction, and supports return-later workflows |
+| Activation definition | `tenant.activated` fires when mandatory baseline is complete AND ≥1 value step (invite OR first record) is done | Config alone is not activation signal; pairing with collaboration or first record signals genuine engagement |
+
+---
+
+*Last updated: 2026-06-05*

--- a/docs/features/tenant-onboarding/rfc.md
+++ b/docs/features/tenant-onboarding/rfc.md
@@ -23,7 +23,7 @@ Define an implementation-ready technical approach for a guided, resumable, dismi
 Implement onboarding as an owner-scoped, additive module using:
 
 - A Drizzle `tenant_onboarding_progress` table (one row per tenant) with RLS policies in `@enterprise/db`.
-- Zod 4 contracts in `@enterprise/contracts` for progress DTOs, step inputs, and the activation result.
+- Zod contracts in `@enterprise/contracts` for progress DTOs, step inputs, and the activation result.
 - A function-based service `@enterprise/core/src/services/onboarding-service.ts` returning `ServiceResult<T>`.
 - Thin Server Actions in `ui/features/onboarding/actions.ts` returning `ActionResult<T>` with Sentry area `onboarding`.
 - **Reuse, not rebuild**: baseline setup delegates to `workspace-settings-service` (`updateWorkspaceProfile` + `updateWorkspaceRegional`); the first-invite step reuses the existing `tenant-team-management` invite dialog/action and only records its own step completion.
@@ -151,7 +151,7 @@ const ownerRoleClaim = sql`(auth.jwt()->'app_metadata'->>'role' = 'owner')`;
 
 ## Contracts
 
-Location: `packages/contracts/src/dto/tenant-onboarding.ts` (re-exported from `src/index.ts`). Zod 4 API.
+Location: `packages/contracts/src/dto/tenant-onboarding.ts` (re-exported from `src/index.ts`). Zod 3 API (project runs `zod@^3.25.0`).
 
 ### Enums
 
@@ -196,7 +196,7 @@ export type CompleteOnboardingStepDto = z.infer<typeof completeOnboardingStepSch
 
 ```typescript
 export const onboardingProgressOutputSchema = z.object({
-  tenantId: z.uuid(),
+  tenantId: z.string().uuid(),
   state: onboardingStateSchema,
   baselineCompleted: z.boolean(),
   firstInviteCompleted: z.boolean(),
@@ -480,7 +480,7 @@ Ships as **chained PRs** — each phase is an independently reviewable slice (ta
 
 | Phase | Deliverable | Dependencies |
 |-------|-------------|--------------|
-| 1 | Contracts: Zod 4 schemas + types in `@enterprise/contracts` + contract tests | None |
+| 1 | Contracts: Zod 3 schemas + types in `@enterprise/contracts` + contract tests | None |
 | 2 | Data model: `tenant_onboarding_progress` table, `onboarding_state` enum, RLS policies, generated migration | Phase 1 |
 | 3 | Service: `onboarding-service.ts` (init/get/complete/seed/dismiss/resume + `evaluateActivation`) + unit tests (TDD); reuse `workspace-settings-service` | Phases 1–2 |
 | 4 | Server Actions + Sentry area `onboarding` + `ROUTES.onboarding` + e2e route helper | Phase 3 |

--- a/docs/features/tenant-onboarding/rfc.md
+++ b/docs/features/tenant-onboarding/rfc.md
@@ -1,0 +1,506 @@
+---
+title: "Tenant onboarding RFC"
+description: "Defines the technical plan for guided, resumable tenant onboarding and activation tracking."
+owner: "Engineering"
+lastUpdated: "2026-06-05"
+---
+
+# Tenant onboarding RFC
+
+## Purpose
+
+Define an implementation-ready technical approach for a guided, resumable, dismissible onboarding experience that takes a new tenant from creation to first meaningful activation — reusing the existing invitation and workspace-settings subsystems rather than rebuilding them.
+
+## Scope
+
+- Included: data model for per-tenant onboarding progress, RLS policies, contracts, the `onboarding-service.ts` service layer, thin Server Actions, UI routes/components (checklist + launcher chip), idempotent seed data, activation tracking, Sentry instrumentation, and the testing strategy.
+- Excluded: adaptive/behavioral onboarding scoring, multi-tenant migration/import tools, onboarding consultant workflows, custom activation-criteria builders, and any new invitation system. The invitation subsystem is owned by `tenant-team-management` and is consumed through its public interface only.
+
+---
+
+## Summary
+
+Implement onboarding as an owner-scoped, additive module using:
+
+- A Drizzle `tenant_onboarding_progress` table (one row per tenant) with RLS policies in `@enterprise/db`.
+- Zod 4 contracts in `@enterprise/contracts` for progress DTOs, step inputs, and the activation result.
+- A function-based service `@enterprise/core/src/services/onboarding-service.ts` returning `ServiceResult<T>`.
+- Thin Server Actions in `ui/features/onboarding/actions.ts` returning `ActionResult<T>` with Sentry area `onboarding`.
+- **Reuse, not rebuild**: baseline setup delegates to `workspace-settings-service` (`updateWorkspaceProfile` + `updateWorkspaceRegional`); the first-invite step reuses the existing `tenant-team-management` invite dialog/action and only records its own step completion.
+- Idempotent activation: `tenant.activated` is emitted at most once, guarded by a DB check on `activated_at`.
+- Audit logging for every mutation and E2E coverage for every owner-facing flow.
+
+## Technical objectives
+
+- Onboarding progress is strictly tenant-scoped and owner-gated (RLS + service guards); no cross-tenant leakage.
+- The onboarding service has **zero dependency** on `tenant-team-service` (no circular imports); invitation reuse happens at the action/UI layer.
+- Activation fires exactly once per tenant and is centralized + documented as an explicit override point.
+- Local development works with no new env vars and no new external adapters.
+- All mutations are auditable and traceable in Sentry under area `onboarding`.
+
+---
+
+## Data model
+
+### `tenant_onboarding_progress` table
+
+Location: `packages/db/src/schema/platform.ts` (platform concern — tenant lifecycle).
+
+One row per tenant (1:1). Step completion is modeled as discrete nullable timestamps for queryability and audit precision; `activated_at` is the single source of truth for activation idempotency.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, UNIQUE, FK to `tenants.id`, ON DELETE CASCADE |
+| `state` | `onboarding_state` enum | NOT NULL, default `not_started` |
+| `baseline_completed_at` | `timestamptz` | NULLABLE — set when name + locale are saved |
+| `first_invite_completed_at` | `timestamptz` | NULLABLE — set when first invitation is created |
+| `sample_data_completed_at` | `timestamptz` | NULLABLE — set when starter data is seeded |
+| `dismissed` | `boolean` | NOT NULL, default `false` |
+| `dismissed_at` | `timestamptz` | NULLABLE |
+| `activated_at` | `timestamptz` | NULLABLE — idempotency guard for `tenant.activated` |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### New enum
+
+```typescript
+export const onboardingStateEnum = pgEnum("onboarding_state", [
+  "not_started",
+  "in_progress",
+  "activated",
+]);
+```
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `onboarding_tenant_idx` | `tenant_id` (UNIQUE) | One progress row per tenant; tenant-scoped lookup |
+| `onboarding_state_idx` | `state` | Filter by lifecycle state (analytics, seed) |
+
+### Constraints
+
+- UNIQUE on `tenant_id` — enforces the 1:1 invariant at the DB level (init becomes a safe upsert via `ON CONFLICT (tenant_id) DO NOTHING`).
+- FK `tenant_id` → `tenants.id` with `ON DELETE CASCADE` — progress is removed with its tenant (supports the additive rollback plan).
+- `activated_at` is written exactly once; the service refuses to overwrite a non-null value.
+
+### Type exports
+
+```typescript
+export type TenantOnboardingProgress = typeof tenantOnboardingProgress.$inferSelect;
+export type NewTenantOnboardingProgress = typeof tenantOnboardingProgress.$inferInsert;
+```
+
+### Drizzle definition (matches platform.ts conventions)
+
+```typescript
+export const tenantOnboardingProgress = pgTable(
+  "tenant_onboarding_progress",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .unique()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    state: onboardingStateEnum("state").notNull().default("not_started"),
+    baselineCompletedAt: timestamp("baseline_completed_at", { withTimezone: true }),
+    firstInviteCompletedAt: timestamp("first_invite_completed_at", { withTimezone: true }),
+    sampleDataCompletedAt: timestamp("sample_data_completed_at", { withTimezone: true }),
+    dismissed: boolean("dismissed").notNull().default(false),
+    dismissedAt: timestamp("dismissed_at", { withTimezone: true }),
+    activatedAt: timestamp("activated_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("onboarding_tenant_idx").on(table.tenantId),
+    index("onboarding_state_idx").on(table.state),
+    // policies below
+  ],
+).enableRLS();
+```
+
+> **Migration note**: `tenant_id UNIQUE` + the FK are Drizzle-generatable. Run `pnpm --filter @enterprise/db db:generate`, review the incremental SQL (expect `CREATE TYPE onboarding_state`, `CREATE TABLE`, `CREATE POLICY`), and commit.
+
+---
+
+## RLS policies
+
+### `tenant_onboarding_progress`
+
+Onboarding is owner-only (PRD), so mutation policies restrict to the `owner` role claim. Reuse the existing `tenantClaimMatchesColumn` predicate; add an `ownerRoleClaim` predicate.
+
+```typescript
+const tenantClaimMatchesColumn = sql`((auth.jwt()->'app_metadata'->>'tenant_id')::uuid = tenant_id)`;
+const ownerRoleClaim = sql`(auth.jwt()->'app_metadata'->>'role' = 'owner')`;
+```
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `onboarding_select` | SELECT | `authenticated` | `tenantClaimMatchesColumn AND ownerRoleClaim` |
+| `onboarding_insert` | INSERT | `authenticated` | `withCheck: tenantClaimMatchesColumn AND ownerRoleClaim` |
+| `onboarding_update` | UPDATE | `authenticated` | `using + withCheck: tenantClaimMatchesColumn AND ownerRoleClaim` |
+| `onboarding_delete` | DELETE | `serviceRole` | `using: true` (no user-facing delete; cleanup only) |
+
+> **No tenant bypass**: every policy is scoped by the JWT `tenant_id` claim. Non-owner roles cannot SELECT or mutate progress rows; combined with the route-level redirect, members/admins never reach onboarding state.
+>
+> **Baseline mutation path**: writing `tenants.name`/`locale` goes through `workspace-settings-service`, whose `tenants_update` policy is `serviceRole`-only — those writes use the admin client (server-only), exactly as the existing settings feature does. The progress row itself is written by the owner's authenticated client under the policies above.
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/tenant-onboarding.ts` (re-exported from `src/index.ts`). Zod 4 API.
+
+### Enums
+
+```typescript
+export const ONBOARDING_STATE = {
+  NOT_STARTED: "not_started",
+  IN_PROGRESS: "in_progress",
+  ACTIVATED: "activated",
+} as const;
+export type OnboardingState = (typeof ONBOARDING_STATE)[keyof typeof ONBOARDING_STATE];
+export const onboardingStateSchema = z.enum(["not_started", "in_progress", "activated"]);
+
+export const ONBOARDING_STEP = {
+  BASELINE: "baseline",
+  FIRST_INVITE: "first-invite",
+  SAMPLE_DATA: "sample-data",
+} as const;
+export type OnboardingStep = (typeof ONBOARDING_STEP)[keyof typeof ONBOARDING_STEP];
+export const onboardingStepSchema = z.enum(["baseline", "first-invite", "sample-data"]);
+```
+
+### Input schemas
+
+```typescript
+// Baseline workspace setup (name + locale) — mandatory step
+export const completeBaselineStepSchema = z.object({
+  name: z.string().min(2).max(100),
+  locale: z.string().min(2).max(35), // BCP-47, e.g. "en-US"
+});
+export type CompleteBaselineStepDto = z.infer<typeof completeBaselineStepSchema>;
+
+// Mark a non-baseline step complete (first-invite | sample-data)
+export const completeOnboardingStepSchema = z.object({
+  step: z.enum(["first-invite", "sample-data"]),
+});
+export type CompleteOnboardingStepDto = z.infer<typeof completeOnboardingStepSchema>;
+```
+
+> `dismiss`/`resume`/`seed`/`get` take no body — they derive tenant + user from the authenticated context, so they need no input schema.
+
+### Output schemas
+
+```typescript
+export const onboardingProgressOutputSchema = z.object({
+  tenantId: z.uuid(),
+  state: onboardingStateSchema,
+  baselineCompleted: z.boolean(),
+  firstInviteCompleted: z.boolean(),
+  sampleDataCompleted: z.boolean(),
+  dismissed: z.boolean(),
+  activatedAt: z.date().nullable(),
+  completedCount: z.number().int().min(0),
+  totalSteps: z.number().int().min(1),
+});
+export type OnboardingProgressOutput = z.infer<typeof onboardingProgressOutputSchema>;
+
+export const activationResultSchema = z.object({
+  activated: z.boolean(),       // true only on the transition that emits the event
+  activatedAt: z.date().nullable(),
+  progress: onboardingProgressOutputSchema,
+});
+export type ActivationResult = z.infer<typeof activationResultSchema>;
+```
+
+---
+
+## Service layer
+
+Location: `packages/core/src/services/onboarding-service.ts`. Pattern: function-based (per `packages/core/AGENTS.md`); receives `SupabaseClient` via DI; returns `ServiceResult<T>`; writes `audit_log` for every mutation; **no** Sentry, `revalidatePath`, or `ActionResult` here.
+
+### Service functions
+
+| Function | Args | Returns | Notes |
+|----------|------|---------|-------|
+| `getOnboardingProgress` | `client, tenantId` | `ServiceResult<OnboardingProgressOutput>` | RLS-scoped read; maps row → DTO (derives `completedCount`/`totalSteps`) |
+| `initOnboardingProgress` | `client, tenantId, ownerId` | `ServiceResult<OnboardingProgressOutput>` | Idempotent upsert (`ON CONFLICT (tenant_id) DO NOTHING`); on first create emits `tenant_onboarding.started` |
+| `completeBaselineStep` | `client, adminClient, tenantId, userId, role, input` | `ServiceResult<ActivationResult>` | Reuses `updateWorkspaceProfile` (name) + `updateWorkspaceRegional` (locale); sets `baseline_completed_at`; recomputes `state`; calls `evaluateActivation` |
+| `completeOnboardingStep` | `client, tenantId, userId, step` | `ServiceResult<ActivationResult>` | Sets `first_invite_completed_at` or `sample_data_completed_at`; emits `tenant_onboarding.step_completed`; calls `evaluateActivation`. **Does not** create invitations |
+| `seedSampleData` | `client, tenantId, userId` | `ServiceResult<ActivationResult>` | Idempotent starter records (see Seed data); marks `sample_data_completed_at`; emits `tenant_onboarding.sample_data_seeded`; calls `evaluateActivation` |
+| `dismissChecklist` | `client, tenantId, userId` | `ServiceResult<OnboardingProgressOutput>` | Sets `dismissed=true`, `dismissed_at=now()`; emits `tenant_onboarding.dismissed` |
+| `resumeChecklist` | `client, tenantId, userId` | `ServiceResult<OnboardingProgressOutput>` | Sets `dismissed=false`, clears `dismissed_at` |
+| `evaluateActivation` | `client, tenantId, userId` (internal) | `ServiceResult<ActivationResult>` | **Activation rule + idempotency guard** (below) |
+
+### Activation rule (single override point) + idempotency
+
+```
+evaluateActivation(client, tenantId, userId):
+  1. Load progress row (baseline_completed_at, value-step timestamps, activated_at)
+  2. Guard — idempotent: if activated_at IS NOT NULL → return { activated: false } (already fired)
+  3. Rule (documented override point):
+       activated := baseline_completed_at IS NOT NULL
+                    AND (first_invite_completed_at IS NOT NULL
+                         OR sample_data_completed_at IS NOT NULL)
+  4. If activated:
+       UPDATE ... SET activated_at = now(), state = 'activated'
+         WHERE tenant_id = $tenantId AND activated_at IS NULL   ← race-safe guard
+       if rowsAffected = 1 → write audit `tenant.activated` { tenantId, activatedAt, completedSteps }
+       (rowsAffected = 0 means a concurrent call already activated → do NOT emit)
+  5. Return { activated, activatedAt, progress }
+```
+
+> The `WHERE ... activated_at IS NULL` predicate makes the emit atomic even under concurrent step completions — only the update that flips NULL→now() emits the event. This satisfies the proposal's "guard `tenant.activated` with a DB check before emit" requirement.
+>
+> **Override point**: the boolean in step 3 is the only place activation is defined. Template adopters change activation criteria here and nowhere else.
+
+### Reuse boundaries (no circular imports)
+
+```
+onboarding-service.ts
+  ├── imports updateWorkspaceProfile, updateWorkspaceRegional  (workspace-settings-service.ts) ✅ leaf service
+  └── DOES NOT import tenant-team-service.ts                    ❌ avoids onboarding↔team coupling
+
+First-invite reuse happens ABOVE the service, at the action/UI layer:
+  invite dialog (tenant-team-management) → inviteMemberAction (area: team) → on success
+    → completeInviteStepAction (area: onboarding) → completeOnboardingStep(step: "first-invite")
+```
+
+The onboarding service therefore never imports invitation internals; it only records that the step happened. The invitation itself is created by the already-shipped `inviteTenantMember` service via the existing `inviteMemberAction`.
+
+---
+
+## Server Actions
+
+Location: `ui/features/onboarding/actions.ts`. All actions: `"use server"`, validate with Zod, resolve auth context (`getUser()` → `tenant_id`/`role`), enforce **owner-only**, call the service via **subpath import** `@enterprise/core/services`, map to `ActionResult<T>`, and `revalidatePath(ROUTES.onboarding)` on success. The Client Component calls `router.refresh()` after a successful mutation so the Server-Component checklist re-renders.
+
+> **Import rule**: use `from "@enterprise/core/services"`, `from "@enterprise/core/supabase/server"`, `from "@enterprise/core/supabase/admin"` — never the barrel `@enterprise/core` (CI `next-flight-action-entry-loader` cannot resolve barrel re-exports).
+
+### Actions list
+
+| Action | Input schema | Service function | Client(s) | Sentry area |
+|--------|-------------|------------------|-----------|-------------|
+| `completeBaselineStepAction` | `completeBaselineStepSchema` | `completeBaselineStep` | server + admin | `onboarding` |
+| `completeInviteStepAction` | — | `completeOnboardingStep("first-invite")` | server | `onboarding` |
+| `seedSampleDataAction` | — | `seedSampleData` | server (+ admin if needed) | `onboarding` |
+| `dismissChecklistAction` | — | `dismissChecklist` | server | `onboarding` |
+| `resumeChecklistAction` | — | `resumeChecklist` | server | `onboarding` |
+
+Progress reads live in `ui/features/onboarding/queries.ts` (`getOnboardingProgress` / `initOnboardingProgress` on first owner load) — Server Components, not actions.
+
+### Sentry instrumentation
+
+Every action's catch block calls `captureActionError(err, { actionName, area: "onboarding", tenantId, userId, userRole, errorCode, inputShape })`. `inputShape` is `Object.keys(parsed.data)` only — **never values** (workspace name, email, tokens are PII/secrets and are excluded; `globals` scrubbing in `beforeSendFilter` is the backstop).
+
+---
+
+## UI routes and components
+
+### Routes
+
+| Route | Component | Auth | Description |
+|-------|-----------|------|-------------|
+| `/onboarding` | `OnboardingPage` (Server Component) | Required, **owner only** | Full checklist; auto-shown on first owner login; non-owners redirect to `/dashboard` |
+| App shell (sidebar) | `OnboardingLauncherChip` | Owner only | Persistent launcher chip with completion fraction; visible until permanent dismiss |
+
+Register the path in **both** `ui/lib/routes.ts` (`ROUTES.onboarding = "/onboarding"`) and `ui/e2e/helpers/routes.ts` (re-export). Pages live under `ui/app/(protected)/onboarding/` (never under `dashboard/`).
+
+```typescript
+// ui/lib/routes.ts (addition)
+export const ROUTES = {
+  // ...existing
+  onboarding: "/onboarding",
+} as const;
+```
+
+### Feature module structure
+
+```
+ui/features/onboarding/
+├── actions.ts                      # Server Actions (thin wrappers, area "onboarding")
+├── queries.ts                      # getOnboardingProgress + initOnboardingProgress (Server)
+├── types.ts                        # Feature-local view types
+├── components/
+│   ├── onboarding-checklist.tsx    # Client — step list + progress bar + dismiss
+│   ├── baseline-setup-form.tsx     # Client — name + locale (useActionState + FormField)
+│   ├── sample-data-step.tsx        # Client — "Load sample data" CTA + loading/error
+│   ├── invite-step-trigger.tsx     # Client — opens reused team invite dialog; onSuccess → completeInviteStepAction
+│   ├── activation-banner.tsx       # "Your workspace is ready"
+│   ├── dismiss-dialog.tsx          # Confirmation → dismissChecklistAction
+│   └── onboarding-launcher-chip.tsx# Sidebar chip "Setup · N/M" → /onboarding (resume)
+└── hooks/                          # (only if shared interactivity emerges)
+```
+
+### App routes
+
+```
+ui/app/(protected)/onboarding/
+├── page.tsx     # Server Component: owner guard + redirect; init/fetch progress; render checklist
+└── error.tsx    # Error boundary wired to Sentry area "onboarding"
+```
+
+### Component sourcing (no rebuild)
+
+- Primitives from `@enterprise/ui` (shadcn): `Card`, `Progress`, `Button`, `Badge`, `Dialog`, `Input`, plus shared `FormField`/`FormBanner`/`SubmitButton` and `useFormValidation` for the baseline form.
+- **Invite step reuses the existing `tenant-team-management` invite dialog component** — no new invite UI. On its success callback, the trigger calls `completeInviteStepAction`.
+
+---
+
+## Seed data
+
+Location: additions to `supabase/seed.sql`. Idempotent (`ON CONFLICT (tenant_id) DO NOTHING`), deterministic UUIDs, clearly labeled, re-run safe under `supabase db reset`. Maps onto existing deterministic seed tenants/users.
+
+```sql
+-- Onboarding progress: not_started (fresh owner workspace)
+INSERT INTO public.tenant_onboarding_progress (
+  id, tenant_id, state, created_at, updated_at
+) VALUES (
+  'd1e2f3a4-0001-0001-0001-000000000001',
+  '<demo_tenant_id>',                       -- admin@enterprise.dev tenant, reset for the not_started case
+  'not_started', now(), now()
+) ON CONFLICT (tenant_id) DO NOTHING;
+
+-- Onboarding progress: in_progress (baseline done, value step pending)
+INSERT INTO public.tenant_onboarding_progress (
+  id, tenant_id, state, baseline_completed_at, created_at, updated_at
+) VALUES (
+  'd1e2f3a4-0001-0001-0001-000000000002',
+  '<second_tenant_id>',
+  'in_progress', now() - interval '1 hour', now() - interval '1 hour', now()
+) ON CONFLICT (tenant_id) DO NOTHING;
+
+-- Onboarding progress: activated (baseline + value step + activated_at set)
+INSERT INTO public.tenant_onboarding_progress (
+  id, tenant_id, state, baseline_completed_at, first_invite_completed_at,
+  activated_at, created_at, updated_at
+) VALUES (
+  'd1e2f3a4-0001-0001-0001-000000000003',
+  '<third_tenant_id>',
+  'activated', now() - interval '2 days', now() - interval '2 days',
+  now() - interval '2 days', now() - interval '2 days', now()
+) ON CONFLICT (tenant_id) DO NOTHING;
+```
+
+> **Note**: `<demo_tenant_id>` etc. reference existing deterministic seed tenant IDs. Because each demo user auto-provisions one tenant via `handle_new_user()`, the in_progress/activated states map to additional seed tenants/users; reuse the same deterministic IDs the E2E suite logs in as. Starter "sample data" rows seeded by `seedSampleData` (e.g. demo `resources`) are tagged so they are recognizable and idempotent.
+
+---
+
+## Testing strategy
+
+Strict TDD (project `strict_tdd=true`): write failing service unit tests first, then implement.
+
+### Unit tests (Vitest) — respect coverage thresholds (core 60%)
+
+Location: `packages/core/src/services/__tests__/onboarding-service.test.ts` (mock `SupabaseClient` per the AGENTS.md pattern).
+
+| Test | Verifies |
+|------|----------|
+| `initOnboardingProgress` first call | Inserts row, emits `tenant_onboarding.started` |
+| `initOnboardingProgress` repeat | `ON CONFLICT DO NOTHING`; no duplicate, no second `started` event |
+| `completeBaselineStep` success | Calls `updateWorkspaceProfile` + `updateWorkspaceRegional`; sets `baseline_completed_at`; state→`in_progress` |
+| `completeBaselineStep` alone | Does **not** activate (no value step yet) |
+| `completeOnboardingStep("first-invite")` | Sets timestamp; emits `step_completed`; no invitation logic invoked |
+| `seedSampleData` idempotent | Re-run does not duplicate records; marks step once |
+| `evaluateActivation` happy path | baseline + value step → sets `activated_at`, state→`activated`, emits `tenant.activated` |
+| `evaluateActivation` idempotency | Second call with `activated_at` set → `activated:false`, no re-emit |
+| `evaluateActivation` race guard | Concurrent flip → only one emit (rowsAffected guard) |
+| `dismissChecklist` / `resumeChecklist` | Toggle `dismissed` + `dismissed_at`; emit on dismiss |
+
+### Contract tests (Vitest) — respect thresholds (contracts 45%)
+
+Location: `packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts`. Cover valid/boundary/invalid for `completeBaselineStepSchema` (name min 2, locale shape), `completeOnboardingStepSchema` (rejects `baseline`), and output schema parsing.
+
+### E2E tests (Playwright) — Page Object Model
+
+Location: `ui/e2e/onboarding/onboarding.spec.ts`. Run **serial** (stateful per-tenant progress); **no `networkidle` waits** — assert on visible state/role-based locators. Import paths from `ui/e2e/helpers/routes.ts`; log in via `e2e/helpers/auth.ts`.
+
+| Test | Tag | Flow |
+|------|-----|------|
+| Owner completes baseline | `@critical` | Login owner → fill name+locale → step checks, progress increments |
+| Owner reaches activation | `@critical` | baseline + invite (or sample data) → activation banner shown |
+| Resume after dismiss | | Dismiss → chip shows `N/M` → click → checklist restored with same state |
+| Skip optional steps | | Optional steps stay pending; no blocking error |
+| Invite via checklist | | Reused dialog creates invite → first-invite step marked complete |
+| Load sample data | | Idempotent seed → step marked complete |
+| Baseline validation | | Empty name → inline error, submission blocked |
+| Member hits `/onboarding` | `@critical` | Redirect to `/dashboard`; no chip |
+| Guest hits `/onboarding` | | Redirect / access denied |
+
+---
+
+## Sentry area registration
+
+Add `onboarding` to the `SentryArea` union in `ui/lib/sentry.ts`:
+
+```typescript
+export type SentryArea =
+  | "auth"
+  | "billing"
+  | "dashboard"
+  | "notifications"
+  | "onboarding"   // ← added
+  | "resources"
+  | "settings"
+  | "team"
+  | "webhook";
+```
+
+---
+
+## Trade-offs
+
+| Decision | Chosen | Not chosen | Rationale |
+|----------|--------|------------|-----------|
+| Step storage | Discrete nullable timestamps | JSON blob of step states | Queryable, auditable, type-safe; trivial completion-fraction derivation |
+| Row cardinality | 1 row per tenant (`tenant_id` UNIQUE) | Row per step | Simpler reads; matches "per-tenant progress" intent |
+| Activation guard | `activated_at IS NULL` predicate in UPDATE | App-level boolean check | Race-safe; only the NULL→now() flip emits the event |
+| First-invite reuse | Reuse dialog + action; service records step only | Onboarding service calls invite service | Prevents onboarding↔team circular import; no duplicated invite logic |
+| Baseline writes | Delegate to `workspace-settings-service` | New tenant-update logic | Reuses audited, RLS-correct (serviceRole) settings path |
+| Owner gating | RLS owner claim + route redirect | UI-only hiding | Defense in depth; RLS is the real boundary |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Onboarding coupling to invitation internals | Reuse confined to action/UI layer; service has no `tenant-team-service` import |
+| Double `tenant.activated` under concurrency | Atomic `WHERE activated_at IS NULL` guard; idempotency unit + race tests |
+| Sample data collides with real data | Idempotent, clearly-labeled starter rows; re-run safe |
+| Activation criteria misfit for adopters | Centralized in `evaluateActivation`, documented as the single override point |
+| RLS drift vs other platform tables | Reuse `tenantClaimMatchesColumn`; add `ownerRoleClaim`; cross-tenant E2E leak test |
+| Owner-only assumption changes later | Policy + redirect are the two switch points; documented together |
+
+---
+
+## Implementation phases
+
+Ships as **chained PRs** — each phase is an independently reviewable slice (target < 400 lines), bottom-up so every layer lands with its tests.
+
+| Phase | Deliverable | Dependencies |
+|-------|-------------|--------------|
+| 1 | Contracts: Zod 4 schemas + types in `@enterprise/contracts` + contract tests | None |
+| 2 | Data model: `tenant_onboarding_progress` table, `onboarding_state` enum, RLS policies, generated migration | Phase 1 |
+| 3 | Service: `onboarding-service.ts` (init/get/complete/seed/dismiss/resume + `evaluateActivation`) + unit tests (TDD); reuse `workspace-settings-service` | Phases 1–2 |
+| 4 | Server Actions + Sentry area `onboarding` + `ROUTES.onboarding` + e2e route helper | Phase 3 |
+| 5 | UI: `/onboarding` page, checklist, baseline form, sample-data step, activation banner, launcher chip; reuse team invite dialog | Phase 4 |
+| 6 | Seed data + Playwright E2E (`ui/e2e/onboarding/`) + production-readiness verification | Phase 5 |
+
+---
+
+## Decisions log
+
+| Decision | Outcome | Rationale |
+|----------|---------|-----------|
+| One progress row per tenant? | Yes — `tenant_id` UNIQUE, 1:1 | Matches per-tenant progress; simplest reads/upsert |
+| Activation idempotency mechanism? | `activated_at` + `WHERE activated_at IS NULL` | Single source of truth; race-safe single emit |
+| Where is activation defined? | `evaluateActivation` only | Explicit, documented override point for adopters |
+| First-invite integration layer? | Action/UI, not service | Avoids circular import; reuses shipped invite service unchanged |
+| Baseline persistence path? | `workspace-settings-service` (name + locale) | Reuses audited, RLS-correct settings mutations |
+| Onboarding visibility (MVP)? | Owner only (RLS owner claim + redirect) | PRD scope; defense in depth |
+| New external adapters/env vars? | None | Reuses invitation email adapter; additive feature |
+
+---
+
+*Last updated: 2026-06-05*

--- a/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
+++ b/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  ONBOARDING_STATE,
-  ONBOARDING_STEP,
   activationResultSchema,
   completeBaselineStepSchema,
   completeOnboardingStepSchema,
+  ONBOARDING_STATE,
+  ONBOARDING_STEP,
   onboardingProgressOutputSchema,
   onboardingStateSchema,
   onboardingStepSchema,
@@ -68,28 +68,27 @@ describe("onboardingStepSchema", () => {
 
 describe("completeBaselineStepSchema", () => {
   it("accepts valid name and locale", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" }),
-    ).toEqual({ name: "Acme Corp", locale: "en-US" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" })).toEqual({
+      name: "Acme Corp",
+      locale: "en-US",
+    });
   });
 
   it("accepts name at minimum boundary (2 chars)", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "AB", locale: "en" }),
-    ).toMatchObject({ name: "AB" });
+    expect(completeBaselineStepSchema.parse({ name: "AB", locale: "en" })).toMatchObject({
+      name: "AB",
+    });
   });
 
   it("accepts name at maximum boundary (100 chars)", () => {
     const longName = "A".repeat(100);
-    expect(
-      completeBaselineStepSchema.parse({ name: longName, locale: "en-US" }),
-    ).toMatchObject({ name: longName });
+    expect(completeBaselineStepSchema.parse({ name: longName, locale: "en-US" })).toMatchObject({
+      name: longName,
+    });
   });
 
   it("rejects name shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "A", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "A", locale: "en-US" })).toThrow();
   });
 
   it("rejects name longer than 100 chars", () => {
@@ -99,28 +98,24 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects empty name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "", locale: "en-US" })).toThrow();
   });
 
   it("accepts locale at minimum boundary (2 chars, e.g. 'en')", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "en" }),
-    ).toMatchObject({ locale: "en" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: "en" })).toMatchObject({
+      locale: "en",
+    });
   });
 
   it("accepts locale at maximum boundary (35 chars)", () => {
     const longLocale = "a".repeat(35);
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale }),
-    ).toMatchObject({ locale: longLocale });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale })).toMatchObject({
+      locale: longLocale,
+    });
   });
 
   it("rejects locale shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "e" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme", locale: "e" })).toThrow();
   });
 
   it("rejects locale longer than 35 chars", () => {
@@ -130,41 +125,33 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects missing name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ locale: "en-US" })).toThrow();
   });
 
   it("rejects missing locale", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme Corp" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme Corp" })).toThrow();
   });
 });
 
 describe("completeOnboardingStepSchema", () => {
   it("accepts first-invite step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "first-invite" }),
-    ).toEqual({ step: "first-invite" });
+    expect(completeOnboardingStepSchema.parse({ step: "first-invite" })).toEqual({
+      step: "first-invite",
+    });
   });
 
   it("accepts sample-data step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "sample-data" }),
-    ).toEqual({ step: "sample-data" });
+    expect(completeOnboardingStepSchema.parse({ step: "sample-data" })).toEqual({
+      step: "sample-data",
+    });
   });
 
   it("rejects baseline step (baseline is handled by its own schema)", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "baseline" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "baseline" })).toThrow();
   });
 
   it("rejects unknown step", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "other" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "other" })).toThrow();
   });
 
   it("rejects missing step", () => {
@@ -204,16 +191,16 @@ describe("onboardingProgressOutputSchema", () => {
 
   it("accepts a Date for activatedAt", () => {
     const activatedAt = new Date("2026-06-01T10:00:00.000Z");
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt }),
-    ).toMatchObject({ activatedAt });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt })).toMatchObject({
+      activatedAt,
+    });
   });
 
   it("accepts all states", () => {
     for (const state of ["not_started", "in_progress", "activated"] as const) {
-      expect(
-        onboardingProgressOutputSchema.parse({ ...validProgress, state }),
-      ).toMatchObject({ state });
+      expect(onboardingProgressOutputSchema.parse({ ...validProgress, state })).toMatchObject({
+        state,
+      });
     }
   });
 
@@ -230,9 +217,9 @@ describe("onboardingProgressOutputSchema", () => {
   });
 
   it("accepts totalSteps at 1 (minimum)", () => {
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 }),
-    ).toMatchObject({ totalSteps: 1 });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 })).toMatchObject(
+      { totalSteps: 1 },
+    );
   });
 
   it("rejects totalSteps below 1", () => {

--- a/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
+++ b/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import {
+  ONBOARDING_STATE,
+  ONBOARDING_STEP,
+  activationResultSchema,
+  completeBaselineStepSchema,
+  completeOnboardingStepSchema,
+  onboardingProgressOutputSchema,
+  onboardingStateSchema,
+  onboardingStepSchema,
+} from "../tenant-onboarding";
+
+// ============================================================================
+// RED phase: tests written before implementation exists
+// ============================================================================
+
+describe("ONBOARDING_STATE", () => {
+  it("has the expected values", () => {
+    expect(ONBOARDING_STATE.NOT_STARTED).toBe("not_started");
+    expect(ONBOARDING_STATE.IN_PROGRESS).toBe("in_progress");
+    expect(ONBOARDING_STATE.ACTIVATED).toBe("activated");
+  });
+});
+
+describe("ONBOARDING_STEP", () => {
+  it("has the expected values", () => {
+    expect(ONBOARDING_STEP.BASELINE).toBe("baseline");
+    expect(ONBOARDING_STEP.FIRST_INVITE).toBe("first-invite");
+    expect(ONBOARDING_STEP.SAMPLE_DATA).toBe("sample-data");
+  });
+});
+
+describe("onboardingStateSchema", () => {
+  it("accepts not_started", () => {
+    expect(onboardingStateSchema.parse("not_started")).toBe("not_started");
+  });
+
+  it("accepts in_progress", () => {
+    expect(onboardingStateSchema.parse("in_progress")).toBe("in_progress");
+  });
+
+  it("accepts activated", () => {
+    expect(onboardingStateSchema.parse("activated")).toBe("activated");
+  });
+
+  it("rejects unknown state", () => {
+    expect(() => onboardingStateSchema.parse("completed")).toThrow();
+  });
+});
+
+describe("onboardingStepSchema", () => {
+  it("accepts baseline", () => {
+    expect(onboardingStepSchema.parse("baseline")).toBe("baseline");
+  });
+
+  it("accepts first-invite", () => {
+    expect(onboardingStepSchema.parse("first-invite")).toBe("first-invite");
+  });
+
+  it("accepts sample-data", () => {
+    expect(onboardingStepSchema.parse("sample-data")).toBe("sample-data");
+  });
+
+  it("rejects unknown step", () => {
+    expect(() => onboardingStepSchema.parse("unknown")).toThrow();
+  });
+});
+
+describe("completeBaselineStepSchema", () => {
+  it("accepts valid name and locale", () => {
+    expect(
+      completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" }),
+    ).toEqual({ name: "Acme Corp", locale: "en-US" });
+  });
+
+  it("accepts name at minimum boundary (2 chars)", () => {
+    expect(
+      completeBaselineStepSchema.parse({ name: "AB", locale: "en" }),
+    ).toMatchObject({ name: "AB" });
+  });
+
+  it("accepts name at maximum boundary (100 chars)", () => {
+    const longName = "A".repeat(100);
+    expect(
+      completeBaselineStepSchema.parse({ name: longName, locale: "en-US" }),
+    ).toMatchObject({ name: longName });
+  });
+
+  it("rejects name shorter than 2 chars", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "A", locale: "en-US" }),
+    ).toThrow();
+  });
+
+  it("rejects name longer than 100 chars", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "A".repeat(101), locale: "en-US" }),
+    ).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "", locale: "en-US" }),
+    ).toThrow();
+  });
+
+  it("accepts locale at minimum boundary (2 chars, e.g. 'en')", () => {
+    expect(
+      completeBaselineStepSchema.parse({ name: "Acme", locale: "en" }),
+    ).toMatchObject({ locale: "en" });
+  });
+
+  it("accepts locale at maximum boundary (35 chars)", () => {
+    const longLocale = "a".repeat(35);
+    expect(
+      completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale }),
+    ).toMatchObject({ locale: longLocale });
+  });
+
+  it("rejects locale shorter than 2 chars", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "Acme", locale: "e" }),
+    ).toThrow();
+  });
+
+  it("rejects locale longer than 35 chars", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "Acme", locale: "a".repeat(36) }),
+    ).toThrow();
+  });
+
+  it("rejects missing name", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ locale: "en-US" }),
+    ).toThrow();
+  });
+
+  it("rejects missing locale", () => {
+    expect(() =>
+      completeBaselineStepSchema.parse({ name: "Acme Corp" }),
+    ).toThrow();
+  });
+});
+
+describe("completeOnboardingStepSchema", () => {
+  it("accepts first-invite step", () => {
+    expect(
+      completeOnboardingStepSchema.parse({ step: "first-invite" }),
+    ).toEqual({ step: "first-invite" });
+  });
+
+  it("accepts sample-data step", () => {
+    expect(
+      completeOnboardingStepSchema.parse({ step: "sample-data" }),
+    ).toEqual({ step: "sample-data" });
+  });
+
+  it("rejects baseline step (baseline is handled by its own schema)", () => {
+    expect(() =>
+      completeOnboardingStepSchema.parse({ step: "baseline" }),
+    ).toThrow();
+  });
+
+  it("rejects unknown step", () => {
+    expect(() =>
+      completeOnboardingStepSchema.parse({ step: "other" }),
+    ).toThrow();
+  });
+
+  it("rejects missing step", () => {
+    expect(() => completeOnboardingStepSchema.parse({})).toThrow();
+  });
+});
+
+describe("onboardingProgressOutputSchema", () => {
+  const validTenantId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+  const validProgress = {
+    tenantId: validTenantId,
+    state: "not_started" as const,
+    baselineCompleted: false,
+    firstInviteCompleted: false,
+    sampleDataCompleted: false,
+    dismissed: false,
+    activatedAt: null,
+    completedCount: 0,
+    totalSteps: 3,
+  };
+
+  it("accepts a complete valid progress record", () => {
+    expect(onboardingProgressOutputSchema.parse(validProgress)).toMatchObject({
+      tenantId: validTenantId,
+      state: "not_started",
+      completedCount: 0,
+      totalSteps: 3,
+    });
+  });
+
+  it("accepts null activatedAt", () => {
+    expect(
+      onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt: null }),
+    ).toMatchObject({ activatedAt: null });
+  });
+
+  it("accepts a Date for activatedAt", () => {
+    const activatedAt = new Date("2026-06-01T10:00:00.000Z");
+    expect(
+      onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt }),
+    ).toMatchObject({ activatedAt });
+  });
+
+  it("accepts all states", () => {
+    for (const state of ["not_started", "in_progress", "activated"] as const) {
+      expect(
+        onboardingProgressOutputSchema.parse({ ...validProgress, state }),
+      ).toMatchObject({ state });
+    }
+  });
+
+  it("accepts completedCount at 0 (minimum)", () => {
+    expect(
+      onboardingProgressOutputSchema.parse({ ...validProgress, completedCount: 0 }),
+    ).toMatchObject({ completedCount: 0 });
+  });
+
+  it("rejects completedCount below 0", () => {
+    expect(() =>
+      onboardingProgressOutputSchema.parse({ ...validProgress, completedCount: -1 }),
+    ).toThrow();
+  });
+
+  it("accepts totalSteps at 1 (minimum)", () => {
+    expect(
+      onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 }),
+    ).toMatchObject({ totalSteps: 1 });
+  });
+
+  it("rejects totalSteps below 1", () => {
+    expect(() =>
+      onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 0 }),
+    ).toThrow();
+  });
+
+  it("rejects invalid state", () => {
+    expect(() =>
+      onboardingProgressOutputSchema.parse({ ...validProgress, state: "done" }),
+    ).toThrow();
+  });
+
+  it("rejects invalid tenantId (not UUID)", () => {
+    expect(() =>
+      onboardingProgressOutputSchema.parse({ ...validProgress, tenantId: "not-a-uuid" }),
+    ).toThrow();
+  });
+
+  it("rejects missing tenantId", () => {
+    const { tenantId: _omitted, ...rest } = validProgress;
+    expect(() => onboardingProgressOutputSchema.parse(rest)).toThrow();
+  });
+});
+
+describe("activationResultSchema", () => {
+  const validTenantId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+  const validProgress = {
+    tenantId: validTenantId,
+    state: "activated" as const,
+    baselineCompleted: true,
+    firstInviteCompleted: true,
+    sampleDataCompleted: false,
+    dismissed: false,
+    activatedAt: new Date("2026-06-01T10:00:00.000Z"),
+    completedCount: 2,
+    totalSteps: 3,
+  };
+
+  it("accepts a successful activation result", () => {
+    expect(
+      activationResultSchema.parse({
+        activated: true,
+        activatedAt: new Date("2026-06-01T10:00:00.000Z"),
+        progress: validProgress,
+      }),
+    ).toMatchObject({ activated: true });
+  });
+
+  it("accepts activated:false with null activatedAt", () => {
+    expect(
+      activationResultSchema.parse({
+        activated: false,
+        activatedAt: null,
+        progress: { ...validProgress, state: "in_progress", activatedAt: null },
+      }),
+    ).toMatchObject({ activated: false, activatedAt: null });
+  });
+
+  it("rejects missing activated field", () => {
+    expect(() =>
+      activationResultSchema.parse({
+        activatedAt: null,
+        progress: validProgress,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid progress sub-object", () => {
+    expect(() =>
+      activationResultSchema.parse({
+        activated: true,
+        activatedAt: null,
+        progress: { tenantId: "bad" },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/contracts/src/dto/tenant-onboarding.ts
+++ b/packages/contracts/src/dto/tenant-onboarding.ts
@@ -1,0 +1,76 @@
+// Tenant Onboarding DTOs
+// Schemas for onboarding progress, baseline setup, step completion, and activation result
+
+import { z } from "zod";
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+export const ONBOARDING_STATE = {
+  NOT_STARTED: "not_started",
+  IN_PROGRESS: "in_progress",
+  ACTIVATED: "activated",
+} as const;
+
+export type OnboardingState = (typeof ONBOARDING_STATE)[keyof typeof ONBOARDING_STATE];
+
+export const onboardingStateSchema = z.enum(["not_started", "in_progress", "activated"]);
+
+export const ONBOARDING_STEP = {
+  BASELINE: "baseline",
+  FIRST_INVITE: "first-invite",
+  SAMPLE_DATA: "sample-data",
+} as const;
+
+export type OnboardingStep = (typeof ONBOARDING_STEP)[keyof typeof ONBOARDING_STEP];
+
+export const onboardingStepSchema = z.enum(["baseline", "first-invite", "sample-data"]);
+
+// ============================================================================
+// Input Schemas
+// ============================================================================
+
+/** Baseline workspace setup (name + locale) — mandatory step */
+export const completeBaselineStepSchema = z.object({
+  name: z.string().min(2).max(100),
+  locale: z.string().min(2).max(35), // BCP-47, e.g. "en-US"
+});
+
+export type CompleteBaselineStepDto = z.infer<typeof completeBaselineStepSchema>;
+
+/** Mark a non-baseline step complete (first-invite | sample-data only) */
+export const completeOnboardingStepSchema = z.object({
+  step: z.enum(["first-invite", "sample-data"]),
+});
+
+export type CompleteOnboardingStepDto = z.infer<typeof completeOnboardingStepSchema>;
+
+// ============================================================================
+// Output Schemas
+// ============================================================================
+
+/** Current onboarding progress for a tenant */
+export const onboardingProgressOutputSchema = z.object({
+  tenantId: z.string().uuid(),
+  state: onboardingStateSchema,
+  baselineCompleted: z.boolean(),
+  firstInviteCompleted: z.boolean(),
+  sampleDataCompleted: z.boolean(),
+  dismissed: z.boolean(),
+  activatedAt: z.date().nullable(),
+  completedCount: z.number().int().min(0),
+  totalSteps: z.number().int().min(1),
+});
+
+export type OnboardingProgressOutput = z.infer<typeof onboardingProgressOutputSchema>;
+
+/** Result of a step completion that may trigger activation */
+export const activationResultSchema = z.object({
+  /** true only on the transition that emits the tenant.activated event */
+  activated: z.boolean(),
+  activatedAt: z.date().nullable(),
+  progress: onboardingProgressOutputSchema,
+});
+
+export type ActivationResult = z.infer<typeof activationResultSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,6 +8,7 @@ export * from "./dto/notifications";
 // DTOs
 export * from "./dto/platform";
 export * from "./dto/resources";
+export * from "./dto/tenant-onboarding";
 export * from "./dto/tenant-team";
 export * from "./dto/workspace-admin";
 export type {


### PR DESCRIPTION
## Summary

- Foundation slice of the tenant-onboarding feature (chained PR 1/6).
- Completes the repo PRD and adds the RFC for tenant-onboarding.
- Adds the Zod DTOs/enums in `@enterprise/contracts` with contract tests.

## Changes

| File | Change |
|------|--------|
| `docs/features/tenant-onboarding/prd.md` | Expanded to full structure (UX spec, user stories, traceability, decisions log) |
| `docs/features/tenant-onboarding/rfc.md` | New technical RFC (data model, RLS, service, 6-phase plan) |
| `packages/contracts/src/dto/tenant-onboarding.ts` | Onboarding state/step enums + progress/baseline/step/activation schemas |
| `packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts` | 42 contract tests (test-first) |
| `packages/contracts/src/index.ts` | Barrel re-export |

## Verification

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

### Contract Verification
- [x] Schemas have colocated type exports
- [x] No imports from other @enterprise/* packages
- [x] Tests cover validation edge cases

> Chained PR 1/6 (stacked-to-main). Base: `main`.