### PR TITLE
feat(ui): tenant-onboarding server actions and routes [4/6]

### DIFF
--- a/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
+++ b/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  ONBOARDING_STATE,
-  ONBOARDING_STEP,
   activationResultSchema,
   completeBaselineStepSchema,
   completeOnboardingStepSchema,
+  ONBOARDING_STATE,
+  ONBOARDING_STEP,
   onboardingProgressOutputSchema,
   onboardingStateSchema,
   onboardingStepSchema,
@@ -68,28 +68,27 @@ describe("onboardingStepSchema", () => {
 
 describe("completeBaselineStepSchema", () => {
   it("accepts valid name and locale", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" }),
-    ).toEqual({ name: "Acme Corp", locale: "en-US" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" })).toEqual({
+      name: "Acme Corp",
+      locale: "en-US",
+    });
   });
 
   it("accepts name at minimum boundary (2 chars)", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "AB", locale: "en" }),
-    ).toMatchObject({ name: "AB" });
+    expect(completeBaselineStepSchema.parse({ name: "AB", locale: "en" })).toMatchObject({
+      name: "AB",
+    });
   });
 
   it("accepts name at maximum boundary (100 chars)", () => {
     const longName = "A".repeat(100);
-    expect(
-      completeBaselineStepSchema.parse({ name: longName, locale: "en-US" }),
-    ).toMatchObject({ name: longName });
+    expect(completeBaselineStepSchema.parse({ name: longName, locale: "en-US" })).toMatchObject({
+      name: longName,
+    });
   });
 
   it("rejects name shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "A", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "A", locale: "en-US" })).toThrow();
   });
 
   it("rejects name longer than 100 chars", () => {
@@ -99,28 +98,24 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects empty name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "", locale: "en-US" })).toThrow();
   });
 
   it("accepts locale at minimum boundary (2 chars, e.g. 'en')", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "en" }),
-    ).toMatchObject({ locale: "en" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: "en" })).toMatchObject({
+      locale: "en",
+    });
   });
 
   it("accepts locale at maximum boundary (35 chars)", () => {
     const longLocale = "a".repeat(35);
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale }),
-    ).toMatchObject({ locale: longLocale });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale })).toMatchObject({
+      locale: longLocale,
+    });
   });
 
   it("rejects locale shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "e" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme", locale: "e" })).toThrow();
   });
 
   it("rejects locale longer than 35 chars", () => {
@@ -130,41 +125,33 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects missing name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ locale: "en-US" })).toThrow();
   });
 
   it("rejects missing locale", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme Corp" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme Corp" })).toThrow();
   });
 });
 
 describe("completeOnboardingStepSchema", () => {
   it("accepts first-invite step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "first-invite" }),
-    ).toEqual({ step: "first-invite" });
+    expect(completeOnboardingStepSchema.parse({ step: "first-invite" })).toEqual({
+      step: "first-invite",
+    });
   });
 
   it("accepts sample-data step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "sample-data" }),
-    ).toEqual({ step: "sample-data" });
+    expect(completeOnboardingStepSchema.parse({ step: "sample-data" })).toEqual({
+      step: "sample-data",
+    });
   });
 
   it("rejects baseline step (baseline is handled by its own schema)", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "baseline" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "baseline" })).toThrow();
   });
 
   it("rejects unknown step", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "other" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "other" })).toThrow();
   });
 
   it("rejects missing step", () => {
@@ -204,16 +191,16 @@ describe("onboardingProgressOutputSchema", () => {
 
   it("accepts a Date for activatedAt", () => {
     const activatedAt = new Date("2026-06-01T10:00:00.000Z");
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt }),
-    ).toMatchObject({ activatedAt });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt })).toMatchObject({
+      activatedAt,
+    });
   });
 
   it("accepts all states", () => {
     for (const state of ["not_started", "in_progress", "activated"] as const) {
-      expect(
-        onboardingProgressOutputSchema.parse({ ...validProgress, state }),
-      ).toMatchObject({ state });
+      expect(onboardingProgressOutputSchema.parse({ ...validProgress, state })).toMatchObject({
+        state,
+      });
     }
   });
 
