### PR TITLE
test(e2e): tenant-onboarding seed, E2E, sample-data [6/6]

### DIFF
--- a/docs/features/roadmap.md
+++ b/docs/features/roadmap.md
@@ -39,7 +39,7 @@ Define the canonical implementation priority for planned features in this templa
 | 15 | P1 | Brand isolation package | Done | Enforces brand code boundaries and prevents brand logic leaks into shared packages. |
 | 16 | P1 | Backend provider decoupling | Done | Introduces port/adapter interfaces to decouple @enterprise/core from Supabase. |
 | 17 | P1 | Test and CI stability hardening | Done | Removes flaky E2E (notifications timing/delay), closes test-coverage gaps, and enforces lockfile/build checks so future feature PRDs don't break the pipeline. |
-| 18 | P2 | Tenant onboarding | Planned | Improves activation and first-run time-to-value. |
+| 18 | P2 | Tenant onboarding | In progress | Improves activation and first-run time-to-value. |
 | 19 | P2 | File storage module | Planned | Covers a common SaaS need for tenant-scoped file handling. |
 | 20 | P2 | i18n and regional settings | Planned | Expands reuse across regions and teams. |
 | 21 | P2 | Deployment provider decoupling | Planned | Adds Docker support and deployment-target abstraction for non-Vercel hosting. |
@@ -89,4 +89,4 @@ Define the canonical implementation priority for planned features in this templa
 
 ---
 
-*Last updated: 2026-05-31*
+*Last updated: 2026-06-07*

--- a/docs/features/tenant-onboarding/prd.md
+++ b/docs/features/tenant-onboarding/prd.md
@@ -299,15 +299,15 @@ Acceptance criteria:
 
 ### Production readiness
 
-- [ ] All audit events verified in `audit_log` table
-- [ ] Sentry area `onboarding` registered and Server Actions instrumented
-- [ ] Unit tests pass for `packages/core/src/services/onboarding-service.ts`
-- [ ] E2E tests pass for all defined flows in `ui/e2e/tenant-onboarding/`
-- [ ] RLS policies verified — no cross-tenant `tenant_onboarding_progress` leaks
-- [ ] Seed data committed and `supabase db reset` works cleanly
-- [ ] `tenant.activated` fires at most once per tenant (idempotency verified in service tests)
-- [ ] Activation rule documented as an override point in `onboarding-service.ts`
-- [ ] `/onboarding` route registered in `ui/lib/routes.ts` (ROUTES object)
+- [ ] All audit events verified in `audit_log` table — requires running DB + manual smoke (CI-gated)
+- [x] Sentry area `onboarding` registered and Server Actions instrumented — Phase 4
+- [x] Unit tests pass for `packages/core/src/services/onboarding-service.ts` — Phase 3 (10+ tests, 200/200)
+- [x] E2E tests written for all defined flows (`ui/e2e/onboarding/onboarding.spec.ts`) — Phase 6; full run is CI-gated
+- [x] RLS policies verified — no cross-tenant `tenant_onboarding_progress` leaks — Phase 2 (4 policies: select/insert/update owner-only, delete service-role)
+- [x] Seed data committed — `supabase/seed.sql` includes 3 onboarding progress rows (not_started, in_progress, activated) — Phase 6
+- [x] `tenant.activated` fires at most once per tenant (idempotency verified in service tests) — Phase 3 (`evaluateActivation` guard)
+- [x] Activation rule documented as an override point in `onboarding-service.ts` — Phase 3
+- [x] `/onboarding` route registered in `ui/lib/routes.ts` (ROUTES object) — Phase 4
 
 ---
 

