### PR TITLE
feat(ui): tenant-onboarding checklist UI and launcher [5/6]

### DIFF
--- a/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
+++ b/packages/contracts/src/dto/__tests__/tenant-onboarding.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  ONBOARDING_STATE,
-  ONBOARDING_STEP,
   activationResultSchema,
   completeBaselineStepSchema,
   completeOnboardingStepSchema,
+  ONBOARDING_STATE,
+  ONBOARDING_STEP,
   onboardingProgressOutputSchema,
   onboardingStateSchema,
   onboardingStepSchema,
@@ -68,28 +68,27 @@ describe("onboardingStepSchema", () => {
 
 describe("completeBaselineStepSchema", () => {
   it("accepts valid name and locale", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" }),
-    ).toEqual({ name: "Acme Corp", locale: "en-US" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme Corp", locale: "en-US" })).toEqual({
+      name: "Acme Corp",
+      locale: "en-US",
+    });
   });
 
   it("accepts name at minimum boundary (2 chars)", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "AB", locale: "en" }),
-    ).toMatchObject({ name: "AB" });
+    expect(completeBaselineStepSchema.parse({ name: "AB", locale: "en" })).toMatchObject({
+      name: "AB",
+    });
   });
 
   it("accepts name at maximum boundary (100 chars)", () => {
     const longName = "A".repeat(100);
-    expect(
-      completeBaselineStepSchema.parse({ name: longName, locale: "en-US" }),
-    ).toMatchObject({ name: longName });
+    expect(completeBaselineStepSchema.parse({ name: longName, locale: "en-US" })).toMatchObject({
+      name: longName,
+    });
   });
 
   it("rejects name shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "A", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "A", locale: "en-US" })).toThrow();
   });
 
   it("rejects name longer than 100 chars", () => {
@@ -99,28 +98,24 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects empty name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "", locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "", locale: "en-US" })).toThrow();
   });
 
   it("accepts locale at minimum boundary (2 chars, e.g. 'en')", () => {
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "en" }),
-    ).toMatchObject({ locale: "en" });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: "en" })).toMatchObject({
+      locale: "en",
+    });
   });
 
   it("accepts locale at maximum boundary (35 chars)", () => {
     const longLocale = "a".repeat(35);
-    expect(
-      completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale }),
-    ).toMatchObject({ locale: longLocale });
+    expect(completeBaselineStepSchema.parse({ name: "Acme", locale: longLocale })).toMatchObject({
+      locale: longLocale,
+    });
   });
 
   it("rejects locale shorter than 2 chars", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme", locale: "e" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme", locale: "e" })).toThrow();
   });
 
   it("rejects locale longer than 35 chars", () => {
@@ -130,41 +125,33 @@ describe("completeBaselineStepSchema", () => {
   });
 
   it("rejects missing name", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ locale: "en-US" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ locale: "en-US" })).toThrow();
   });
 
   it("rejects missing locale", () => {
-    expect(() =>
-      completeBaselineStepSchema.parse({ name: "Acme Corp" }),
-    ).toThrow();
+    expect(() => completeBaselineStepSchema.parse({ name: "Acme Corp" })).toThrow();
   });
 });
 
 describe("completeOnboardingStepSchema", () => {
   it("accepts first-invite step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "first-invite" }),
-    ).toEqual({ step: "first-invite" });
+    expect(completeOnboardingStepSchema.parse({ step: "first-invite" })).toEqual({
+      step: "first-invite",
+    });
   });
 
   it("accepts sample-data step", () => {
-    expect(
-      completeOnboardingStepSchema.parse({ step: "sample-data" }),
-    ).toEqual({ step: "sample-data" });
+    expect(completeOnboardingStepSchema.parse({ step: "sample-data" })).toEqual({
+      step: "sample-data",
+    });
   });
 
   it("rejects baseline step (baseline is handled by its own schema)", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "baseline" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "baseline" })).toThrow();
   });
 
   it("rejects unknown step", () => {
-    expect(() =>
-      completeOnboardingStepSchema.parse({ step: "other" }),
-    ).toThrow();
+    expect(() => completeOnboardingStepSchema.parse({ step: "other" })).toThrow();
   });
 
   it("rejects missing step", () => {
@@ -204,16 +191,16 @@ describe("onboardingProgressOutputSchema", () => {
 
   it("accepts a Date for activatedAt", () => {
     const activatedAt = new Date("2026-06-01T10:00:00.000Z");
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt }),
-    ).toMatchObject({ activatedAt });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, activatedAt })).toMatchObject({
+      activatedAt,
+    });
   });
 
   it("accepts all states", () => {
     for (const state of ["not_started", "in_progress", "activated"] as const) {
-      expect(
-        onboardingProgressOutputSchema.parse({ ...validProgress, state }),
-      ).toMatchObject({ state });
+      expect(onboardingProgressOutputSchema.parse({ ...validProgress, state })).toMatchObject({
+        state,
+      });
     }
   });
 