@@ -230,9 +217,9 @@ describe("onboardingProgressOutputSchema", () => {
   });
 
   it("accepts totalSteps at 1 (minimum)", () => {
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 }),
-    ).toMatchObject({ totalSteps: 1 });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 })).toMatchObject(
+      { totalSteps: 1 },
+    );
   });
 
   it("rejects totalSteps below 1", () => {

--- a/packages/core/src/services/__tests__/onboarding-service.test.ts
+++ b/packages/core/src/services/__tests__/onboarding-service.test.ts
@@ -366,7 +366,10 @@ describe("seedSampleData", () => {
     const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
 
     // Row already has sample_data_completed_at set → idempotent path
-    const alreadySeededRow = { ...IN_PROGRESS_ROW, sample_data_completed_at: new Date().toISOString() };
+    const alreadySeededRow = {
+      ...IN_PROGRESS_ROW,
+      sample_data_completed_at: new Date().toISOString(),
+    };
 
     const client = buildClient({
       tenant_onboarding_progress: {
@@ -489,7 +492,10 @@ describe("evaluateActivation", () => {
     // NO additional tenant.activated event (step_completed may still fire)
     const activationCalls = auditInsert.mock.calls.filter((call) => {
       const row = call[0] as Record<string, unknown>;
-      return typeof row["metadata"] === "string" && (row["metadata"] as string).includes("tenant.activated");
+      return (
+        typeof row["metadata"] === "string" &&
+        (row["metadata"] as string).includes("tenant.activated")
+      );
     });
     expect(activationCalls).toHaveLength(0);
   });
@@ -555,7 +561,10 @@ describe("evaluateActivation", () => {
     // No tenant.activated emitted by this call (the other concurrent call did it)
     const activationCalls = auditInsert.mock.calls.filter((call) => {
       const row = call[0] as Record<string, unknown>;
-      return typeof row["metadata"] === "string" && (row["metadata"] as string).includes("tenant.activated");
+      return (
+        typeof row["metadata"] === "string" &&
+        (row["metadata"] as string).includes("tenant.activated")
+      );
     });
     expect(activationCalls).toHaveLength(0);
   });

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -13,6 +13,7 @@ export type { BackendAdapters } from "./backend-adapters";
 export { createBackendAdapters } from "./backend-adapters";
 export * from "./billing-service";
 export * from "./notification-service";
+export * from "./onboarding-service";
 // Backend ports — provider-agnostic interfaces
 export type { AuthPort } from "./ports/auth-port";
 export type { InvitationEmailParams, InvitationEmailPort } from "./ports/invitation-email-port";

--- a/packages/core/src/services/onboarding-service.ts
+++ b/packages/core/src/services/onboarding-service.ts
@@ -12,10 +12,7 @@ import type {
 } from "@enterprise/contracts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ServiceResult } from "./auth-service";
-import {
-  updateWorkspaceProfile,
-  updateWorkspaceRegional,
-} from "./workspace-settings-service";
+import { updateWorkspaceProfile, updateWorkspaceRegional } from "./workspace-settings-service";
 
 // ─── Internal row type ────────────────────────────────────────────────────────
 
@@ -43,11 +40,12 @@ async function writeAuditLog(
   resourceId?: string,
   metadata?: Record<string, unknown>,
 ): Promise<void> {
-  const action = event.includes("activated") || event.includes("started")
-    ? "create"
-    : event.includes("dismissed")
-    ? "update"
-    : "update";
+  const action =
+    event.includes("activated") || event.includes("started")
+      ? "create"
+      : event.includes("dismissed")
+        ? "update"
+        : "update";
 
   const { error } = await client.from("audit_log").insert({
     tenant_id: tenantId,
@@ -251,7 +249,10 @@ export async function initOnboardingProgress(
   // ON CONFLICT (tenant_id) DO NOTHING — ignoreDuplicates skips on conflict
   const { data: inserted, error: upsertError } = await client
     .from("tenant_onboarding_progress")
-    .upsert({ tenant_id: tenantId, state: "not_started" }, { onConflict: "tenant_id", ignoreDuplicates: true })
+    .upsert(
+      { tenant_id: tenantId, state: "not_started" },
+      { onConflict: "tenant_id", ignoreDuplicates: true },
+    )
     .select()
     .maybeSingle();
 

--- a/ui/features/onboarding/actions.ts
+++ b/ui/features/onboarding/actions.ts
@@ -5,14 +5,8 @@ import type {
   ActivationResult,
   OnboardingProgressOutput,
 } from "@enterprise/contracts";
-import {
-  completeBaselineStepSchema,
-  inviteMemberSchema,
-} from "@enterprise/contracts";
-import {
-  ConsoleInvitationEmailAdapter,
-  inviteTenantMember,
-} from "@enterprise/core/services";
+import { completeBaselineStepSchema, inviteMemberSchema } from "@enterprise/contracts";
+import { ConsoleInvitationEmailAdapter, inviteTenantMember } from "@enterprise/core/services";
 import {
   completeBaselineStep,
   completeOnboardingStep,

--- a/ui/features/onboarding/actions.ts
+++ b/ui/features/onboarding/actions.ts
@@ -1,0 +1,378 @@
+"use server";
+
+import type {
+  ActionResult,
+  ActivationResult,
+  OnboardingProgressOutput,
+} from "@enterprise/contracts";
+import {
+  completeBaselineStepSchema,
+  inviteMemberSchema,
+} from "@enterprise/contracts";
+import {
+  ConsoleInvitationEmailAdapter,
+  inviteTenantMember,
+} from "@enterprise/core/services";
+import {
+  completeBaselineStep,
+  completeOnboardingStep,
+  dismissChecklist,
+  resumeChecklist,
+  seedSampleData,
+} from "@enterprise/core/services/onboarding-service";
+import { getAdminClient } from "@enterprise/core/supabase/admin";
+import { getServerClient } from "@enterprise/core/supabase/server";
+import { getAppUrl } from "@enterprise/core/utils/env";
+import { revalidatePath } from "next/cache";
+import { ROUTES } from "@/lib/routes";
+import { captureActionError } from "@/lib/sentry";
+
+// ─── Auth context helper ──────────────────────────────────────────────────────
+
+async function getAuthContext(supabase: Awaited<ReturnType<typeof getServerClient>>) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+  const role = (user.app_metadata?.["role"] as string | undefined) ?? null;
+
+  return { userId: user.id, tenantId, role };
+}
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+/**
+ * Complete the baseline onboarding step (workspace name + locale).
+ * Owner-only. Updates workspace profile via workspace-settings-service
+ * and marks the baseline step complete on the onboarding progress row.
+ */
+export async function completeBaselineStepAction(
+  input: Record<string, unknown>,
+): Promise<ActionResult<ActivationResult>> {
+  const parsed = completeBaselineStepSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Only owners can complete the baseline onboarding step",
+      },
+    };
+  }
+
+  try {
+    const adminClient = getAdminClient();
+    const result = await completeBaselineStep(
+      supabase,
+      adminClient,
+      auth.tenantId,
+      auth.userId,
+      auth.role,
+      parsed.data,
+    );
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "STEP_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.onboarding);
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "completeBaselineStepAction",
+      area: "onboarding",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Send a team invitation and mark the first-invite onboarding step complete.
+ * Owner-only. Reuses inviteTenantMember service (action-layer reuse with tenant-team).
+ * The onboarding service only records the step — the invite is done here.
+ */
+export async function completeInviteStepAction(
+  input: Record<string, unknown>,
+): Promise<ActionResult<ActivationResult>> {
+  const parsed = inviteMemberSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid input",
+        details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
+      },
+    };
+  }
+
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Only owners can invite members during onboarding",
+      },
+    };
+  }
+
+  try {
+    const emailAdapter = new ConsoleInvitationEmailAdapter();
+    const inviteResult = await inviteTenantMember(
+      supabase,
+      auth.tenantId,
+      auth.userId,
+      auth.role,
+      parsed.data,
+      emailAdapter,
+      { appUrl: getAppUrl() },
+    );
+
+    if (!inviteResult.success) {
+      return {
+        success: false,
+        error: {
+          code: inviteResult.code ?? "INVITE_FAILED",
+          message: inviteResult.error,
+        },
+      };
+    }
+
+    // Record the onboarding step completion after the invite succeeds
+    const stepResult = await completeOnboardingStep(
+      supabase,
+      auth.tenantId,
+      auth.userId,
+      "first-invite",
+    );
+
+    if (!stepResult.success) {
+      return {
+        success: false,
+        error: { code: stepResult.code ?? "STEP_FAILED", message: stepResult.error },
+      };
+    }
+
+    revalidatePath(ROUTES.onboarding);
+
+    return { success: true, data: stepResult.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "completeInviteStepAction",
+      area: "onboarding",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+      inputShape: Object.keys(parsed.data),
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Load starter sample data and mark the sample-data onboarding step complete.
+ * Owner-only. Idempotent — safe to call multiple times.
+ */
+export async function seedSampleDataAction(): Promise<ActionResult<ActivationResult>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: { code: "FORBIDDEN", message: "Only owners can seed sample data" },
+    };
+  }
+
+  try {
+    const result = await seedSampleData(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "SEED_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.onboarding);
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "seedSampleDataAction",
+      area: "onboarding",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Dismiss the onboarding checklist.
+ * Owner-only. The checklist can be resumed later.
+ */
+export async function dismissChecklistAction(): Promise<ActionResult<OnboardingProgressOutput>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Only owners can dismiss the onboarding checklist",
+      },
+    };
+  }
+
+  try {
+    const result = await dismissChecklist(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "DISMISS_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.onboarding);
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "dismissChecklistAction",
+      area: "onboarding",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}
+
+/**
+ * Resume a previously dismissed onboarding checklist.
+ * Owner-only. Clears the dismissed flag and dismissed_at timestamp.
+ */
+export async function resumeChecklistAction(): Promise<ActionResult<OnboardingProgressOutput>> {
+  const supabase = await getServerClient();
+  const auth = await getAuthContext(supabase);
+
+  if (!auth?.tenantId) {
+    return {
+      success: false,
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    };
+  }
+
+  if (auth.role !== "owner") {
+    return {
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "Only owners can resume the onboarding checklist",
+      },
+    };
+  }
+
+  try {
+    const result = await resumeChecklist(supabase, auth.tenantId, auth.userId);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: { code: result.code ?? "RESUME_FAILED", message: result.error },
+      };
+    }
+
+    revalidatePath(ROUTES.onboarding);
+
+    return { success: true, data: result.data };
+  } catch (err) {
+    captureActionError(err, {
+      actionName: "resumeChecklistAction",
+      area: "onboarding",
+      tenantId: auth.tenantId,
+      userId: auth.userId,
+    });
+
+    return {
+      success: false,
+      error: { code: "UNEXPECTED_ERROR", message: "An unexpected error occurred" },
+    };
+  }
+}

--- a/ui/features/onboarding/queries.ts
+++ b/ui/features/onboarding/queries.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+import type { OnboardingProgressOutput } from "@enterprise/contracts";
+import {
+  getOnboardingProgress,
+  initOnboardingProgress,
+} from "@enterprise/core/services/onboarding-service";
+import { getServerClient } from "@enterprise/core/supabase/server";
+
+/**
+ * Fetch the current onboarding progress for the authenticated owner.
+ * Returns null if no progress row exists yet or if the user is not authenticated.
+ * RLS ensures only the tenant owner can read the row.
+ */
+export async function fetchOnboardingProgress(): Promise<OnboardingProgressOutput | null> {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+
+  if (!tenantId) {
+    return null;
+  }
+
+  const result = await getOnboardingProgress(supabase, tenantId);
+
+  if (!result.success) {
+    if (result.code === "PROGRESS_NOT_FOUND") {
+      return null;
+    }
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}
+
+/**
+ * Initialize and return the onboarding progress row for the authenticated owner.
+ * Idempotent — safe to call on every owner page load.
+ * Emits `tenant_onboarding.started` only on the first call.
+ * Throws if the user is not authenticated or tenant is missing.
+ */
+export async function fetchInitOnboardingProgress(): Promise<OnboardingProgressOutput> {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("Authentication required");
+  }
+
+  const tenantId = (user.app_metadata?.["tenant_id"] as string | undefined) ?? null;
+
+  if (!tenantId) {
+    throw new Error("Tenant not found in auth metadata");
+  }
+
+  const result = await initOnboardingProgress(supabase, tenantId, user.id);
+
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}

--- a/ui/features/onboarding/types.ts
+++ b/ui/features/onboarding/types.ts
@@ -1,0 +1,22 @@
+// Feature-local view types for the onboarding checklist UI.
+// Enriches service DTOs with display metadata consumed by onboarding components.
+
+import type { OnboardingProgressOutput } from "@enterprise/contracts";
+
+// ─── Step metadata ─────────────────────────────────────────────────────────────
+
+export interface OnboardingStepMeta {
+  id: string;
+  label: string;
+  description: string;
+  completed: boolean;
+  optional: boolean;
+}
+
+// ─── Enriched view state ───────────────────────────────────────────────────────
+
+export interface OnboardingViewState extends OnboardingProgressOutput {
+  steps: OnboardingStepMeta[];
+  progressPercent: number;
+  isActivated: boolean;
+}

--- a/ui/lib/routes.ts
+++ b/ui/lib/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   billing: "/billing",
   notifications: "/notifications",
   notificationPreferences: "/settings/notifications",
+  onboarding: "/onboarding",
   settings: "/settings",
   team: "/team",
   resources: {

--- a/ui/lib/sentry.ts
+++ b/ui/lib/sentry.ts
@@ -8,6 +8,7 @@ export type SentryArea =
   | "billing"
   | "dashboard"
   | "notifications"
+  | "onboarding"
   | "resources"
   | "settings"
   | "team"


### PR DESCRIPTION
## Summary

- Chained PR 4/6. Thin Server Actions wrapping the onboarding service.

## Changes

| File | Change |
|------|--------|
| `ui/features/onboarding/actions.ts` | 5 Server Actions (owner-guard, Zod, Sentry `onboarding`, revalidatePath) |
| `ui/features/onboarding/queries.ts` | Server-only progress fetch/init |
| `ui/features/onboarding/types.ts` | Feature-local view types |
| `ui/lib/sentry.ts` | Register `onboarding` Sentry area |
| `ui/lib/routes.ts` | `ROUTES.onboarding` |

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Subpath imports from `@enterprise/core/services` (no barrel)
- [x] First-invite reuses existing `inviteTenantMember` (no rebuild)

> Chained PR 4/6. Base: `feat/tenant-onboarding-service` (review after 3/6).