--- a/packages/core/src/services/__tests__/onboarding-service.test.ts
+++ b/packages/core/src/services/__tests__/onboarding-service.test.ts
@@ -362,6 +362,120 @@ describe("completeOnboardingStep", () => {
 // ─── seedSampleData ────────────────────────────────────────────────────────────
 
 describe("seedSampleData", () => {
+  it("fresh seed — inserts 3 demo resources, marks step, emits sample_data_seeded event", async () => {
+    const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    const resourcesUpsert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    // IN_PROGRESS_ROW has baseline_completed_at set but sample_data_completed_at null
+    // → enters the !alreadySeeded block; evaluateActivation will see no value step → no activation
+    const client = buildClient({
+      tenant_onboarding_progress: {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi
+              .fn()
+              .mockResolvedValueOnce({ data: IN_PROGRESS_ROW, error: null }) // idempotency check
+              .mockResolvedValueOnce({ data: IN_PROGRESS_ROW, error: null }), // evaluateActivation SELECT
+          })),
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ data: null, error: null }), // progress mark
+        })),
+      },
+      resources: {
+        upsert: resourcesUpsert,
+      },
+      audit_log: { insert: auditInsert },
+    });
+
+    const result = await seedSampleData(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(true);
+
+    // 3 demo resources were upserted
+    expect(resourcesUpsert).toHaveBeenCalledOnce();
+    const [rows, opts] = resourcesUpsert.mock.calls[0] as [
+      Array<Record<string, unknown>>,
+      Record<string, unknown>,
+    ];
+    expect(rows).toHaveLength(3);
+    const titles = rows.map((r) => r["title"]);
+    expect(titles).toContain("[Demo] Starter Product");
+    expect(titles).toContain("[Demo] Onboarding Guide");
+    expect(titles).toContain("[Demo] Sample Service Plan");
+    // Verify each row has tenant_id and created_by set
+    for (const row of rows) {
+      expect(row["tenant_id"]).toBe(TENANT_ID);
+      expect(row["created_by"]).toBe(USER_ID);
+      expect(typeof row["id"]).toBe("string"); // deterministic id present
+    }
+    // Idempotent upsert options — same IDs on retry will be ignored
+    expect(opts).toMatchObject({ onConflict: "id", ignoreDuplicates: true });
+
+    // Audit event was fired for sample_data_seeded
+    expect(auditInsert).toHaveBeenCalled();
+  });
+
+  it("retry safety — deterministic IDs produce identical rows on repeated calls", async () => {
+    // Both calls share the same resources.upsert mock to capture both batches
+    const resourcesUpsert = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    function makeClient() {
+      return buildClient({
+        tenant_onboarding_progress: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi
+                .fn()
+                .mockResolvedValueOnce({ data: IN_PROGRESS_ROW, error: null })
+                .mockResolvedValueOnce({ data: IN_PROGRESS_ROW, error: null }),
+            })),
+          })),
+          update: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
+        },
+        resources: { upsert: resourcesUpsert },
+        audit_log: { insert: vi.fn().mockResolvedValue({ data: null, error: null }) },
+      });
+    }
+
+    await seedSampleData(makeClient(), TENANT_ID, USER_ID);
+    await seedSampleData(makeClient(), TENANT_ID, USER_ID);
+
+    const call1 = resourcesUpsert.mock.calls[0] as [Array<Record<string, unknown>>];
+    const call2 = resourcesUpsert.mock.calls[1] as [Array<Record<string, unknown>>];
+    const ids1 = call1[0].map((r) => r["id"]);
+    const ids2 = call2[0].map((r) => r["id"]);
+
+    // Same deterministic IDs for the same tenantId → upsert ignoreDuplicates is safe on retry
+    expect(ids1).toEqual(ids2);
+  });
+
+  it("insert failure — returns SEED_INSERT_FAILED, step is NOT marked complete", async () => {
+    const resourcesUpsert = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "DB constraint violation" } });
+
+    const client = buildClient({
+      tenant_onboarding_progress: {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({ data: IN_PROGRESS_ROW, error: null }),
+          })),
+        })),
+      },
+      resources: { upsert: resourcesUpsert },
+    });
+
+    const result = await seedSampleData(client, TENANT_ID, USER_ID);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("SEED_INSERT_FAILED");
+    }
+  });
+
   it("idempotent — re-run does not duplicate step_completed; marks step once", async () => {
     const auditInsert = vi.fn().mockResolvedValue({ data: null, error: null });
 

--- a/packages/core/src/services/onboarding-service.ts
+++ b/packages/core/src/services/onboarding-service.ts
@@ -5,6 +5,7 @@
 //
 // Activation override point: evaluateActivation() — see internal docs below.
 
+import { createHash } from "node:crypto";
 import type {
   ActivationResult,
   CompleteBaselineStepDto,
@@ -28,6 +29,51 @@ interface OnboardingProgressRow {
   activated_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+// ─── Demo seed resources ─────────────────────────────────────────────────────
+
+/** Starter demo resources inserted during the sample-data onboarding step. */
+const DEMO_RESOURCES = [
+  {
+    title: "[Demo] Starter Product",
+    type: "product" as const,
+    status: "active" as const,
+    description: "Example resource so you can see how your workspace looks.",
+  },
+  {
+    title: "[Demo] Onboarding Guide",
+    type: "document" as const,
+    status: "active" as const,
+    description: "A sample document. Safe to edit or delete.",
+  },
+  {
+    title: "[Demo] Sample Service Plan",
+    type: "service" as const,
+    status: "draft" as const,
+    description: "A draft service example to show status badges.",
+  },
+] as const;
+
+/**
+ * Derives a deterministic UUID from a tenant ID and resource title.
+ * Uses SHA-256 and formats the hash as a UUID v4-compatible string
+ * (version nibble = 4, variant = RFC 4122 10xx).
+ *
+ * Combined with `upsert({ onConflict: "id", ignoreDuplicates: true })`,
+ * this makes demo-resource insertion safe to retry after a partial failure.
+ */
+function deriveDemoResourceId(tenantId: string, title: string): string {
+  const hash = createHash("sha256").update(`demo-resource:${tenantId}:${title}`).digest("hex");
+  const b16 = hash[16] ?? "0";
+  const variantHex = ((parseInt(b16, 16) & 0x3) | 0x8).toString(16);
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    `4${hash.slice(13, 16)}`,
+    `${variantHex}${hash.slice(17, 20)}`,
+    hash.slice(20, 32),
+  ].join("-");
 }
 
 // ─── Audit Logging ────────────────────────────────────────────────────────────
@@ -437,8 +483,25 @@ export async function seedSampleData(
   const alreadySeeded = row.sample_data_completed_at !== null;
 
   if (!alreadySeeded) {
-    // TODO Phase 6: insert idempotent starter resource rows tagged as demo data
-    // For now, mark the step and emit the event
+    // Build demo resource rows with deterministic IDs so a retry after a partial
+    // failure (insert ok, progress update fails) won't create duplicates.
+    const demoRows = DEMO_RESOURCES.map((r) => ({
+      id: deriveDemoResourceId(tenantId, r.title),
+      tenant_id: tenantId,
+      created_by: userId,
+      title: r.title,
+      type: r.type,
+      status: r.status,
+      description: r.description,
+    }));
+
+    const { error: insertError } = await client
+      .from("resources")
+      .upsert(demoRows, { onConflict: "id", ignoreDuplicates: true });
+
+    if (insertError) {
+      return { success: false, error: insertError.message, code: "SEED_INSERT_FAILED" };
+    }
 
     const now = new Date();
     const { error: updateError } = await client

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -704,3 +704,106 @@ SELECT
 FROM public.profiles p
 WHERE p.id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
 ON CONFLICT (id) DO NOTHING;
+
+-- ─── Onboarding: seed progress rows ──────────────────────────────────────────
+--
+-- Three rows representing the three canonical onboarding states, one per tenant.
+-- Row 1 → admin demo tenant (not_started)  — primary E2E scenario starting point.
+-- Row 2 → in_progress   state (baseline done, value step pending, not yet activated).
+-- Row 3 → activated      state (baseline + sample-data done, activated_at set).
+--
+-- Rows 2 and 3 use deterministic seed-only tenant entries (slugs: seed-inprogress,
+-- seed-activated) that exist only for state-representation purposes.
+-- All UUIDs use the e0000001-… prefix to avoid collisions with other seed records.
+-- Idempotent: ON CONFLICT (id) / (tenant_id) DO NOTHING — safe to run repeatedly.
+--
+-- User reference:
+--   demo tenant owner → a1b2c3d4-e5f6-7890-abcd-ef1234567890 (admin@enterprise.dev)
+
+-- Seed-only tenants for the in_progress and activated state reference rows.
+INSERT INTO public.tenants (id, name, slug, status, created_at, updated_at)
+VALUES
+  (
+    'e0000001-0000-0000-0001-000000000001'::uuid,
+    'Seed In-Progress Org',
+    'seed-inprogress',
+    'active',
+    NOW(),
+    NOW()
+  ),
+  (
+    'e0000001-0000-0000-0001-000000000002'::uuid,
+    'Seed Activated Org',
+    'seed-activated',
+    'active',
+    NOW(),
+    NOW()
+  )
+ON CONFLICT (slug) DO NOTHING;
+
+-- Onboarding progress rows (3 states).
+INSERT INTO public.tenant_onboarding_progress (
+  id,
+  tenant_id,
+  state,
+  baseline_completed_at,
+  first_invite_completed_at,
+  sample_data_completed_at,
+  dismissed,
+  dismissed_at,
+  activated_at,
+  created_at,
+  updated_at
+)
+SELECT
+  e.id::uuid,
+  e.tenant_id,
+  e.state::onboarding_state,
+  e.baseline_completed_at,
+  e.first_invite_completed_at,
+  e.sample_data_completed_at,
+  e.dismissed,
+  e.dismissed_at,
+  e.activated_at,
+  NOW(),
+  NOW()
+FROM (
+  VALUES
+    -- Row 1: admin demo tenant — not_started (E2E serial-flow baseline)
+    (
+      'e0000001-0000-0000-0000-000000000001',
+      (SELECT tenant_id FROM public.profiles WHERE id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'),
+      'not_started',
+      NULL::timestamptz,
+      NULL::timestamptz,
+      NULL::timestamptz,
+      FALSE,
+      NULL::timestamptz,
+      NULL::timestamptz
+    ),
+    -- Row 2: seed-inprogress tenant — baseline complete, awaiting value step
+    (
+      'e0000001-0000-0000-0000-000000000002',
+      'e0000001-0000-0000-0001-000000000001'::uuid,
+      'in_progress',
+      NOW() - INTERVAL '10 minutes',
+      NULL::timestamptz,
+      NULL::timestamptz,
+      FALSE,
+      NULL::timestamptz,
+      NULL::timestamptz
+    ),
+    -- Row 3: seed-activated tenant — baseline + sample-data complete, activated
+    (
+      'e0000001-0000-0000-0000-000000000003',
+      'e0000001-0000-0000-0001-000000000002'::uuid,
+      'activated',
+      NOW() - INTERVAL '20 minutes',
+      NULL::timestamptz,
+      NOW() - INTERVAL '15 minutes',
+      FALSE,
+      NULL::timestamptz,
+      NOW() - INTERVAL '15 minutes'
+    )
+) AS e(id, tenant_id, state, baseline_completed_at, first_invite_completed_at, sample_data_completed_at, dismissed, dismissed_at, activated_at)
+ON CONFLICT (id) DO NOTHING;

--- a/ui/e2e/onboarding/onboarding-page.ts
+++ b/ui/e2e/onboarding/onboarding-page.ts
@@ -1,0 +1,164 @@
+import { expect, type Page } from "@playwright/test";
+import { ROUTES } from "../helpers/routes";
+
+/**
+ * Page Object Model for the /onboarding route.
+ *
+ * Encapsulates all selectors and interactions for the onboarding checklist page.
+ * Follows the project's POM convention: no test logic here — only reusable page actions.
+ */
+export class OnboardingPage {
+  constructor(private readonly page: Page) {}
+
+  // ─── Navigation ─────────────────────────────────────────────────────────────
+
+  /**
+   * Navigate to /onboarding and wait until the checklist card is visible.
+   * Content-ready guard: prevents flaky selector misses on slow CI cold starts.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto(ROUTES.onboarding);
+    await this.page.waitForURL(new RegExp(ROUTES.onboarding));
+    await expect(this.page.getByTestId("onboarding-checklist")).toBeVisible({
+      timeout: 30_000,
+    });
+  }
+
+  // ─── Baseline setup form ────────────────────────────────────────────────────
+
+  async fillBaselineForm(workspaceName: string, locale = "en-US"): Promise<void> {
+    await this.page.getByTestId("baseline-name-input").fill(workspaceName);
+    await this.page.getByTestId("baseline-locale-input").fill(locale);
+  }
+
+  async clearBaselineName(): Promise<void> {
+    await this.page.getByTestId("baseline-name-input").clear();
+  }
+
+  async submitBaselineForm(): Promise<void> {
+    const submitBtn = this.page.getByTestId("baseline-submit-button");
+    await submitBtn.click();
+    // Wait for form to leave pending state (either success or error).
+    await expect(submitBtn).not.toContainText("Saving", { timeout: 30_000 });
+  }
+
+  /**
+   * Asserts that the baseline step is marked complete.
+   * When complete, the form (and submit button) are hidden via `{!completed && children}`.
+   */
+  async expectBaselineStepCompleted(): Promise<void> {
+    await expect(this.page.getByTestId("baseline-submit-button")).toHaveCount(0, {
+      timeout: 30_000,
+    });
+  }
+
+  async expectBaselineFormVisible(): Promise<void> {
+    await expect(this.page.getByTestId("baseline-submit-button")).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+
+  // ─── Invite step ────────────────────────────────────────────────────────────
+
+  async openInviteDialog(): Promise<void> {
+    await this.page.getByTestId("invite-step-trigger-button").click();
+    await expect(this.page.getByRole("dialog")).toBeVisible({ timeout: 15_000 });
+  }
+
+  async fillInviteEmail(email: string): Promise<void> {
+    await this.page.getByTestId("invite-email-input").fill(email);
+  }
+
+  async submitInviteForm(): Promise<void> {
+    const submitBtn = this.page.getByTestId("invite-submit-button");
+    await submitBtn.click();
+    await expect(submitBtn).not.toContainText("Sending", { timeout: 30_000 });
+  }
+
+  /**
+   * Asserts that the invite step is marked complete.
+   * When complete, the invite trigger button is hidden.
+   */
+  async expectInviteStepCompleted(): Promise<void> {
+    await expect(this.page.getByTestId("invite-step-trigger-button")).toHaveCount(0, {
+      timeout: 30_000,
+    });
+  }
+
+  // ─── Sample data step ────────────────────────────────────────────────────────
+
+  async loadSampleData(): Promise<void> {
+    const btn = this.page.getByTestId("load-sample-data-button");
+    await btn.click();
+    await expect(btn).not.toContainText("Loading", { timeout: 30_000 });
+  }
+
+  /**
+   * Asserts that the sample data step is marked complete.
+   * When complete, the load button is hidden.
+   */
+  async expectSampleDataStepCompleted(): Promise<void> {
+    await expect(this.page.getByTestId("load-sample-data-button")).toHaveCount(0, {
+      timeout: 30_000,
+    });
+  }
+
+  // ─── Activation ─────────────────────────────────────────────────────────────
+
+  async expectActivationBanner(): Promise<void> {
+    await expect(this.page.getByText("Your workspace is ready")).toBeVisible({
+      timeout: 30_000,
+    });
+  }
+
+  async expectNoActivationBanner(): Promise<void> {
+    await expect(this.page.getByText("Your workspace is ready")).toHaveCount(0);
+  }
+
+  // ─── Progress indicator ─────────────────────────────────────────────────────
+
+  /**
+   * Checks the `N/M` progress counter displayed in the checklist header.
+   * Matches the exact text emitted by the `role="status"` span.
+   */
+  async expectProgressText(completed: number, total: number): Promise<void> {
+    await expect(
+      this.page.getByRole("status").filter({ hasText: `${completed}/${total}` }),
+    ).toBeVisible({ timeout: 15_000 });
+  }
+
+  // ─── Dismiss dialog ─────────────────────────────────────────────────────────
+
+  async openDismissDialog(): Promise<void> {
+    await this.page.getByRole("button", { name: "Dismiss checklist" }).click();
+    await expect(this.page.getByRole("dialog")).toBeVisible({ timeout: 15_000 });
+  }
+
+  async confirmDismiss(): Promise<void> {
+    await this.page.getByTestId("dismiss-confirm-button").click();
+  }
+
+  // ─── Launcher chip ──────────────────────────────────────────────────────────
+
+  async expectLauncherChipVisible(): Promise<void> {
+    await expect(this.page.getByTestId("onboarding-launcher-chip")).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+
+  async expectLauncherChipHidden(): Promise<void> {
+    await expect(this.page.getByTestId("onboarding-launcher-chip")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  }
+
+  // ─── Redirect assertions ────────────────────────────────────────────────────
+
+  async expectRedirectedToDashboard(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(ROUTES.dashboard), { timeout: 15_000 });
+  }
+
+  async expectRedirectedToSignIn(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/sign-in/, { timeout: 15_000 });
+  }
+}

--- a/ui/e2e/onboarding/onboarding.spec.ts
+++ b/ui/e2e/onboarding/onboarding.spec.ts
@@ -1,0 +1,239 @@
+import { expect, test } from "@playwright/test";
+import { login } from "../helpers/auth";
+import { ROUTES } from "../helpers/routes";
+import { deleteRows, supabaseRequest, updateRows } from "../helpers/supabase-rest";
+import { OnboardingPage } from "./onboarding-page";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Deterministic owner user ID from seed.sql (admin@enterprise.dev). */
+const ADMIN_USER_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+/** Prefix for E2E invite emails — used for targeted teardown. */
+const E2E_INVITE_PREFIX = "e2e-onboarding-invite";
+
+// ─── Setup helpers ────────────────────────────────────────────────────────────
+
+async function getAdminTenantId(): Promise<string> {
+  const rows = await supabaseRequest<Array<{ tenant_id: string }>>("profiles", {
+    params: { id: `eq.${ADMIN_USER_ID}`, select: "tenant_id", limit: "1" },
+  });
+  const [profile] = rows;
+  if (!profile?.tenant_id) throw new Error("Unable to resolve admin tenant_id from profiles");
+  return profile.tenant_id;
+}
+
+/**
+ * Reset the admin tenant's onboarding progress to a known, consistent state.
+ * Uses the service-role key (bypasses RLS). Safe only in E2E setup/teardown.
+ *
+ * - "not_started": all steps null, no activation
+ * - "in_progress":  baseline done, value steps pending, not activated
+ */
+async function resetOnboarding(
+  tenantId: string,
+  state: "not_started" | "in_progress" = "not_started",
+): Promise<void> {
+  const baselineCompletedAt =
+    state === "in_progress" ? new Date(Date.now() - 10 * 60 * 1000).toISOString() : null;
+
+  await updateRows(
+    "tenant_onboarding_progress",
+    { tenant_id: `eq.${tenantId}` },
+    {
+      state,
+      baseline_completed_at: baselineCompletedAt,
+      first_invite_completed_at: null,
+      sample_data_completed_at: null,
+      dismissed: false,
+      dismissed_at: null,
+      activated_at: null,
+    },
+  );
+}
+
+/** Remove E2E invite rows created during the activation flow serial suite. */
+async function teardownInvites(): Promise<void> {
+  try {
+    await deleteRows("tenant_invitations", { email: `like.${E2E_INVITE_PREFIX}%` });
+  } catch (err) {
+    console.warn("[teardown] onboarding E2E invite cleanup failed:", err);
+  }
+}
+
+// ─── Auth guard ───────────────────────────────────────────────────────────────
+
+test.describe("Tenant Onboarding — auth guard", () => {
+  test(`unauthenticated visit to ${ROUTES.onboarding} redirects to sign-in`, {
+    tag: ["@critical", "@e2e", "@onboarding", "@ONBOARDING-E2E-001"],
+  }, async ({ page }) => {
+    const onboarding = new OnboardingPage(page);
+    await page.goto(ROUTES.onboarding);
+    await onboarding.expectRedirectedToSignIn();
+  });
+});
+
+// ─── Access control and RLS ───────────────────────────────────────────────────
+
+test.describe("Tenant Onboarding — access control and RLS", () => {
+  test("non-owner (member) accessing /onboarding is redirected to /dashboard", {
+    tag: ["@critical", "@e2e", "@onboarding", "@ONBOARDING-E2E-002"],
+  }, async ({ page }) => {
+    // member@enterprise.dev is in the admin tenant but has role=member (not owner).
+    // The page server component enforces owner-only; non-owners redirect to dashboard.
+    const onboarding = new OnboardingPage(page);
+    await login(page, "member@enterprise.dev", "password123");
+    await page.goto(ROUTES.onboarding);
+    await onboarding.expectRedirectedToDashboard();
+  });
+
+  test("non-owner does not see launcher chip — cross-tenant / role RLS isolation", {
+    tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-003"],
+  }, async ({ page }) => {
+    // The launcher chip is rendered server-side in the layout only for owners.
+    // A member-role JWT must not trigger the chip query; chip must be absent from DOM.
+    const onboarding = new OnboardingPage(page);
+    await login(page, "member@enterprise.dev", "password123");
+    // login() lands on dashboard — chip must not be visible in the shell.
+    await onboarding.expectLauncherChipHidden();
+  });
+});
+
+// ─── Owner activation flow (stateful serial) ─────────────────────────────────
+
+test.describe
+  .serial("Tenant Onboarding — owner activation flow", () => {
+    let tenantId: string;
+    // Unique email per run avoids conflicts with DB-persisted invitations from prior E2E runs.
+    const inviteEmail = `${E2E_INVITE_PREFIX}-${Date.now()}@example.com`;
+
+    test.beforeAll(async () => {
+      tenantId = await getAdminTenantId();
+      await resetOnboarding(tenantId, "not_started");
+    });
+
+    test.afterAll(async () => {
+      // Restore to not_started so subsequent runs and other suites start clean.
+      await resetOnboarding(tenantId, "not_started");
+      await teardownInvites();
+    });
+
+    test("checklist renders in not_started state — 0/3 progress, no activation banner", {
+      tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-004"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      await onboarding.expectProgressText(0, 3);
+      await onboarding.expectNoActivationBanner();
+      await onboarding.expectBaselineFormVisible();
+    });
+
+    test("owner completes baseline setup step — progress increments to 1/3", {
+      tag: ["@critical", "@e2e", "@onboarding", "@ONBOARDING-E2E-005"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      await onboarding.fillBaselineForm("E2E Demo Workspace", "en-US");
+      await onboarding.submitBaselineForm();
+      await onboarding.expectBaselineStepCompleted();
+      await onboarding.expectProgressText(1, 3);
+      // Activation must NOT fire yet — baseline alone does not satisfy criteria.
+      await onboarding.expectNoActivationBanner();
+    });
+
+    test("owner completes first-invite step via onboarding checklist", {
+      tag: ["@critical", "@e2e", "@onboarding", "@ONBOARDING-E2E-006"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      await onboarding.openInviteDialog();
+      await onboarding.fillInviteEmail(inviteEmail);
+      await onboarding.submitInviteForm();
+      await onboarding.expectInviteStepCompleted();
+    });
+
+    test("activation banner shown after baseline + first-invite (value step criteria met)", {
+      tag: ["@critical", "@e2e", "@onboarding", "@ONBOARDING-E2E-007"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      // baseline + first-invite satisfies: mandatory baseline AND ≥1 value step.
+      await onboarding.expectActivationBanner();
+    });
+
+    test("launcher chip is hidden in dashboard shell after workspace is activated", {
+      tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-008"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await page.goto(ROUTES.dashboard);
+      // Chip must not render for tenants in activated state.
+      await onboarding.expectLauncherChipHidden();
+    });
+  });
+
+// ─── Dismiss and resume (stateful serial) ─────────────────────────────────────
+
+test.describe
+  .serial("Tenant Onboarding — dismiss and resume", () => {
+    let tenantId: string;
+
+    test.beforeAll(async () => {
+      tenantId = await getAdminTenantId();
+      // Start at in_progress: baseline complete, value steps pending, not dismissed.
+      await resetOnboarding(tenantId, "in_progress");
+    });
+
+    test.afterAll(async () => {
+      await resetOnboarding(tenantId, "not_started");
+    });
+
+    test("partial checklist (in_progress) preserves state across navigations", {
+      tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-009"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      // Baseline step is complete (1/3); value steps are pending.
+      await onboarding.expectProgressText(1, 3);
+      await onboarding.expectBaselineStepCompleted();
+      await onboarding.expectNoActivationBanner();
+      // Navigate away and return — server-side progress must be unchanged.
+      await page.goto(ROUTES.dashboard);
+      await onboarding.goto();
+      await onboarding.expectProgressText(1, 3);
+    });
+
+    test("owner dismisses checklist — redirected to dashboard with launcher chip visible", {
+      tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-010"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      await onboarding.goto();
+      await onboarding.openDismissDialog();
+      await onboarding.confirmDismiss();
+      // DismissDialog calls router.push(ROUTES.dashboard) on confirm.
+      await onboarding.expectRedirectedToDashboard();
+      // Chip must appear in the shell for in_progress dismissed tenants.
+      await onboarding.expectLauncherChipVisible();
+    });
+
+    test("clicking launcher chip reopens checklist with preserved progress (1/3)", {
+      tag: ["@high", "@e2e", "@onboarding", "@ONBOARDING-E2E-011"],
+    }, async ({ page }) => {
+      const onboarding = new OnboardingPage(page);
+      await login(page);
+      // Previous serial test set dismissed=true — chip must be visible on fresh load.
+      await page.goto(ROUTES.dashboard);
+      await onboarding.expectLauncherChipVisible();
+      // Click chip — navigates to /onboarding (standard anchor link, not router.push).
+      await page.getByTestId("onboarding-launcher-chip").click();
+      await expect(page).toHaveURL(new RegExp(ROUTES.onboarding), { timeout: 15_000 });
+      // State must be preserved: 1/3 progress, baseline done.
+      await onboarding.expectProgressText(1, 3);
+    });
+  });


### PR DESCRIPTION
## Summary

- Chained PR 6/6 (final). Seed data, E2E coverage, real sample-data seeding, and roadmap update.

## Changes

| File | Change |
|------|--------|
| `ui/e2e/onboarding/onboarding-page.ts` | Page Object Model |
| `ui/e2e/onboarding/onboarding.spec.ts` | 11 E2E scenarios (serial, no networkidle) |
| `supabase/seed.sql` | 3 idempotent onboarding rows (not_started / in_progress / activated) |
| `packages/core/src/services/onboarding-service.ts` | Real sample-data seeding (deterministic-id upsert) + tests |
| `docs/features/roadmap.md` | tenant-onboarding → In progress |

## Verification

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (893 unit)
- [x] `pnpm exec playwright test ui/e2e/onboarding --list` → 11 tests compile
- [ ] Full `pnpm e2e` against live Supabase — CI-gated

> Chained PR 6/6. Base: `feat/tenant-onboarding-ui` (review after 5/6). Once all slices merge, flip roadmap #18 to "Done".