@@ -230,9 +217,9 @@ describe("onboardingProgressOutputSchema", () => {
   });
 
   it("accepts totalSteps at 1 (minimum)", () => {
-    expect(
-      onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 }),
-    ).toMatchObject({ totalSteps: 1 });
+    expect(onboardingProgressOutputSchema.parse({ ...validProgress, totalSteps: 1 })).toMatchObject(
+      { totalSteps: 1 },
+    );
   });
 
   it("rejects totalSteps below 1", () => {

--- a/packages/core/src/services/__tests__/onboarding-service.test.ts
+++ b/packages/core/src/services/__tests__/onboarding-service.test.ts
@@ -87,7 +87,7 @@ function buildClient(tableMocks: Record<string, unknown>): SupabaseClient {
 }
 
 /** Standard audit_log mock — insert always succeeds silently */
-const AUDIT_OK = { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+const _AUDIT_OK = { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
 
 // ─── getOnboardingProgress ────────────────────────────────────────────────────
 
@@ -366,7 +366,10 @@ describe("seedSampleData", () => {
     const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
 
     // Row already has sample_data_completed_at set → idempotent path
-    const alreadySeededRow = { ...IN_PROGRESS_ROW, sample_data_completed_at: new Date().toISOString() };
+    const alreadySeededRow = {
+      ...IN_PROGRESS_ROW,
+      sample_data_completed_at: new Date().toISOString(),
+    };
 
     const client = buildClient({
       tenant_onboarding_progress: {
@@ -489,7 +492,10 @@ describe("evaluateActivation", () => {
     // NO additional tenant.activated event (step_completed may still fire)
     const activationCalls = auditInsert.mock.calls.filter((call) => {
       const row = call[0] as Record<string, unknown>;
-      return typeof row["metadata"] === "string" && (row["metadata"] as string).includes("tenant.activated");
+      return (
+        typeof row["metadata"] === "string" &&
+        (row["metadata"] as string).includes("tenant.activated")
+      );
     });
     expect(activationCalls).toHaveLength(0);
   });
@@ -555,7 +561,10 @@ describe("evaluateActivation", () => {
     // No tenant.activated emitted by this call (the other concurrent call did it)
     const activationCalls = auditInsert.mock.calls.filter((call) => {
       const row = call[0] as Record<string, unknown>;
-      return typeof row["metadata"] === "string" && (row["metadata"] as string).includes("tenant.activated");
+      return (
+        typeof row["metadata"] === "string" &&
+        (row["metadata"] as string).includes("tenant.activated")
+      );
     });
     expect(activationCalls).toHaveLength(0);
   });

--- a/packages/core/src/services/onboarding-service.ts
+++ b/packages/core/src/services/onboarding-service.ts
@@ -12,10 +12,7 @@ import type {
 } from "@enterprise/contracts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ServiceResult } from "./auth-service";
-import {
-  updateWorkspaceProfile,
-  updateWorkspaceRegional,
-} from "./workspace-settings-service";
+import { updateWorkspaceProfile, updateWorkspaceRegional } from "./workspace-settings-service";
 
 // ─── Internal row type ────────────────────────────────────────────────────────
 
@@ -43,11 +40,12 @@ async function writeAuditLog(
   resourceId?: string,
   metadata?: Record<string, unknown>,
 ): Promise<void> {
-  const action = event.includes("activated") || event.includes("started")
-    ? "create"
-    : event.includes("dismissed")
-    ? "update"
-    : "update";
+  const action =
+    event.includes("activated") || event.includes("started")
+      ? "create"
+      : event.includes("dismissed")
+        ? "update"
+        : "update";
 
   const { error } = await client.from("audit_log").insert({
     tenant_id: tenantId,
@@ -251,7 +249,10 @@ export async function initOnboardingProgress(
   // ON CONFLICT (tenant_id) DO NOTHING — ignoreDuplicates skips on conflict
   const { data: inserted, error: upsertError } = await client
     .from("tenant_onboarding_progress")
-    .upsert({ tenant_id: tenantId, state: "not_started" }, { onConflict: "tenant_id", ignoreDuplicates: true })
+    .upsert(
+      { tenant_id: tenantId, state: "not_started" },
+      { onConflict: "tenant_id", ignoreDuplicates: true },
+    )
     .select()
     .maybeSingle();
 
@@ -504,7 +505,7 @@ export async function dismissChecklist(
 export async function resumeChecklist(
   client: SupabaseClient,
   tenantId: string,
-  userId: string,
+  _userId: string,
 ): Promise<ServiceResult<OnboardingProgressOutput>> {
   const now = new Date();
   const { data, error } = await client

--- a/ui/app/(protected)/layout.tsx
+++ b/ui/app/(protected)/layout.tsx
@@ -1,10 +1,25 @@
 import { DashboardShell } from "@/components/layout/dashboard-shell";
 import { requireAuth } from "@/features/auth/queries";
 import { getNotificationUnreadCount } from "@/features/notifications/queries";
+import { fetchOnboardingProgress } from "@/features/onboarding/queries";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await requireAuth();
-  const initialUnreadCount = user.role !== "guest" ? await getNotificationUnreadCount() : 0;
+
+  const [initialUnreadCount, onboardingProgress] = await Promise.all([
+    user.role !== "guest" ? getNotificationUnreadCount() : Promise.resolve(0),
+    // Fetch onboarding chip data only for owners; chip is hidden until row is initialized
+    user.role === "owner" ? fetchOnboardingProgress() : Promise.resolve(null),
+  ]);
+
+  // Build minimal chip data — only shown when state is not yet activated
+  const onboardingChip =
+    onboardingProgress && onboardingProgress.state !== "activated"
+      ? {
+          completedCount: onboardingProgress.completedCount,
+          totalSteps: onboardingProgress.totalSteps,
+        }
+      : null;
 
   return (
     <DashboardShell
@@ -13,6 +28,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
       userId={user.id}
       tenantId={user.tenantId}
       initialUnreadCount={initialUnreadCount}
+      onboardingChip={onboardingChip}
     >
       {children}
     </DashboardShell>

--- a/ui/app/(protected)/onboarding/error.tsx
+++ b/ui/app/(protected)/onboarding/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ErrorState } from "@enterprise/ui/components/error-state";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function OnboardingError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error, {
+      tags: { area: "onboarding" },
+    });
+  }, [error]);
+
+  return (
+    <ErrorState
+      message="An error occurred while loading your onboarding checklist. Please try again."
+      onReset={reset}
+    />
+  );
+}

--- a/ui/app/(protected)/onboarding/page.tsx
+++ b/ui/app/(protected)/onboarding/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from "next/navigation";
+import { requireAuth } from "@/features/auth/queries";
+import { OnboardingChecklist } from "@/features/onboarding/components/onboarding-checklist";
+import { fetchInitOnboardingProgress } from "@/features/onboarding/queries";
+import { ROUTES } from "@/lib/routes";
+
+export const metadata = { title: "Get started" };
+
+export default async function OnboardingPage() {
+  const user = await requireAuth();
+
+  // Non-owners are redirected — defense in depth (RLS is the real boundary)
+  if (user.role !== "owner") {
+    redirect(ROUTES.dashboard);
+  }
+
+  // Idempotent init: creates the row on first visit, returns existing on subsequent visits.
+  // Emits tenant_onboarding.started only on first call.
+  const progress = await fetchInitOnboardingProgress();
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <OnboardingChecklist progress={progress} />
+    </div>
+  );
+}

--- a/ui/components/layout/dashboard-shell.tsx
+++ b/ui/components/layout/dashboard-shell.tsx
@@ -3,7 +3,7 @@
 import type { UserRole } from "@enterprise/contracts";
 import { BottomTabBar } from "./bottom-tab-bar";
 import { Header } from "./header";
-import { Sidebar } from "./sidebar";
+import { type OnboardingChipData, Sidebar } from "./sidebar";
 
 interface DashboardShellProps {
   children: React.ReactNode;
@@ -12,6 +12,7 @@ interface DashboardShellProps {
   userId: string;
   tenantId: string;
   initialUnreadCount: number;
+  onboardingChip?: OnboardingChipData | null;
 }
 
 export function DashboardShell({
@@ -21,10 +22,11 @@ export function DashboardShell({
   userId,
   tenantId,
   initialUnreadCount,
+  onboardingChip,
 }: DashboardShellProps) {
   return (
     <div className="min-h-screen lg:h-screen">
-      <Sidebar userRole={userRole} userLabel={userLabel} />
+      <Sidebar userRole={userRole} userLabel={userLabel} onboardingChip={onboardingChip} />
       <div className="flex min-h-screen flex-1 flex-col lg:ml-[var(--sidebar-width)] lg:h-screen lg:overflow-hidden">
         <Header
           userRole={userRole}

--- a/ui/components/layout/sidebar.tsx
+++ b/ui/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "@enterprise/ui/lib/utils";
 import { CreditCard, LayoutDashboard, Package, Settings, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { OnboardingLauncherChip } from "@/features/onboarding/components/onboarding-launcher-chip";
 import { ROUTES } from "@/lib/routes";
 import type { NavItem } from "./nav-utils";
 import { filterNavItemsByRole, isNavItemActive } from "./nav-utils";
@@ -17,12 +18,18 @@ export const NAV_ITEMS: NavItem[] = [
   { label: "Settings", href: ROUTES.settings, icon: Settings, roles: ["owner", "admin"] },
 ];
 
+export interface OnboardingChipData {
+  completedCount: number;
+  totalSteps: number;
+}
+
 interface SidebarProps {
   userRole: UserRole;
   userLabel: string;
+  onboardingChip?: OnboardingChipData | null;
 }
 
-export function Sidebar({ userRole, userLabel }: SidebarProps) {
+export function Sidebar({ userRole, userLabel, onboardingChip }: SidebarProps) {
   const items = filterNavItemsByRole(NAV_ITEMS, userRole);
   const pathname = usePathname();
 
@@ -53,6 +60,16 @@ export function Sidebar({ userRole, userLabel }: SidebarProps) {
           );
         })}
       </nav>
+
+      {/* Onboarding launcher chip — owner-only, hidden once fully activated */}
+      {userRole === "owner" && onboardingChip && (
+        <div className="px-2 pb-2">
+          <OnboardingLauncherChip
+            completedCount={onboardingChip.completedCount}
+            totalSteps={onboardingChip.totalSteps}
+          />
+        </div>
+      )}
 
       <div className="mt-auto border-t p-4 text-xs text-muted-foreground">{userLabel}</div>
     </aside>

--- a/ui/features/onboarding/actions.ts
+++ b/ui/features/onboarding/actions.ts
@@ -5,14 +5,8 @@ import type {
   ActivationResult,
   OnboardingProgressOutput,
 } from "@enterprise/contracts";
-import {
-  completeBaselineStepSchema,
-  inviteMemberSchema,
-} from "@enterprise/contracts";
-import {
-  ConsoleInvitationEmailAdapter,
-  inviteTenantMember,
-} from "@enterprise/core/services";
+import { completeBaselineStepSchema, inviteMemberSchema } from "@enterprise/contracts";
+import { ConsoleInvitationEmailAdapter, inviteTenantMember } from "@enterprise/core/services";
 import {
   completeBaselineStep,
   completeOnboardingStep,

--- a/ui/features/onboarding/components/activation-banner.tsx
+++ b/ui/features/onboarding/components/activation-banner.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { CheckCircle2 } from "lucide-react";
+
+interface ActivationBannerProps {
+  activatedAt: Date | null;
+}
+
+export function ActivationBanner({ activatedAt }: ActivationBannerProps) {
+  if (!activatedAt) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-xl bg-success/10 px-4 py-3"
+    >
+      <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-success" aria-hidden="true" />
+      <div className="flex flex-col gap-0.5">
+        <p className="text-sm font-semibold text-success">Your workspace is ready</p>
+        <p className="text-sm text-muted-foreground">
+          You have completed the essential setup. Your workspace is now activated.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/features/onboarding/components/baseline-setup-form.tsx
+++ b/ui/features/onboarding/components/baseline-setup-form.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { ActionResult, ActivationResult } from "@enterprise/contracts";
+import { completeBaselineStepSchema } from "@enterprise/contracts";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { Input } from "@enterprise/ui/components/input";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { useFormValidation } from "@enterprise/ui/hooks/use-form-validation";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect } from "react";
+import { completeBaselineStepAction } from "@/features/onboarding/actions";
+
+interface BaselineSetupFormProps {
+  defaultWorkspaceName?: string;
+  defaultLocale?: string;
+  onSuccess?: () => void;
+}
+
+// Module-level wrapper — stable reference, no re-creation on render
+async function submitBaseline(
+  _prevState: ActionResult<ActivationResult> | null,
+  formData: FormData,
+): Promise<ActionResult<ActivationResult>> {
+  return completeBaselineStepAction({
+    name: formData.get("name"),
+    locale: formData.get("locale"),
+  });
+}
+
+export function BaselineSetupForm({
+  defaultWorkspaceName = "",
+  defaultLocale = "en-US",
+  onSuccess,
+}: BaselineSetupFormProps) {
+  const router = useRouter();
+
+  // Client-side Zod validation wrapping the server action
+  const validatedAction = useFormValidation({
+    schema: completeBaselineStepSchema,
+    serverAction: submitBaseline,
+  });
+
+  const [state, formAction] = useActionState(validatedAction, null);
+
+  // Trigger router refresh when the server action reports success
+  useEffect(() => {
+    if (state?.success) {
+      router.refresh();
+      onSuccess?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
+
+  return (
+    <form action={formAction} noValidate className="flex flex-col gap-4">
+      <FormBanner state={state} />
+
+      <FormField name="name" label="Workspace name" state={state} required>
+        <Input
+          placeholder="Acme Inc."
+          defaultValue={defaultWorkspaceName}
+          data-testid="baseline-name-input"
+        />
+      </FormField>
+
+      <FormField
+        name="locale"
+        label="Locale"
+        state={state}
+        required
+        description="BCP-47 language tag, e.g. en-US, pt-BR"
+      >
+        <Input
+          placeholder="en-US"
+          defaultValue={defaultLocale}
+          data-testid="baseline-locale-input"
+        />
+      </FormField>
+
+      <SubmitButton pendingText="Saving…" data-testid="baseline-submit-button">
+        Save workspace settings
+      </SubmitButton>
+    </form>
+  );
+}

--- a/ui/features/onboarding/components/dismiss-dialog.tsx
+++ b/ui/features/onboarding/components/dismiss-dialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@enterprise/ui/components/dialog";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { dismissChecklistAction } from "@/features/onboarding/actions";
+import { ROUTES } from "@/lib/routes";
+
+export function DismissDialog() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleConfirm() {
+    startTransition(async () => {
+      const result = await dismissChecklistAction();
+      if (result.success) {
+        setOpen(false);
+        // Navigate to dashboard — the chip in the sidebar serves as re-entry
+        router.push(ROUTES.dashboard);
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="text-muted-foreground">
+          Dismiss checklist
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Hide this checklist?</DialogTitle>
+          <DialogDescription>
+            You can reopen it at any time from the sidebar. Your progress will be saved.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="default"
+            onClick={handleConfirm}
+            disabled={isPending}
+            data-testid="dismiss-confirm-button"
+          >
+            {isPending ? "Hiding…" : "Hide checklist"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/features/onboarding/components/invite-step-trigger.tsx
+++ b/ui/features/onboarding/components/invite-step-trigger.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import type { ActionResult, ActivationResult } from "@enterprise/contracts";
+import { Button } from "@enterprise/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@enterprise/ui/components/dialog";
+import { FormBanner } from "@enterprise/ui/components/form-banner";
+import { FormField } from "@enterprise/ui/components/form-field";
+import { FormMessage } from "@enterprise/ui/components/form-message";
+import { Input } from "@enterprise/ui/components/input";
+import { Label } from "@enterprise/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@enterprise/ui/components/select";
+import { SubmitButton } from "@enterprise/ui/components/submit-button";
+import { UserPlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useActionState, useState } from "react";
+import { completeInviteStepAction } from "@/features/onboarding/actions";
+
+// Roles that can be invited during onboarding (same as tenant-team-management)
+const ASSIGNABLE_ROLES = [
+  { value: "admin", label: "Admin" },
+  { value: "member", label: "Member" },
+  { value: "guest", label: "Guest" },
+] as const;
+
+interface InviteStepTriggerProps {
+  onSuccess?: () => void;
+}
+
+export function InviteStepTrigger({ onSuccess }: InviteStepTriggerProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  async function boundAction(
+    _prevState: ActionResult<ActivationResult> | null,
+    formData: FormData,
+  ): Promise<ActionResult<ActivationResult>> {
+    const result = await completeInviteStepAction({
+      email: formData.get("email"),
+      role: formData.get("role"),
+    });
+
+    if (result.success) {
+      setOpen(false);
+      router.refresh();
+      onSuccess?.();
+    }
+
+    return result;
+  }
+
+  const [state, formAction] = useActionState(boundAction, null);
+
+  const roleError =
+    state && !state.success && state.error?.details
+      ? (state.error.details as Record<string, string[]>)["role"]?.[0]
+      : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" data-testid="invite-step-trigger-button">
+          <UserPlus className="size-4" />
+          Invite teammate
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite your first teammate</DialogTitle>
+          <DialogDescription>
+            Send an invitation email to add a teammate to your workspace.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form action={formAction} noValidate className="flex flex-col gap-4">
+          <FormBanner state={state} />
+
+          <FormField name="email" label="Email address" state={state} required>
+            <Input
+              type="email"
+              placeholder="colleague@example.com"
+              data-testid="invite-email-input"
+            />
+          </FormField>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="invite-role">
+              Role <span className="text-destructive">*</span>
+            </Label>
+            <Select name="role" defaultValue="member">
+              <SelectTrigger id="invite-role" data-testid="invite-role-select">
+                <SelectValue placeholder="Select role" />
+              </SelectTrigger>
+              <SelectContent>
+                {ASSIGNABLE_ROLES.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {roleError && <FormMessage>{roleError}</FormMessage>}
+          </div>
+
+          <SubmitButton pendingText="Sending…" data-testid="invite-submit-button">
+            Send invitation
+          </SubmitButton>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/features/onboarding/components/onboarding-checklist.tsx
+++ b/ui/features/onboarding/components/onboarding-checklist.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import type { OnboardingProgressOutput } from "@enterprise/contracts";
+import { Badge } from "@enterprise/ui/components/badge";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@enterprise/ui/components/card";
+import { cn } from "@enterprise/ui/lib/utils";
+import { CheckCircle2, Circle } from "lucide-react";
+import { ActivationBanner } from "./activation-banner";
+import { BaselineSetupForm } from "./baseline-setup-form";
+import { DismissDialog } from "./dismiss-dialog";
+import { InviteStepTrigger } from "./invite-step-trigger";
+import { SampleDataStep } from "./sample-data-step";
+
+interface OnboardingChecklistProps {
+  progress: OnboardingProgressOutput;
+}
+
+// ─── Inline progress bar (no Progress primitive in @enterprise/ui) ─────────────
+
+interface ProgressBarProps {
+  value: number; // 0–100
+}
+
+function ProgressBar({ value }: ProgressBarProps) {
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label="Setup progress"
+      className="h-2 w-full overflow-hidden rounded-full bg-muted"
+    >
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+}
+
+// ─── Step row ─────────────────────────────────────────────────────────────────
+
+interface StepRowProps {
+  label: string;
+  description: string;
+  completed: boolean;
+  optional?: boolean;
+  children?: React.ReactNode;
+}
+
+function StepRow({ label, description, completed, optional = false, children }: StepRowProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-xl p-4 transition-colors",
+        completed ? "opacity-60" : "bg-surface-container-low hover:bg-muted/50",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        {completed ? (
+          <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-success" aria-hidden="true" />
+        ) : (
+          <Circle className="mt-0.5 size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        <div className="flex flex-1 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium">{label}</span>
+            {optional && (
+              <Badge variant="neutral" className="text-xs">
+                Optional
+              </Badge>
+            )}
+            {completed && (
+              <Badge variant="success" className="text-xs">
+                Done
+              </Badge>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+      </div>
+
+      {!completed && children && <div className="ml-8">{children}</div>}
+    </div>
+  );
+}
+
+// ─── Main checklist ───────────────────────────────────────────────────────────
+
+export function OnboardingChecklist({ progress }: OnboardingChecklistProps) {
+  const { completedCount, totalSteps, activatedAt } = progress;
+  const progressPercent = totalSteps > 0 ? Math.round((completedCount / totalSteps) * 100) : 0;
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="onboarding-checklist">
+      {activatedAt && <ActivationBanner activatedAt={activatedAt} />}
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <CardTitle>Get started</CardTitle>
+              <span
+                role="status"
+                className="text-sm font-medium text-muted-foreground"
+                aria-label={`${completedCount} of ${totalSteps} steps complete`}
+              >
+                {completedCount}/{totalSteps}
+              </span>
+            </div>
+            <ProgressBar value={progressPercent} />
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex flex-col gap-3">
+          {/* Step 1: Baseline workspace setup (mandatory) */}
+          <StepRow
+            label="Set up your workspace"
+            description="Give your workspace a name and set the locale for date and number formatting."
+            completed={progress.baselineCompleted}
+          >
+            <BaselineSetupForm />
+          </StepRow>
+
+          {/* Step 2: Invite first teammate (optional) */}
+          <StepRow
+            label="Invite your first teammate"
+            description="Add a colleague to start collaborating in your workspace."
+            completed={progress.firstInviteCompleted}
+            optional
+          >
+            <InviteStepTrigger />
+          </StepRow>
+
+          {/* Step 3: Load sample data (optional) */}
+          <StepRow
+            label="Load sample data"
+            description="Populate your workspace with starter records to explore the platform."
+            completed={progress.sampleDataCompleted}
+            optional
+          >
+            <SampleDataStep />
+          </StepRow>
+        </CardContent>
+
+        <CardFooter className="justify-end">
+          <DismissDialog />
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/ui/features/onboarding/components/onboarding-launcher-chip.tsx
+++ b/ui/features/onboarding/components/onboarding-launcher-chip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@enterprise/ui/lib/utils";
+import { Rocket } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ROUTES } from "@/lib/routes";
+
+interface OnboardingLauncherChipProps {
+  completedCount: number;
+  totalSteps: number;
+  className?: string;
+}
+
+export function OnboardingLauncherChip({
+  completedCount,
+  totalSteps,
+  className,
+}: OnboardingLauncherChipProps) {
+  const pathname = usePathname();
+  const isActive = pathname === ROUTES.onboarding;
+
+  return (
+    <Link
+      href={ROUTES.onboarding}
+      aria-label={`Workspace setup: ${completedCount} of ${totalSteps} steps complete`}
+      data-testid="onboarding-launcher-chip"
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all",
+        isActive
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        className,
+      )}
+    >
+      <Rocket className="size-4 shrink-0" aria-hidden="true" />
+      <span>
+        Setup{" "}
+        <span className="text-xs font-normal">
+          · {completedCount}/{totalSteps}
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/ui/features/onboarding/components/sample-data-step.tsx
+++ b/ui/features/onboarding/components/sample-data-step.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Button } from "@enterprise/ui/components/button";
+import { Database, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { seedSampleDataAction } from "@/features/onboarding/actions";
+
+interface SampleDataStepProps {
+  onSuccess?: () => void;
+}
+
+export function SampleDataStep({ onSuccess }: SampleDataStepProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function handleLoad() {
+    setErrorMessage(null);
+    startTransition(async () => {
+      const result = await seedSampleDataAction();
+
+      if (result.success) {
+        router.refresh();
+        onSuccess?.();
+      } else {
+        setErrorMessage(result.error?.message ?? "Sample data could not be loaded. Try again.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleLoad}
+        disabled={isPending}
+        data-testid="load-sample-data-button"
+      >
+        {isPending ? (
+          <>
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            Loading…
+          </>
+        ) : (
+          <>
+            <Database className="size-4" aria-hidden="true" />
+            Load sample data
+          </>
+        )}
+      </Button>
+
+      {errorMessage && (
+        <p role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Chained PR 5/6. The `/onboarding` page, checklist components, and sidebar launcher chip.

## Changes

| File | Change |
|------|--------|
| `ui/app/(protected)/onboarding/page.tsx`, `error.tsx` | SSR page (owner guard) + error boundary |
| `ui/features/onboarding/components/*` | 8 components: checklist, baseline form, invite trigger, sample-data CTA, activation banner, dismiss dialog, launcher chip |
| `ui/components/layout/*` | Sidebar wiring for the launcher chip (owners only) |

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes

### UI Verification
- [x] All UI states handled (loading, error, empty)
- [x] `router.refresh()` on mutations affecting server data
- [x] E2E coverage added in PR 6/6

> Chained PR 5/6. Base: `feat/tenant-onboarding-actions` (review after 4/6).