### PR TITLE
chore(openspec): reconcile change state with shipped code

### DIFF
--- a/openspec/changes/archive/2026-06-08-notifications/archive-report.md
+++ b/openspec/changes/archive/2026-06-08-notifications/archive-report.md
@@ -1,0 +1,26 @@
+# Archive Report: Notifications
+
+**Archived**: 2026-06-08
+**Status**: Shipped (implemented and merged to `main`)
+
+## Summary
+
+The notifications feature described by this change was fully implemented and merged
+to `main` ahead of this archive. The planning artifacts (proposal, design, specs,
+tasks) were never committed during the change lifecycle, so they are archived here
+retroactively to preserve the design rationale.
+
+## Evidence of Completion
+
+| Area | Shipped Artifact |
+|------|------------------|
+| Service layer | `packages/core/src/services/notification-service.ts` (+ tests) |
+| Email adapter | `packages/core/src/services/ports/notification-email-port.ts` + console/Resend adapters |
+| UI | `ui/features/notifications/`, `ui/app/(protected)/notifications/`, `ui/app/(protected)/settings/notifications/` |
+| E2E | `ui/e2e/notifications/` |
+| Roadmap | `docs/features/roadmap.md` — Notifications (#10) marked **Done** |
+
+## Notes
+
+- No reverse migration or rollback was required; the feature is live.
+- This archive is documentation-only and introduces no code changes.

--- a/openspec/changes/archive/2026-06-08-notifications/design.md
+++ b/openspec/changes/archive/2026-06-08-notifications/design.md
@@ -1,0 +1,175 @@
+# Design: Notifications
+
+## Technical Approach
+
+Implement notifications as a new vertical module following the existing platform patterns: Drizzle schema in `packages/db/`, Zod contracts in `packages/contracts/`, function-based service in `packages/core/`, thin Server Actions + feature UI in `ui/`. The email adapter mirrors the existing `InvitationEmailPort` / factory pattern. Supabase Realtime (first subscription in codebase) is scoped to badge-only via a custom hook. Services call `createNotification()` directly — no event bus.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternative | Rationale |
+|----------|--------|-------------|-----------|
+| Dispatch model | Direct service calls | Event-driven (pub/sub) | No infra dependency for MVP; event-driven is follow-up |
+| Notification INSERT auth | Admin client (`service_role`) | Authenticated client | Callers (billing, team) may lack recipient JWT context |
+| Email adapter pattern | `NotificationEmailPort` + factory | Inline Resend calls | Mirrors `InvitationEmailPort`; env-based selection; testable |
+| Adapter factory caching | Singleton per process (like `payment-adapter-factory.ts`) | Fresh instance per call | Serverless-safe; consistent with existing pattern |
+| Realtime scope | Badge count only (INSERT events) | Full feed + list | Lowest complexity for highest UX value; full feed is follow-up |
+| Schema file | New `notifications.ts` | Extend `platform.ts` | Domain separation; notifications grow independently |
+| Metadata column | `text` (JSON string) | `jsonb` | Consistent with billing `features`/`limits` pattern |
+| Preference defaults | Missing row = all enabled | Explicit rows on user creation | Less data; rows only created when user customizes |
+| Guest access | No notifications | Limited read-only | Consistent with guest permission model across all features |
+
+## Data Flow
+
+### Notification Creation (service → DB + email)
+
+```
+billing-service / tenant-team-service
+  │
+  ├─ try { createNotification(adminClient, input) }
+  │    │
+  │    ├─ 1. isCritical(type)? → skip preference check
+  │    │   else → query notification_preferences
+  │    │
+  │    ├─ 2. in_app_enabled OR critical?
+  │    │      → INSERT notifications (adminClient, service_role)
+  │    │        → Supabase Realtime broadcasts INSERT to subscribed clients
+  │    │
+  │    ├─ 3. email_enabled OR critical?
+  │    │      → emailAdapter.sendNotificationEmail(...)
+  │    │        → success: audit log notification.email_sent
+  │    │        → failure: audit log notification.email_failed + Sentry
+  │    │
+  │    └─ 4. return ServiceResult<Notification>
+  │
+  └─ catch → log to Sentry; parent mutation still succeeds
+```
+
+### Unread Badge (Realtime)
+
+```
+useUnreadCount hook (Client Component)
+  │
+  ├─ mount: getUnreadCountAction() → initial count
+  ├─ supabase.channel("notifications-badge")
+  │    .on("postgres_changes", { event: "INSERT", table: "notifications", filter: user_id })
+  │    → increment local count
+  ├─ on markAsRead/markAllAsRead → refresh count via action
+  └─ unmount: channel.unsubscribe()
+```
+
+### Notification Center (Server → Client)
+
+```
+/notifications (page.tsx — Server Component)
+  │
+  ├─ listNotificationsAction(query) → NotificationList (Client Component)
+  │    ├─ NotificationItem × N
+  │    ├─ NotificationFilters (category, read state)
+  │    └─ MarkAllReadButton
+  └─ on mutation success → router.refresh()
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `packages/contracts/src/dto/notifications.ts` | Create | Zod schemas: input/output contracts, type exports |
+| `packages/contracts/src/dto/index.ts` | Modify | Re-export notifications barrel |
+| `packages/db/src/schema/notifications.ts` | Create | Enums, tables, RLS policies, indexes, type exports |
+| `packages/db/src/index.ts` | Modify | Re-export notifications schema |
+| `packages/core/src/services/ports/notification-email-port.ts` | Create | `NotificationEmailPort` interface |
+| `packages/core/src/services/adapters/console-notification-email.ts` | Create | Console adapter (dev) |
+| `packages/core/src/services/adapters/resend-notification-email.ts` | Create | Resend adapter (prod) |
+| `packages/core/src/services/adapters/notification-email-adapter-factory.ts` | Create | Factory: env-based selection with singleton cache |
+| `packages/core/src/services/notification-service.ts` | Create | 8 functions: list, count, markRead, markAllRead, create, createBulk, getPrefs, updatePrefs |
+| `packages/core/src/services/billing-service.ts` | Modify | Add `createNotification` calls after plan change/cancel/past_due mutations |
+| `packages/core/src/services/tenant-team-service.ts` | Modify | Add `createNotification` calls after invite/accept/role-change/remove |
+| `ui/features/notifications/actions.ts` | Create | 6 thin Server Actions with Sentry `notifications` area |
+| `ui/features/notifications/queries.ts` | Create | Server-side data fetching for pages |
+| `ui/features/notifications/components/notification-bell.tsx` | Create | Header bell icon + unread badge (Client Component) |
+| `ui/features/notifications/components/notification-list.tsx` | Create | Paginated list container |
+| `ui/features/notifications/components/notification-item.tsx` | Create | Single notification row |
+| `ui/features/notifications/components/notification-filters.tsx` | Create | Category + read-state filter bar |
+| `ui/features/notifications/components/notification-empty-state.tsx` | Create | Empty state illustration |
+| `ui/features/notifications/components/notification-preferences-form.tsx` | Create | Per-category toggle grid (Client Component) |
+| `ui/features/notifications/components/mark-all-read-button.tsx` | Create | Bulk mark-read action |
+| `ui/features/notifications/hooks/use-unread-count.ts` | Create | Supabase Realtime subscription hook |
+| `ui/app/(protected)/notifications/page.tsx` | Create | Notification center page (Server Component) |
+| `ui/app/(protected)/notifications/error.tsx` | Create | Error boundary with Sentry |
+| `ui/app/(protected)/settings/notifications/page.tsx` | Create | Preferences page (Server Component) |
+| `ui/app/(protected)/settings/notifications/error.tsx` | Create | Error boundary with Sentry |
+| `ui/lib/routes.ts` | Modify | Add `notifications` and `notificationPreferences` routes |
+| `ui/lib/sentry.ts` | Modify | Add `"notifications"` to `SentryArea` union |
+| `ui/components/layout/header.tsx` | Modify | Insert `NotificationBell` between `ThemeToggle` and user avatar |
+| `supabase/migrations/XXXX_notifications.sql` | Create | Tables, enums, indexes, RLS policies |
+| `supabase/seed.sql` | Modify | Add seed notifications and preferences |
+
+## Interfaces / Contracts
+
+### NotificationEmailPort (mirrors InvitationEmailPort)
+
+```typescript
+// packages/core/src/services/ports/notification-email-port.ts
+export interface NotificationEmailPort {
+  sendNotificationEmail(params: {
+    to: string;
+    subject: string;
+    title: string;
+    body: string;
+    ctaUrl?: string;
+    ctaLabel?: string;
+  }): Promise<{ success: boolean; error?: string }>;
+}
+```
+
+### Non-Blocking Dispatch Wrapper
+
+```typescript
+// Used by billing-service and tenant-team-service at call sites
+try {
+  await createNotification(adminClient, { ...input });
+} catch (err) {
+  // Parent mutation already succeeded — log and continue
+  console.error("[notification-dispatch] Failed:", err);
+  // Sentry capture happens inside createNotification
+}
+```
+
+### Header Bell Integration
+
+```typescript
+// header.tsx receives userId and tenantId from layout
+// Renders NotificationBell only when role !== "guest"
+{userRole !== "guest" && (
+  <NotificationBell userId={userId} tenantId={tenantId} />
+)}
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | notification-service: 18 cases (list, count, markRead, create, preferences, critical bypass, email failure) | Vitest + mocked SupabaseClient + mocked NotificationEmailPort |
+| Unit | contracts: all schemas valid/invalid boundaries | Vitest schema.parse / schema.safeParse |
+| E2E | 11 flows: bell badge, list, mark read, mark all, filters, preferences, guest exclusion, empty state | Playwright + seed data + Page Object Model |
+
+## Migration / Rollout
+
+### Migration (new schema)
+
+1. Generate migration from `packages/db/src/schema/notifications.ts` via `pnpm --filter @enterprise/db db:generate`
+2. Flatten migration directory per Drizzle skill checklist
+3. Verify incremental content (no full schema dump)
+4. Migration creates: 2 enums, 2 tables, 6 indexes, 1 unique constraint, 5 RLS policies
+
+### Rollout
+
+No feature flags needed — notifications are additive. No existing data is modified. Rollback is a reverse migration + revert of service integration calls.
+
+### Seed data
+
+5 notification rows (mix of read/unread, team/billing categories) + 1 preference row added to `supabase/seed.sql`.
+
+## Open Questions
+
+- [x] All questions resolved in proposal and RFC — no blockers.

--- a/openspec/changes/archive/2026-06-08-notifications/proposal.md
+++ b/openspec/changes/archive/2026-06-08-notifications/proposal.md
@@ -1,0 +1,100 @@
+# Proposal: Notifications
+
+## Intent
+
+Users miss critical events (billing past_due, team invitations, role changes) because the platform has no notification system. No in-app alerts, no email delivery, no preference controls. Services have no dispatch API for downstream features to hook into.
+
+## Scope
+
+### In Scope
+- Drizzle schema: `notifications` + `notification_preferences` tables with RLS
+- Zod contracts: input/output schemas in `@enterprise/contracts`
+- Service layer: `notification-service.ts` (create, list, mark-read, preferences, bulk)
+- Email adapter: `NotificationEmailPort` + console/Resend implementations
+- Integration: wire `createNotification()` into billing-service + tenant-team-service
+- Server Actions: 6 thin wrappers with Sentry `notifications` area
+- UI: `/notifications` center, `/settings/notifications` preferences, header bell
+- Realtime: unread badge via Supabase Realtime (first subscription in codebase)
+- Seed data + E2E tests (11 flows)
+
+### Out of Scope
+- SMS/push channels
+- Event-driven architecture (message queue, pub/sub)
+- Digest emails, notification grouping
+- Rich notification actions (inline buttons)
+- System category notifications
+- Automatic retention cleanup cron
+
+## Capabilities
+
+### New Capabilities
+- `notifications`: In-app notification center, email dispatch, preferences, Realtime badge, guest exclusion
+
+### Modified Capabilities
+- `billing`: billing-service gains `createNotification`/`createBulkNotifications` calls after mutations
+- `tenant-team`: tenant-team-service gains `createNotification` calls after invite/accept/role-change/remove
+
+## Approach
+
+Port/adapter pattern mirroring existing `InvitationEmailPort`. Function-based service in `@enterprise/core`. Direct service calls (no event bus). Admin client for notification INSERT (service_role for RLS). Supabase Realtime for badge only. Critical events bypass preferences via centralized `isCritical()` check.
+
+**Key decision — `team_invited` userId gap**: When `inviteTenantMember()` fires, query `auth.users` by email. If user exists: create in-app + email. If not: email-only (no in-app row). When `acceptTenantInvitation()` fires: always create `team_invitation_accepted` for inviter. For `team_removed`: email-only (user loses tenant access).
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `packages/contracts/src/dto/notifications.ts` | New | Zod schemas for all notification I/O |
+| `packages/db/src/schema/notifications.ts` | New | Tables, enums, RLS, indexes |
+| `packages/db/src/index.ts` | Modified | Re-export notifications schema |
+| `packages/core/src/services/notification-service.ts` | New | All notification business logic |
+| `packages/core/src/services/ports/notification-email-port.ts` | New | Email adapter interface |
+| `packages/core/src/services/adapters/console-notification-email.ts` | New | Dev email adapter |
+| `packages/core/src/services/adapters/resend-notification-email.ts` | New | Prod email adapter |
+| `packages/core/src/services/adapters/notification-email-adapter-factory.ts` | New | Adapter factory |
+| `packages/core/src/services/billing-service.ts` | Modified | Add createNotification calls (4 functions) |
+| `packages/core/src/services/tenant-team-service.ts` | Modified | Add createNotification calls (4 functions) |
+| `ui/features/notifications/` | New | Actions, queries, components, hooks |
+| `ui/app/(protected)/notifications/` | New | Page + error boundary |
+| `ui/app/(protected)/settings/notifications/` | New | Preferences page + error boundary |
+| `ui/components/layout/header.tsx` | Modified | Add notification bell |
+| `ui/lib/routes.ts` | Modified | Add `notifications` + `notificationPreferences` |
+| `ui/lib/sentry.ts` | Modified | Add `"notifications"` to SentryArea |
+| `supabase/migrations/` | New | Notification tables migration |
+| `supabase/seed.sql` | Modified | Seed notifications + preferences |
+| `ui/e2e/notifications/` | New | 11 E2E test flows |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| First Realtime subscription — no patterns to follow | Med | Isolate in `use-unread-count.ts` hook; cleanup on unmount |
+| Notification INSERT failure breaks billing/team mutation | Low | Wrap in try/catch; parent mutation always succeeds |
+| Cross-tenant notification leak | Low | RLS enforces `user_id = auth.uid()` + `tenant_id` match |
+| Bulk recipient lookup adds DB call to billing functions | Low | Single `profiles` query via adminClient; acceptable latency |
+| Supabase Realtime connection exhaustion | Low | One channel per user; unsubscribe on unmount/logout |
+| Review budget exceeded (~800 lines across 19 files) | High | Chain into 3-4 PRs by RFC phase (contracts+schema, service+integration, UI+E2E) |
+
+## Rollback Plan
+
+1. **Schema**: Drop `notifications` and `notification_preferences` tables via reverse migration
+2. **Integration**: Revert `createNotification` calls in billing-service and tenant-team-service (try/catch wrappers make this safe)
+3. **UI**: Remove bell from header, remove `/notifications` and `/settings/notifications` routes
+4. **Realtime**: Remove channel subscription hook — no other features use Realtime yet
+
+## Dependencies
+
+- Existing billing-service.ts and tenant-team-service.ts must be stable (no concurrent refactors)
+- Resend API key for production email (optional — console adapter works without it)
+- Supabase Realtime enabled on the project (enabled by default)
+
+## Success Criteria
+
+- [ ] `createNotification()` dispatches in-app + email for critical events regardless of preferences
+- [ ] Non-critical notifications respect per-user, per-tenant, per-category preferences
+- [ ] Unread badge updates in real-time without page reload
+- [ ] Guest users see no bell, cannot access notification routes
+- [ ] Billing and team mutations succeed even if notification dispatch fails
+- [ ] All 11 E2E flows pass
+- [ ] Unit tests cover all service functions with preference/critical bypass logic
+- [ ] RLS prevents cross-tenant and cross-user notification access

--- a/openspec/changes/archive/2026-06-08-notifications/specs/billing/spec.md
+++ b/openspec/changes/archive/2026-06-08-notifications/specs/billing/spec.md
@@ -1,0 +1,51 @@
+# Delta for Billing
+
+## ADDED Requirements
+
+### Requirement: Billing Notification Dispatch
+
+After each successful billing mutation, billing-service MUST call `createNotification()` or `createBulkNotifications()` to notify affected users.
+
+Calls MUST be wrapped in `try/catch`. A notification dispatch failure MUST NOT cause the billing mutation to fail.
+
+#### Scenario: billing_past_due dispatches to owner and admins
+
+- GIVEN `processWebhookEvent` transitions a subscription to `past_due`
+- WHEN the state change is persisted
+- THEN `createBulkNotifications` is called with `type: "billing_past_due"` for the owner AND all admin users of the tenant
+- AND both in-app and email are dispatched (critical — bypasses preferences)
+- AND if `createBulkNotifications` throws, the webhook processing still returns success
+
+#### Scenario: billing_canceled dispatches to owner and admins
+
+- GIVEN `cancelSubscription` succeeds
+- WHEN the cancellation is persisted
+- THEN `createBulkNotifications` is called with `type: "billing_canceled"` for owner AND all admins
+- AND both in-app and email are dispatched (critical)
+
+#### Scenario: billing_plan_upgraded dispatches to owner
+
+- GIVEN `changePlan` upgrades a plan
+- WHEN the plan change is persisted
+- THEN `createNotification` is called with `type: "billing_plan_upgraded"` for the tenant owner
+- AND `metadata` includes `JSON.stringify({ fromPlanId, toPlanId })`
+
+#### Scenario: billing_plan_downgraded dispatches to owner
+
+- GIVEN `changePlan` downgrades a plan
+- WHEN the plan change is persisted
+- THEN `createNotification` is called with `type: "billing_plan_downgraded"` for the owner
+
+#### Scenario: billing_activated dispatches to owner
+
+- GIVEN `processWebhookEvent` activates a subscription
+- WHEN the activation is persisted
+- THEN `createNotification` is called with `type: "billing_activated"` for the owner
+
+#### Scenario: Notification failure is non-blocking
+
+- GIVEN `createNotification` throws an error
+- WHEN called after a `changePlan` mutation
+- THEN the plan change is NOT rolled back
+- AND the error is logged to Sentry
+- AND `billing-service` returns success to its caller

--- a/openspec/changes/archive/2026-06-08-notifications/specs/notifications/spec.md
+++ b/openspec/changes/archive/2026-06-08-notifications/specs/notifications/spec.md
@@ -1,0 +1,505 @@
+# Notifications Specification
+
+## Purpose
+
+Tenant-scoped, user-scoped notification system. Delivers in-app alerts and critical-event emails. Provides per-user, per-category preference controls and a service-level dispatch API for other platform services.
+
+---
+
+## Data Model
+
+### Enums
+
+| Enum | Values |
+|------|--------|
+| `notification_type` | `team_invited`, `team_invitation_accepted`, `team_role_changed`, `team_removed`, `billing_past_due`, `billing_plan_upgraded`, `billing_plan_downgraded`, `billing_canceled`, `billing_activated` |
+| `notification_category` | `team`, `billing`, `system` |
+
+### Table: `notifications`
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `user_id` | `uuid` | NOT NULL (recipient — `auth.users.id`) |
+| `type` | `notification_type` | NOT NULL |
+| `category` | `notification_category` | NOT NULL |
+| `title` | `text` | NOT NULL |
+| `body` | `text` | NOT NULL |
+| `metadata` | `text` | NULLABLE — JSON string |
+| `is_read` | `boolean` | NOT NULL, default `false` |
+| `read_at` | `timestamptz` | NULLABLE |
+| `source_event` | `text` | NULLABLE |
+| `source_entity_id` | `uuid` | NULLABLE |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+### Table: `notification_preferences`
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | `uuid` | PK, `defaultRandom()` |
+| `user_id` | `uuid` | NOT NULL (`auth.users.id`) |
+| `tenant_id` | `uuid` | NOT NULL, FK `tenants.id` ON DELETE CASCADE |
+| `category` | `notification_category` | NOT NULL |
+| `in_app_enabled` | `boolean` | NOT NULL, default `true` |
+| `email_enabled` | `boolean` | NOT NULL, default `true` |
+| `created_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+| `updated_at` | `timestamptz` | NOT NULL, `defaultNow()` |
+
+UNIQUE constraint: `(user_id, tenant_id, category)`.
+
+### Indexes
+
+| Index | Columns |
+|-------|---------|
+| `notifications_user_tenant_idx` | `user_id`, `tenant_id` |
+| `notifications_user_unread_idx` | `user_id`, `tenant_id`, `is_read` |
+| `notifications_category_idx` | `category` |
+| `notifications_created_at_idx` | `created_at` |
+| `notifications_source_event_idx` | `source_event` |
+| `preferences_user_tenant_idx` | `user_id`, `tenant_id` |
+
+---
+
+## RLS Policies
+
+### `notifications`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `notifications_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `notifications_insert` | INSERT | `service_role` | Service role only |
+| `notifications_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `notifications_delete` | DELETE | — | None — no deletes |
+
+### `notification_preferences`
+
+| Policy | Operation | Role | Condition |
+|--------|-----------|------|-----------|
+| `preferences_select` | SELECT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_insert` | INSERT | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_update` | UPDATE | `authenticated` | `user_id = auth.uid()` AND `tenant_id` matches JWT claim |
+| `preferences_delete` | DELETE | — | None |
+
+---
+
+## Contracts
+
+Location: `packages/contracts/src/dto/notifications.ts`
+
+### Output Schemas
+
+```typescript
+export const notificationSchema = z.object({
+  id: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum(["team_invited","team_invitation_accepted","team_role_changed","team_removed",
+    "billing_past_due","billing_plan_upgraded","billing_plan_downgraded","billing_canceled","billing_activated"]),
+  category: z.enum(["team","billing","system"]),
+  title: z.string(),
+  body: z.string(),
+  metadata: z.string().nullable(),
+  isRead: z.boolean(),
+  readAt: z.string().datetime().nullable(),
+  sourceEvent: z.string().nullable(),
+  sourceEntityId: z.string().uuid().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export const notificationPreferenceSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  tenantId: z.string().uuid(),
+  category: z.enum(["team","billing","system"]),
+  inAppEnabled: z.boolean(),
+  emailEnabled: z.boolean(),
+});
+
+export const unreadCountSchema = z.object({ count: z.number().int().min(0) });
+```
+
+### Input Schemas
+
+```typescript
+export const markAsReadSchema = z.object({ notificationId: z.string().uuid() });
+export const markAllAsReadSchema = z.object({});
+
+export const updatePreferencesSchema = z.object({
+  preferences: z.array(z.object({
+    category: z.enum(["team","billing","system"]),
+    inAppEnabled: z.boolean(),
+    emailEnabled: z.boolean(),
+  })),
+});
+
+export const notificationsQuerySchema = z.object({
+  category: z.enum(["team","billing","system"]).optional(),
+  isRead: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+export const createNotificationSchema = z.object({
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+  type: z.enum([/* all 9 types */]),
+  category: z.enum(["team","billing","system"]),
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(1000),
+  metadata: z.string().nullable().optional(),
+  sourceEvent: z.string().nullable().optional(),
+  sourceEntityId: z.string().uuid().nullable().optional(),
+});
+```
+
+---
+
+## Service API
+
+Location: `packages/core/src/services/notification-service.ts`
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `listNotifications` | `(client, tenantId, userId, query) → ServiceResult<Notification[]>` | Paginated, filtered by category/isRead |
+| `getUnreadCount` | `(client, tenantId, userId) → ServiceResult<{ count: number }>` | Unread count for badge |
+| `markAsRead` | `(client, tenantId, userId, notificationId) → ServiceResult<null>` | Sets `is_read=true`, `read_at=now()` |
+| `markAllAsRead` | `(client, tenantId, userId) → ServiceResult<{ updated: number }>` | Bulk update all unread |
+| `createNotification` | `(adminClient, input) → ServiceResult<Notification>` | Checks preferences, dispatches email |
+| `createBulkNotifications` | `(adminClient, inputs[]) → ServiceResult<Notification[]>` | Multi-recipient dispatch |
+| `getPreferences` | `(client, tenantId, userId) → ServiceResult<NotificationPreference[]>` | Missing rows = defaults (enabled) |
+| `updatePreferences` | `(client, tenantId, userId, input) → ServiceResult<NotificationPreference[]>` | Upsert; audit logs change |
+
+### Critical Types Constant
+
+```typescript
+const CRITICAL_TYPES: NotificationType[] = [
+  "billing_past_due", "billing_canceled", "team_invited", "team_removed",
+];
+function isCritical(type: NotificationType): boolean {
+  return CRITICAL_TYPES.includes(type);
+}
+```
+
+---
+
+## Email Adapter
+
+### Interface
+
+Location: `packages/core/src/services/ports/notification-email-port.ts`
+
+```typescript
+export interface NotificationEmailPort {
+  sendNotificationEmail(params: {
+    to: string; subject: string; title: string; body: string;
+    ctaUrl?: string; ctaLabel?: string;
+  }): Promise<{ success: boolean; error?: string }>;
+}
+```
+
+### Implementations
+
+| Adapter | Location | Selection |
+|---------|----------|-----------|
+| `ConsoleNotificationEmailAdapter` | `adapters/console-notification-email.ts` | Default (no `RESEND_API_KEY`) |
+| `ResendNotificationEmailAdapter` | `adapters/resend-notification-email.ts` | When `RESEND_API_KEY` is set |
+
+Factory: `createNotificationEmailAdapter()` in `adapters/notification-email-adapter-factory.ts` — selects by env var presence, NOT `NODE_ENV`.
+
+---
+
+## Server Actions
+
+Location: `ui/features/notifications/actions.ts`
+
+| Action | Input Schema | Service fn | Sentry area |
+|--------|-------------|-----------|-------------|
+| `listNotificationsAction` | `notificationsQuerySchema` | `listNotifications` | `notifications` |
+| `getUnreadCountAction` | — | `getUnreadCount` | `notifications` |
+| `markAsReadAction` | `markAsReadSchema` | `markAsRead` | `notifications` |
+| `markAllAsReadAction` | `markAllAsReadSchema` | `markAllAsRead` | `notifications` |
+| `getPreferencesAction` | — | `getPreferences` | `notifications` |
+| `updatePreferencesAction` | `updatePreferencesSchema` | `updatePreferences` | `notifications` |
+
+All actions: `Sentry.withServerActionInstrumentation` wraps the body. `captureActionError` on non-validation errors. PII exclusions: notification body, email addresses, user names.
+
+---
+
+## Realtime
+
+Hook: `ui/features/notifications/hooks/use-unread-count.ts`
+
+- Subscribes to `INSERT` events on `notifications` table filtered by `user_id=eq.{userId}`
+- On INSERT: increment local unread count
+- On unmount: unsubscribe channel
+- RLS enforces row-level visibility — no extra filter needed beyond `user_id`
+
+---
+
+## UI Routes
+
+| Route | Auth | Component |
+|-------|------|-----------|
+| `/notifications` | owner/admin/member | `NotificationsPage` — paginated list, category+read filters |
+| `/settings/notifications` | owner/admin/member | `NotificationPreferencesPage` — per-category toggles |
+
+Query params: `category` (team/billing/all), `isRead` (true/false/all), `page` (offset).
+
+Register in `ui/lib/routes.ts`:
+```typescript
+notifications: "/notifications",
+notificationPreferences: "/settings/notifications",
+```
+
+---
+
+## Requirements
+
+### Requirement: Notification Dispatch
+
+The system MUST create a notification record for every eligible event dispatched via `createNotification()` or `createBulkNotifications()`.
+
+A notification MUST be scoped to a single `(tenant_id, user_id)` pair.
+
+The `isCritical()` check MUST run before any preference lookup. If `true`, preferences are bypassed entirely for all channels.
+
+#### Scenario: Critical type bypasses preferences
+
+- GIVEN a user has disabled billing email in preferences
+- WHEN `createNotification` is called with `type: "billing_past_due"`
+- THEN the notification is created in the DB
+- AND the email adapter sends an email regardless of the preference setting
+
+#### Scenario: Non-critical respects in-app preference
+
+- GIVEN a user has `in_app_enabled: false` for category `billing`
+- WHEN `createNotification` is called with `type: "billing_plan_upgraded"`
+- THEN no in-app notification row is inserted
+- AND no email is sent (no email channel for this type)
+
+#### Scenario: Non-critical respects email preference
+
+- GIVEN a user has `email_enabled: false` for category `team`
+- WHEN `createNotification` is called with `type: "team_invitation_accepted"` (has email channel)
+- THEN the in-app row IS inserted (in-app not disabled)
+- AND the email adapter is NOT called
+
+#### Scenario: Missing preference row defaults to enabled
+
+- GIVEN a user has no preference row for category `billing`
+- WHEN `createNotification` is called with `type: "billing_plan_upgraded"`
+- THEN the in-app row IS inserted (default = enabled)
+
+#### Scenario: Email adapter failure is non-blocking
+
+- GIVEN the email adapter throws an error
+- WHEN `createNotification` is called with a type requiring email
+- THEN the in-app notification IS created
+- AND the error is captured in Sentry
+- AND `notification.email_failed` audit event is logged
+- AND `ServiceResult` still returns success with the created notification
+
+### Requirement: Notification Lifecycle
+
+Notifications MUST be immutable after creation. Only `is_read` and `read_at` MAY be mutated.
+
+#### Scenario: Mark single as read
+
+- GIVEN an unread notification owned by the current user
+- WHEN `markAsRead` is called with the notification ID
+- THEN `is_read` becomes `true` and `read_at` is set to `now()`
+
+#### Scenario: Mark as read — wrong user
+
+- GIVEN a notification belonging to another user
+- WHEN `markAsRead` is called
+- THEN `ServiceResult` returns a permission error
+- AND no row is mutated
+
+#### Scenario: Mark as read — already read
+
+- GIVEN a notification with `is_read = true`
+- WHEN `markAsRead` is called
+- THEN `ServiceResult` returns success (idempotent — no error)
+
+#### Scenario: Mark all as read — no unread
+
+- GIVEN the user has zero unread notifications for the current tenant
+- WHEN `markAllAsRead` is called
+- THEN `ServiceResult` returns `{ updated: 0 }` (success)
+
+### Requirement: Notification Listing
+
+The system MUST return notifications scoped to the current `(user_id, tenant_id)` pair only.
+
+Results MUST be ordered by `created_at DESC`. Default page size is 20.
+
+#### Scenario: List with category filter
+
+- GIVEN a user has 3 team and 2 billing notifications
+- WHEN `listNotifications` is called with `category: "team"`
+- THEN only the 3 team notifications are returned
+
+#### Scenario: List with isRead filter
+
+- GIVEN a user has 2 unread and 3 read notifications
+- WHEN `listNotifications` is called with `isRead: false`
+- THEN only the 2 unread notifications are returned
+
+#### Scenario: List pagination
+
+- GIVEN a user has 25 notifications
+- WHEN `listNotifications` is called with `limit: 20, offset: 0`
+- THEN 20 notifications are returned ordered newest first
+- WHEN `listNotifications` is called with `limit: 20, offset: 20`
+- THEN the remaining 5 are returned
+
+#### Scenario: Cross-tenant isolation
+
+- GIVEN user A belongs to tenants T1 and T2, and has notifications in both
+- WHEN `listNotifications` is called with T1's `tenant_id`
+- THEN only notifications for T1 are returned
+
+### Requirement: Unread Count
+
+The system MUST return an accurate count of unread notifications for the `(user_id, tenant_id)` pair.
+
+#### Scenario: Count after marking all read
+
+- GIVEN a user has 3 unread notifications
+- WHEN `markAllAsRead` is called
+- AND `getUnreadCount` is called
+- THEN the count is `0`
+
+#### Scenario: Count with no notifications
+
+- GIVEN a user has no notifications for the tenant
+- WHEN `getUnreadCount` is called
+- THEN count is `0`
+
+### Requirement: Unread Badge Realtime
+
+The notification bell MUST display the live unread count and update it without page reload when a new notification is inserted.
+
+Badge shows: `0` = no badge, `1–99` = numeric, `> 99` = "99+".
+
+#### Scenario: Badge increments on new notification
+
+- GIVEN the notification bell shows count `2`
+- WHEN a new notification row is inserted for the current user and tenant
+- THEN the badge updates to `3` without page reload
+
+#### Scenario: Realtime channel unsubscribes on unmount
+
+- GIVEN the bell component is mounted with an active Realtime subscription
+- WHEN the component unmounts
+- THEN the Supabase channel is removed (cleanup executed)
+
+### Requirement: Notification Preferences
+
+The system MUST allow users to configure per-tenant, per-category `in_app_enabled` and `email_enabled` flags.
+
+Missing preference rows MUST behave as if both channels are enabled.
+
+Critical events (`billing_past_due`, `billing_canceled`, `team_invited`, `team_removed`) MUST be shown as always-on in the UI (disabled toggles) and MUST bypass preferences in the service.
+
+#### Scenario: Save preferences
+
+- GIVEN a user changes billing email to disabled
+- WHEN `updatePreferences` is called
+- THEN the `notification_preferences` row for `(user_id, tenant_id, "billing")` is upserted
+- AND `notification.preferences_updated` audit event is logged with `{ userId, tenantId, changes }`
+
+#### Scenario: Preferences take effect immediately
+
+- GIVEN a user saves billing email disabled at T0
+- WHEN `createNotification` is called with `type: "billing_plan_upgraded"` at T1 > T0
+- THEN no email is dispatched
+
+#### Scenario: Critical events shown as always-on in UI
+
+- GIVEN the user is on `/settings/notifications`
+- WHEN the preferences page renders
+- THEN critical event rows show disabled toggles with explanatory text
+- AND toggling them is not possible
+
+### Requirement: Guest Exclusion
+
+Guests MUST NOT see the notification bell, access `/notifications`, or access `/settings/notifications`.
+
+#### Scenario: Guest sees no bell
+
+- GIVEN a user with role `guest` is authenticated
+- WHEN they view any protected page
+- THEN the notification bell is not rendered in the header
+
+#### Scenario: Guest redirected from notification routes
+
+- GIVEN a guest navigates to `/notifications` or `/settings/notifications`
+- THEN they are redirected to `/dashboard`
+- AND no notification data is fetched
+
+#### Scenario: Notification service excludes guests
+
+- GIVEN the event involves a user with role `guest`
+- WHEN notification dispatch is attempted
+- THEN no notification row is created for the guest user
+
+### Requirement: Audit Events
+
+| Event | Trigger | Required Metadata |
+|-------|---------|-------------------|
+| `notification.created` | Notification row inserted | `{ type, category, recipientUserId, sourceEvent, tenantId }` |
+| `notification.email_sent` | Email adapter succeeds | `{ type, recipientEmail, tenantId }` |
+| `notification.email_failed` | Email adapter fails | `{ type, recipientEmail, errorCode, tenantId }` |
+| `notification.preferences_updated` | User saves preferences | `{ userId, tenantId, changes }` |
+
+`notification.marked_read` and `notification.marked_all_read` are NOT audited.
+
+### Requirement: Sentry Instrumentation
+
+All 6 Server Actions MUST be wrapped with `Sentry.withServerActionInstrumentation`. Non-validation errors MUST call `captureActionError` with `area: "notifications"`.
+
+`"notifications"` MUST be added to the `SentryArea` union in `ui/lib/sentry.ts`.
+
+PII MUST NOT be sent: notification body content, email addresses, user names.
+Allowed: `inputShape` keys, `errorCode`, `tenantId`, `userId`, `userRole`, `notificationType`, `category`.
+
+---
+
+## Seed Data
+
+Location: additions to `supabase/seed.sql`
+
+| Notification | Recipient | Type | State |
+|-------------|-----------|------|-------|
+| "You were invited to join Demo Workspace" | member user | `team_invited` | unread |
+| "Your subscription is past due" | owner user | `billing_past_due` | unread |
+| "Plan upgraded to Pro" | owner user | `billing_plan_upgraded` | read (2 days ago) |
+| "Member User accepted your invitation" | admin user | `team_invitation_accepted` | read (5 days ago) |
+| "Your role was changed to admin" | member user | `team_role_changed` | unread |
+
+| Preference | User | Category | State |
+|-----------|------|----------|-------|
+| billing email disabled | member user | billing | `in_app_enabled: true, email_enabled: false` |
+
+---
+
+## E2E Flows
+
+Location: `ui/e2e/notifications/notifications.spec.ts`
+
+| Scenario | Tag | Actor |
+|----------|-----|-------|
+| Bell shows unread badge | `@critical` | member |
+| Opens notification center | `@critical` | member |
+| Marks single notification as read | `@critical` | member |
+| Marks all as read | | member |
+| Filters by category | | member |
+| Filters by unread | | member |
+| Configures preferences | | member |
+| Guest cannot see bell | `@critical` | guest |
+| Guest redirected from /notifications | | guest |
+| Empty state renders | | clean member |
+| Owner sees billing notifications | | owner |

--- a/openspec/changes/archive/2026-06-08-notifications/specs/tenant-team/spec.md
+++ b/openspec/changes/archive/2026-06-08-notifications/specs/tenant-team/spec.md
@@ -1,0 +1,59 @@
+# Delta for Tenant-Team
+
+## ADDED Requirements
+
+### Requirement: Team Notification Dispatch
+
+After each successful team mutation, tenant-team-service MUST call `createNotification()` to notify the affected user(s).
+
+Calls MUST be wrapped in `try/catch`. A notification dispatch failure MUST NOT cause the team mutation to fail.
+
+The `team_invited` case MUST resolve the invited user's `userId` from `auth.users` by email before dispatching:
+- If the user exists → create in-app notification AND send email
+- If the user does not exist → send email only (no in-app row; userId is unknown)
+
+#### Scenario: team_invited — existing user
+
+- GIVEN `inviteTenantMember` succeeds for a registered user
+- WHEN `auth.users` is queried by the invited email and a user is found
+- THEN `createNotification` is called with `type: "team_invited"` for that userId
+- AND both in-app and email are dispatched (critical — bypasses preferences)
+- AND `metadata` includes `JSON.stringify({ inviterId, role })`
+- AND `title` is `"You were invited to join {tenantName}"`
+
+#### Scenario: team_invited — new user (no account yet)
+
+- GIVEN `inviteTenantMember` succeeds for an email with no account
+- WHEN `auth.users` is queried by email and no user is found
+- THEN the email adapter sends an invitation email directly (no in-app row created)
+- AND no `notifications` row is inserted
+
+#### Scenario: team_invitation_accepted notifies inviter
+
+- GIVEN `acceptTenantInvitation` succeeds
+- WHEN the invitation row is resolved to the original inviter
+- THEN `createNotification` is called with `type: "team_invitation_accepted"` for the inviter's userId
+- AND `metadata` includes `JSON.stringify({ acceptedByName, role })`
+
+#### Scenario: team_role_changed notifies affected member
+
+- GIVEN `changeTenantMemberRole` succeeds
+- WHEN the role update is persisted
+- THEN `createNotification` is called with `type: "team_role_changed"` for the affected member's userId
+- AND `metadata` includes `JSON.stringify({ previousRole, newRole, changedBy })`
+
+#### Scenario: team_removed — email-only
+
+- GIVEN `removeTenantMember` succeeds
+- WHEN the member is removed from the tenant
+- THEN the email adapter sends a removal notice to the removed member's email
+- AND no in-app notification row is created (member loses tenant access)
+- AND the email is sent regardless of preferences (critical)
+
+#### Scenario: Notification failure is non-blocking
+
+- GIVEN `createNotification` throws an error
+- WHEN called after `changeTenantMemberRole`
+- THEN the role change is NOT rolled back
+- AND the error is logged to Sentry
+- AND `tenant-team-service` returns success to its caller

--- a/openspec/changes/archive/2026-06-08-notifications/tasks.md
+++ b/openspec/changes/archive/2026-06-08-notifications/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Notifications
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2,300 additions + ~50 modifications = ~2,350 total |
+| 400-line budget risk | High |
+| 800-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Delivery strategy | auto-forecast → chained PRs |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Contracts + DB schema + email adapter + service | PR 1 | Base: `feat/notifications`; includes unit + contract tests |
+| 2 | Integration into billing-service + tenant-team-service | PR 2 | Base: PR 1 branch; non-blocking dispatch + Sentry |
+| 3 | Server Actions + Sentry area + routes | PR 3 | Base: PR 2 branch |
+| 4 | UI components + pages + Realtime hook + header bell | PR 4 | Base: PR 3 branch |
+| 5 | Seed data + E2E tests | PR 5 | Base: PR 4 branch; 11 Playwright flows |
+
+---
+
+## Phase 1: Contracts — Zod Schemas and Types
+
+- [x] 1.1 Create `packages/contracts/src/dto/notifications.ts` — output schemas: `notificationSchema`, `notificationPreferenceSchema`, `unreadCountSchema`
+- [x] 1.2 Add input schemas to same file: `markAsReadSchema`, `markAllAsReadSchema`, `updatePreferencesSchema`, `notificationsQuerySchema`, `createNotificationSchema`
+- [x] 1.3 Export all schemas and inferred types (`Notification`, `NotificationPreference`, `CreateNotificationInput`, etc.)
+- [x] 1.4 Add re-export for `notifications.ts` to `packages/contracts/src/dto/index.ts` (or create it if missing)
+- [x] 1.5 Write `packages/contracts/src/__tests__/notifications.test.ts` — valid/boundary/rejection cases for all 8 schemas
+
+**Work unit commit**: `feat(contracts): add notification Zod schemas and types`
+
+---
+
+## Phase 2: Data Model — Drizzle Schema, RLS, Migration
+
+- [x] 2.1 Create `packages/db/src/schema/notifications.ts` — define `notificationTypeEnum` (9 values) and `notificationCategoryEnum` (3 values)
+- [x] 2.2 Add `notifications` table to same file — all columns per spec (uuid PK, tenant_id FK cascade, user_id, type/category enums, title/body, metadata text, is_read, read_at, source_event, source_entity_id, created_at)
+- [x] 2.3 Add `notificationPreferences` table — uuid PK, user_id, tenant_id FK cascade, category enum, in_app_enabled, email_enabled, created_at, updated_at; UNIQUE(user_id, tenant_id, category)
+- [x] 2.4 Add 6 indexes: `notifications_user_tenant_idx`, `notifications_user_unread_idx`, `notifications_category_idx`, `notifications_created_at_idx`, `notifications_source_event_idx`, `preferences_user_tenant_idx`
+- [x] 2.5 Add 5 RLS policies via `pgPolicy()`: `notifications_select` (authenticated), `notifications_insert` (service_role), `notifications_update` (authenticated), `preferences_select` (authenticated), `preferences_insert/update` (authenticated)
+- [x] 2.6 Export inferred types: `Notification`, `NewNotification`, `NotificationPreference`, `NewNotificationPreference`
+- [x] 2.7 Add `notifications` and `notificationPreferences` exports to `packages/db/src/index.ts`
+- [x] 2.8 Run `pnpm db:generate`, flatten migration dir to `supabase/migrations/<timestamp>_add_notifications.sql`, verify SQL contains enums + tables + indexes + RLS
+
+**Work unit commit**: `feat(db): add notifications and notification_preferences schema with RLS`
+
+---
+
+## Phase 3: Email Adapter — Port + Adapters + Factory
+
+- [x] 3.1 Create `packages/core/src/services/ports/notification-email-port.ts` — `NotificationEmailPort` interface with `sendNotificationEmail({ to, subject, title, body, ctaUrl?, ctaLabel? }): Promise<{ success: boolean; error?: string }>`
+- [x] 3.2 Create `packages/core/src/services/adapters/console-notification-email.ts` — `ConsoleNotificationEmailAdapter` implements `NotificationEmailPort`; logs to `console.info`
+- [x] 3.3 Create `packages/core/src/services/adapters/resend-notification-email.ts` — `ResendNotificationEmailAdapter` implements `NotificationEmailPort`; sends via Resend generic template
+- [x] 3.4 Create `packages/core/src/services/adapters/notification-email-adapter-factory.ts` — `createNotificationEmailAdapter()` singleton; selects by `RESEND_API_KEY` presence (NOT `NODE_ENV`)
+
+**Work unit commit**: `feat(core): add NotificationEmailPort interface and console/Resend adapters`
+
+---
+
+## Phase 4: Service Layer — notification-service.ts + Unit Tests
+
+- [x] 4.1 Create `packages/core/src/services/notification-service.ts` — define `CRITICAL_TYPES` array and `isCritical(type)` helper
+- [x] 4.2 Implement `createNotification(adminClient, input)` — preference check (skip if critical), INSERT notifications via adminClient, call emailAdapter if channel requires it; non-blocking email failure with Sentry capture; audit `notification.created` + `notification.email_sent/failed`
+- [x] 4.3 Implement `createBulkNotifications(adminClient, inputs[])` — loop `createNotification` per recipient; return all created rows
+- [x] 4.4 Implement `listNotifications(client, tenantId, userId, query)` — RLS-scoped SELECT with category/isRead filters, ORDER BY created_at DESC, limit/offset pagination
+- [x] 4.5 Implement `getUnreadCount(client, tenantId, userId)` — COUNT WHERE is_read = false for user+tenant
+- [x] 4.6 Implement `markAsRead(client, tenantId, userId, notificationId)` — UPDATE is_read=true, read_at=now(); idempotent (no error if already read); guard user_id match
+- [x] 4.7 Implement `markAllAsRead(client, tenantId, userId)` — bulk UPDATE all unread for user+tenant; return `{ updated: number }`
+- [x] 4.8 Implement `getPreferences(client, tenantId, userId)` — SELECT preference rows; missing categories return default (all enabled)
+- [x] 4.9 Implement `updatePreferences(client, tenantId, userId, input)` — UPSERT preference rows; audit `notification.preferences_updated`
+- [x] 4.10 Write `packages/core/src/services/__tests__/notification-service.test.ts` — all 18 test cases from RFC: list (3), unread count (2), markAsRead (3), markAllAsRead (2), createNotification (5), createBulk (1), getPreferences (2), updatePreferences (1)
+
+**Work unit commit**: `feat(core): add notification service with full unit tests`
+
+---
+
+## Phase 5: Integration — Billing and Team Service Wiring
+
+- [x] 5.1 Modify `packages/core/src/services/billing-service.ts` — import `createNotification`, `createBulkNotifications` from `notification-service`; wrap all calls in try/catch (non-blocking)
+- [x] 5.2 Add `billing_past_due` dispatch in billing-service: `createBulkNotifications(adminClient, [owner, ...admins])` — critical, in-app + email
+- [x] 5.3 Add `billing_canceled` dispatch: `createBulkNotifications(adminClient, [owner, ...admins])` — critical, in-app + email
+- [x] 5.4 Add `billing_plan_upgraded` dispatch: `createNotification(adminClient, owner)` — metadata: `{ fromPlanId, toPlanId }`
+- [x] 5.5 Add `billing_plan_downgraded` and `billing_activated` dispatches for owner
+- [x] 5.6 Modify `packages/core/src/services/tenant-team-service.ts` — import and wire notification dispatches; all wrapped in try/catch
+- [x] 5.7 Add `team_invited` dispatch in team-service: if invited user exists → `createNotification(adminClient, userId)` critical; if no account → email-only via adapter
+- [x] 5.8 Add `team_invitation_accepted` dispatch: `createNotification(adminClient, inviterId)` — metadata: `{ acceptedByName, role }`
+- [x] 5.9 Add `team_role_changed` dispatch: `createNotification(adminClient, affectedUserId)` — metadata: `{ previousRole, newRole, changedBy }`
+- [x] 5.10 Add `team_removed` dispatch: email-only via adapter (no in-app row — user loses access), critical bypass
+
+**Work unit commit**: `feat(core): wire notification dispatch into billing and team services`
+
+---
+
+## Phase 6: Server Actions + Sentry Area Registration
+
+- [x] 6.1 Add `"notifications"` to `SentryArea` union in `ui/lib/sentry.ts`
+- [x] 6.2 Add `ROUTES.notifications` and `ROUTES.notificationPreferences` to `ui/lib/routes.ts`
+- [x] 6.3 Create `ui/features/notifications/actions.ts` (`"use server"`) — import from `@enterprise/core/services` subpath (not barrel)
+- [x] 6.4 Implement `listNotificationsAction` — validate with `notificationsQuerySchema`, call `listNotifications`, return `ActionResult<Notification[]>`; Sentry area `"notifications"`
+- [x] 6.5 Implement `getUnreadCountAction` — no input validation, call `getUnreadCount`, return `ActionResult<{ count: number }>`
+- [x] 6.6 Implement `markAsReadAction` — validate with `markAsReadSchema`, call `markAsRead`, return `ActionResult<null>`; `revalidatePath(ROUTES.notifications)`
+- [x] 6.7 Implement `markAllAsReadAction` — no input, call `markAllAsRead`, return `ActionResult<{ updated: number }>`; `revalidatePath(ROUTES.notifications)`
+- [x] 6.8 Implement `getPreferencesAction` — no input, call `getPreferences`, return `ActionResult<NotificationPreference[]>`
+- [x] 6.9 Implement `updatePreferencesAction` — validate with `updatePreferencesSchema`, call `updatePreferences`, return `ActionResult<NotificationPreference[]>`; `revalidatePath(ROUTES.notificationPreferences)`
+- [x] 6.10 Create `ui/features/notifications/queries.ts` — server-side data fetching functions (SSR for pages): `getNotificationsQuery`, `getUnreadCountQuery`, `getPreferencesQuery`
+- [x] 6.11 Create `ui/features/notifications/types.ts` — feature-local types (filter state, UI props)
+
+**Work unit commit**: `feat(ui): add notification Server Actions and Sentry instrumentation`
+
+---
+
+## Phase 7: UI — Components, Pages, Routes
+
+- [x] 7.1 Create `ui/features/notifications/components/notification-item.tsx` — category icon, title, body (2-line truncate), relative timestamp, unread blue dot indicator; click marks as read
+- [x] 7.2 Create `ui/features/notifications/components/notification-filters.tsx` — read-state toggles (All/Unread) + category dropdown (All/Team/Billing); state as URL query params
+- [x] 7.3 Create `ui/features/notifications/components/notification-empty-state.tsx` — "No notifications yet" and "You're all caught up" variants
+- [x] 7.4 Create `ui/features/notifications/components/mark-all-read-button.tsx` — disabled when no unread; calls `markAllAsReadAction`; shows count label
+- [x] 7.5 Create `ui/features/notifications/components/notification-list.tsx` — Client Component; paginated list with `router.refresh()` after mutations; renders `notification-item` list + `notification-empty-state`
+- [x] 7.6 Create `ui/features/notifications/components/notification-preferences-form.tsx` — toggle grid per category per channel; critical events show disabled toggles; calls `updatePreferencesAction`; success toast
+- [x] 7.7 Create `ui/features/notifications/components/notification-bell.tsx` — bell icon; unread badge (numeric ≤99, "99+" above); navigates to `/notifications`; receives `initialCount` prop; uses `useUnreadCount` hook; renders only if role ≠ `"guest"`
+- [x] 7.8 Create `ui/app/(protected)/notifications/page.tsx` — Server Component; calls `getNotificationsQuery` + `getUnreadCountQuery`; renders `NotificationList` + `MarkAllReadButton` + `NotificationFilters`
+- [x] 7.9 Create `ui/app/(protected)/notifications/error.tsx` — error boundary with Sentry; "Could not load notifications. Try again." + retry button
+- [x] 7.10 Create `ui/app/(protected)/settings/notifications/page.tsx` — Server Component; calls `getPreferencesQuery`; renders `NotificationPreferencesForm`
+- [x] 7.11 Create `ui/app/(protected)/settings/notifications/error.tsx` — error boundary for preferences page
+
+**Work unit commit**: `feat(ui): add notification center, preferences pages and components`
+
+---
+
+## Phase 8: Realtime — Badge Subscription Hook + Header Integration
+
+- [x] 8.1 Create `ui/features/notifications/hooks/use-unread-count.ts` — Client-side hook; subscribes to Supabase Realtime `postgres_changes` INSERT on `notifications` table filtered by `user_id=eq.${userId}`; increments count; unsubscribes on unmount; logs Realtime errors to Sentry
+- [x] 8.2 Modify `ui/components/layout/header.tsx` — conditionally render `<NotificationBell>` between ThemeToggle and avatar dropdown; pass `userId`, `tenantId`, `initialCount`, `role` from layout context; guard: skip render if `role === "guest"`
+
+**Work unit commit**: `feat(ui): add Realtime unread badge hook and integrate bell in header`
+
+---
+
+## Phase 9: Seed Data + E2E Tests
+
+- [x] 9.1 Add 5 seed notifications and 1 preference row to `supabase/seed.sql` — unread team_invited (member), unread billing_past_due (owner), read billing_plan_upgraded (owner), read team_invitation_accepted (admin), unread team_role_changed (member); preference: member billing email disabled
+- [x] 9.2 Create `ui/e2e/notifications/notifications.spec.ts` — Page Object `NotificationsPage` + `NotificationPreferencesPage`; import paths from `ui/e2e/helpers/routes.ts`
+- [x] 9.3 E2E: `@critical` — User sees notification bell with badge (login as member, verify unread count > 0)
+- [x] 9.4 E2E: `@critical` — User opens notification center (click bell → `/notifications` loads list)
+- [x] 9.5 E2E: `@critical` — User marks notification as read (click unread item → blue dot gone, badge decrements)
+- [x] 9.6 E2E: User marks all as read ("Mark all as read" → badge gone, all dots gone)
+- [x] 9.7 E2E: User filters by category (select "Team" → only team notifications visible)
+- [x] 9.8 E2E: User filters by unread (select "Unread" → only unread shown)
+- [x] 9.9 E2E: User configures preferences (toggle billing email off → save → verify persisted)
+- [x] 9.10 E2E: `@critical` — Guest cannot see bell (login as guest → no bell in header)
+- [x] 9.11 E2E: Guest redirected from `/notifications` (navigate → redirected to `/dashboard`)
+- [x] 9.12 E2E: Empty state renders correctly (clean user → "No notifications yet" message)
+- [x] 9.13 E2E: Owner sees billing notifications (login as owner → billing_past_due present in list)
+- [x] 9.14 Add `ROUTES.notifications` and `ROUTES.notificationPreferences` to `ui/e2e/helpers/routes.ts`
+
+**Work unit commit**: `test(ui): add E2E tests and seed data for notifications feature`
+
+---
+
+## Task Summary
+
+| Phase | Tasks | Focus | PR |
+|-------|-------|-------|----|
+| 1 | 1.1–1.5 (5) | Contracts + contract tests | PR 1 |
+| 2 | 2.1–2.8 (8) | DB schema + RLS + migration | PR 1 |
+| 3 | 3.1–3.4 (4) | Email adapter port + factory | PR 1 |
+| 4 | 4.1–4.10 (10) | Service layer + 18 unit tests | PR 1 |
+| 5 | 5.1–5.10 (10) | Integration wiring (billing + team) | PR 2 |
+| 6 | 6.1–6.11 (11) | Server Actions + Sentry + routes | PR 3 |
+| 7 | 7.1–7.11 (11) | UI components + pages | PR 4 |
+| 8 | 8.1–8.2 (2) | Realtime hook + header bell | PR 4 |
+| 9 | 9.1–9.14 (14) | Seed data + E2E tests | PR 5 |
+| **Total** | **75** | | **5 PRs** |
+
+## Feature-Branch Chain Strategy
+
+```
+main
+ └─ feat/notifications (tracker)
+     ├─ PR 1: feat/notifications-foundation  → base: feat/notifications
+     ├─ PR 2: feat/notifications-integration  → base: PR 1 branch
+     ├─ PR 3: feat/notifications-actions      → base: PR 2 branch
+     ├─ PR 4: feat/notifications-ui           → base: PR 3 branch
+     └─ PR 5: feat/notifications-e2e          → base: PR 4 branch
+```
+
+Only `feat/notifications` tracker merges to `main`. Each child PR targets the immediate previous branch so diff stays focused on that slice only.

--- a/openspec/changes/brand-and-decoupling/design.md
+++ b/openspec/changes/brand-and-decoupling/design.md
@@ -1,0 +1,217 @@
+# Design: Brand Abstraction Layer + Backend Provider Decoupling
+
+## Technical Approach
+
+Two parallel, zero-overlap tracks extend the template's customization surface. Track B adds a brand identity layer in `@enterprise/ui` that wraps `ThemeProvider` and is driven by static `*.brand.ts` configs validated against a Zod schema in `@enterprise/contracts`. Track C introduces `AuthPort`, `StoragePort`, and `SessionPort` in `@enterprise/core/services/ports/` with Supabase reference adapters, following the existing `PaymentProviderPort` + `StripePaymentAdapter` pattern. Both tracks share the same port/adapter/factory architecture already proven by billing.
+
+## Architecture Decisions
+
+| # | Decision | Choice | Alternatives | Rationale |
+|---|----------|--------|-------------|-----------|
+| 1 | Brand module location | `@enterprise/ui/src/brand/` | New `@enterprise/brand` package | `@enterprise/ui` already owns `ThemeProvider`; brand is a neighbor. Package extraction is clean follow-up if scope grows. No new package for MVP. |
+| 2 | BrandProvider component type | Client Component (`"use client"`) | Server Component | `ThemeProvider` uses `useState`; `BrandProvider` renders it internally → must be client. Resolution is server-side via `resolveBrand()` in layout. |
+| 3 | Brand config storage | Static `*.brand.ts` files | Database-driven | Git history, PR review, Zod type safety free. DB-driven config is P2 follow-up. |
+| 4 | Brand resolution priority | ENV → subdomain → path prefix → default | Any other order | ENV is most explicit (single-brand deploys), subdomain is canonical prod, path prefix is local dev fallback, default prevents 500s. |
+| 5 | Auth/Storage factory return shape | `(client) => Adapter` functions | Fully-constructed adapter (billing pattern) | `SupabaseClient` is request-scoped (from `getServerClient()`). Can't capture at module level. Session adapter IS constructed eagerly since it creates its own internal client per call. |
+| 6 | Service function migration | `SupabaseClient` → `AuthPort` as first param | Keep `SupabaseClient`, wrap internally | Moving provider logic into adapters makes services stable interface boundaries. Tests mock `AuthPort` (plain object), not Supabase SDK. |
+| 7 | SessionPort return type | `NextResponse` (Next.js type) | Custom response wrapper | Middleware is a Next.js primitive. Custom abstraction adds complexity without benefit. Framework swap requires middleware rewrite anyway. |
+| 8 | Middleware split dependency | `SessionPort` for refresh, `SupabaseClient` for DB query | Full decoupling (requires DatabasePort) | Bounded concession documented explicitly. `DatabasePort` is P1 follow-up. |
+
+## Data Flow
+
+### Brand Resolution (Track B)
+
+```
+Next.js Server (RSC)              Client
+─────────────────────             ──────
+layout.tsx
+  │
+  ├─ resolveBrand()               
+  │   ├─ ENV BRAND_SLUG? → Map.get()
+  │   ├─ headers().host → subdomain? → Map.get()
+  │   ├─ headers().path → prefix? → Map.get()
+  │   └─ getDefaultBrand()
+  │
+  ├─ generateBrandMetadata(brand) → <head>
+  │
+  └─ <BrandProvider brand={brand}>    ← serialized as prop
+        │
+        ├─ BrandContext.Provider       ← useBrand() reads here
+        └─ <ThemeProvider defaultMode>  ← themeRef drives mode
+              └─ {children}
+```
+
+### Auth Action Flow (Track C — post-migration)
+
+```
+Client                     Server Action                    Adapter
+──────                     ─────────────                    ───────
+signInAction(formData)
+  │                        ├─ Zod validate
+  │                        ├─ getServerClient() → client
+  │                        ├─ authFactory(client) → AuthPort
+  │                        ├─ signInWithPasswordService(auth, input)
+  │                        │     └─ auth.signInWithPassword(input) ──→ SupabaseAuthAdapter
+  │                        │                                            └─ client.auth.signInWithPassword()
+  │                        └─ redirect(rolePath)
+```
+
+### Middleware Session Flow (Track C — post-migration)
+
+```
+Request → middleware.ts
+            ├─ sessionPort.refreshSession(request) ──→ SupabaseSessionAdapter
+            │                                            └─ updateSession(request, config)
+            ├─ createMiddlewareClient(request)     ← DB query (kept until DatabasePort)
+            │     └─ supabase.auth.getUser()
+            │     └─ getUserRoleService(supabase, userId)
+            └─ NextResponse (with refreshed cookies)
+```
+
+## File Changes
+
+| File | Action | PR | Description |
+|------|--------|-----|-------------|
+| `packages/contracts/src/schemas/brand.ts` | Create | B1 | `brandConfigSchema` + all sub-schemas + type exports |
+| `packages/contracts/src/index.ts` | Modify | B1 | Add brand schema + type exports to barrel |
+| `packages/ui/src/brand/context.ts` | Create | B1 | `BrandContext` — `createContext<BrandContextValue \| null>(null)` |
+| `packages/ui/src/brand/provider.tsx` | Create | B1 | `BrandProvider` (wraps ThemeProvider) + `useBrand()` hook |
+| `packages/ui/src/brand/registry.ts` | Create | B1 | `buildRegistry()` — loads, validates, deduplicates brand configs |
+| `packages/ui/src/brand/resolve.ts` | Create | B1 | `resolveBrand()` — async, server-only, priority chain lookup |
+| `packages/ui/src/brand/brand-meta.ts` | Create | B1 | `generateBrandMetadata()` — returns Next.js `Metadata` from `BrandConfig` |
+| `packages/ui/src/brands/index.ts` | Create | B1 | Barrel re-export of all `*.brand.ts` configs |
+| `packages/ui/src/brands/enterprise.brand.ts` | Create | B1 | Default brand config (isDefault: true) |
+| `packages/ui/package.json` | Modify | B1 | Add 6 subpath exports: `./brand/provider`, `./brand/context`, `./brand/resolve`, `./brand/brand-logo`, `./brand/brand-footer`, `./brand/brand-meta` |
+| `ui/app/layout.tsx` | Modify | B1 | Static `metadata` → async `generateMetadata()`, `ThemeProvider` → `BrandProvider`, preserve fonts + Toaster |
+| `packages/ui/src/brand/brand-logo.tsx` | Create | B2 | Light/dark logo switcher with text fallback |
+| `packages/ui/src/brand/brand-footer.tsx` | Create | B2 | Legal links, social icons, optional "Powered by" |
+| `packages/ui/src/index.ts` | Modify | B2 | Add brand exports: BrandProvider, useBrand, BrandLogo, BrandFooter, BrandContext |
+| `packages/ui/src/brands/acme.brand.ts` | Create | B2 | Commented-out example brand for adopters |
+| `packages/ui/src/brand/__tests__/registry.test.ts` | Create | B2 | Registry validation + duplicate slug tests |
+| `packages/ui/src/brand/__tests__/resolve.test.ts` | Create | B2 | Resolution priority chain tests |
+| `packages/ui/src/brand/__tests__/brand-logo.test.tsx` | Create | B2 | Logo variant + text fallback tests |
+| `packages/contracts/src/__tests__/brand.test.ts` | Create | B2 | Schema validation edge cases |
+| `ui/e2e/brand/brand.spec.ts` | Create | B2 | E2E: default brand renders, logo variants, metadata |
+| `docs/features/roadmap.md` | Modify | B2 | Notifications #10 status: "Planned" → "Done" |
+| `packages/core/src/services/ports/auth-port.ts` | Create | C1 | `AuthPort` interface — 7 methods matching auth-service functions |
+| `packages/core/src/services/ports/storage-port.ts` | Create | C1 | `StoragePort` interface — upload, download, delete, signedUrl, publicUrl, listFiles |
+| `packages/core/src/services/ports/session-port.ts` | Create | C1 | `SessionPort` interface — `refreshSession(request): Promise<NextResponse>` |
+| `packages/core/src/services/adapters/supabase-auth-adapter.ts` | Create | C1 | Wraps `SupabaseClient.auth.*` + profiles table — 1:1 with current auth-service logic |
+| `packages/core/src/services/adapters/supabase-storage-adapter.ts` | Create | C1 | Wraps `SupabaseClient.storage.*` — all 6 StoragePort methods |
+| `packages/core/src/services/adapters/supabase-session-adapter.ts` | Create | C1 | Wraps existing `updateSession()` from middleware.ts |
+| `packages/core/src/services/backend-adapters.ts` | Create | C1 | `createBackendAdapters()` — env-var driven factory, returns `{ auth, storage, session }` |
+| `packages/core/src/services/auth-service.ts` | Modify | C2 | 7 function signatures: `SupabaseClient` → `AuthPort`. Bodies become thin delegations. `ServiceResult`, input/data types, `resolveRoleRedirectPath` unchanged. |
+| `ui/features/auth/actions.ts` | Modify | C2 | Module-level `createBackendAdapters()`, per-call `authFactory(client)`. All 6 actions updated. |
+| `ui/middleware.ts` | Modify | C2 | `updateSession()` → `sessionPort.refreshSession()`. Keep `createMiddlewareClient` for DB query. |
+| `packages/core/src/services/__tests__/auth-service.test.ts` | Modify | C3 | Full rewrite: `createMockAuthPort()` replaces `createMockClient()`. No `@supabase/supabase-js` imports. |
+| `packages/core/src/services/__tests__/supabase-auth-adapter.test.ts` | Create | C3 | Adapter-level tests that DO mock Supabase SDK |
+| `packages/core/src/services/__tests__/supabase-storage-adapter.test.ts` | Create | C3 | Storage adapter mapping tests |
+| `packages/core/src/services/__tests__/backend-adapters.test.ts` | Create | C3 | Factory env-var selection + error handling |
+| `.env.example` | Modify | C3 | Add `BRAND_SLUG`, `BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER` with docs |
+
+## Interfaces / Contracts
+
+### AuthPort (key signatures)
+
+```typescript
+interface AuthPort {
+  signInWithPassword(input: SignInServiceInput): Promise<ServiceResult<SignInServiceData>>;
+  signUp(input: SignUpServiceInput): Promise<ServiceResult<SignUpServiceData>>;
+  signOut(): Promise<ServiceResult<null>>;
+  getUser(): Promise<ServiceResult<PlatformUser | null>>;
+  getUserRole(userId: string): Promise<ServiceResult<UserRoleServiceData>>;
+  requestPasswordReset(input: PasswordResetServiceInput): Promise<ServiceResult<null>>;
+  updatePassword(input: UpdatePasswordServiceInput): Promise<ServiceResult<null>>;
+}
+```
+
+### createBackendAdapters return type
+
+```typescript
+function createBackendAdapters(): {
+  auth: (client: SupabaseClient) => AuthPort;
+  storage: (client: SupabaseClient) => StoragePort;
+  session: SessionPort; // eager — creates own internal client per call
+};
+```
+
+### BrandProvider wrapper chain (layout.tsx after migration)
+
+```tsx
+// ui/app/layout.tsx — key structural change
+export async function generateMetadata() {
+  const brand = await resolveBrand();
+  return generateBrandMetadata(brand);
+}
+
+export default async function RootLayout({ children }) {
+  const brand = await resolveBrand();
+  return (
+    <html lang="en" data-theme="dark" suppressHydrationWarning
+          className={`${inter.variable} ${jetbrainsMono.variable} ${plusJakartaSans.variable} ${spaceGrotesk.variable}`}>
+      <body className="min-h-screen bg-background font-sans antialiased">
+        <BrandProvider brand={brand}>
+          {children}
+        </BrandProvider>
+        <Toaster richColors position="top-right" />
+      </body>
+    </html>
+  );
+}
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| **Unit — contracts** | `brandConfigSchema` validation (valid/invalid slugs, missing fields, nested errors) | Vitest, 9 cases per RFC |
+| **Unit — registry** | `buildRegistry()` — valid config, duplicate slug, invalid field, missing default | Vitest, mock brand modules |
+| **Unit — resolve** | Resolution priority (env > subdomain > path > default), invalid env throws | Vitest, mock `next/headers` + `process.env` |
+| **Unit — BrandLogo** | Light/dark variant, text fallback, className passthrough, throw outside provider | Vitest + React Testing Library |
+| **Unit — auth-service (post-migration)** | All 7 functions delegate to `AuthPort` mock — `createMockAuthPort()` with `vi.fn()` stubs | Vitest, zero Supabase imports |
+| **Unit — SupabaseAuthAdapter** | SDK response → `ServiceResult` mapping (success, errors, edge cases like PGRST116) | Vitest, mock `SupabaseClient` |
+| **Unit — SupabaseStorageAdapter** | All 6 methods: upload/download/delete/signedUrl/publicUrl/listFiles mapping | Vitest, mock `SupabaseClient.storage` |
+| **Unit — backend-adapters factory** | Default returns Supabase, unknown provider throws, missing env throws | Vitest, env var manipulation |
+| **E2E — brand** | Default brand renders (title, favicon, footer links), logo light/dark, `BRAND_SLUG` override | Playwright, `@critical` tag |
+| **E2E — auth (implicit)** | Existing auth E2E suite passes unchanged — validates adapter equivalence | Playwright, no new tests needed |
+
+### Port Mock Pattern (canonical)
+
+```typescript
+function createMockAuthPort(): AuthPort {
+  return {
+    signInWithPassword: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getUser: vi.fn(),
+    getUserRole: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    updatePassword: vi.fn(),
+  };
+}
+```
+
+## PR Delivery Plan
+
+| PR | Track | Base | Content | Est. Lines | Isolated Build/Test |
+|----|-------|------|---------|------------|---------------------|
+| **PR-B1** | Brand | `main` | Contracts schema, brand module (registry, resolve, context, provider, brand-meta), enterprise.brand.ts, layout.tsx migration, package.json exports | ~600 | `pnpm typecheck && pnpm test` — brand unit tests + contracts tests pass. Layout renders with BrandProvider wrapping ThemeProvider. |
+| **PR-B2** | Brand | PR-B1 | BrandLogo, BrandFooter, barrel exports, acme.brand.ts example, E2E tests, roadmap fix, .env.example BRAND_SLUG | ~400 | `pnpm typecheck && pnpm test && pnpm e2e` — brand E2E suite passes. |
+| **PR-C1** | Decoupling | `main` | Port interfaces (auth, storage, session), Supabase adapters (3 files), backend-adapters.ts factory | ~500 | `pnpm typecheck && pnpm test` — factory tests + adapter tests pass. No existing code changed. |
+| **PR-C2** | Decoupling | PR-C1 | auth-service.ts migration (7 fn signatures), auth actions.ts (adapter injection), middleware.ts (SessionPort) | ~600 | `pnpm typecheck && pnpm test && pnpm e2e` — all existing tests + E2E pass (Supabase default path). |
+| **PR-C3** | Decoupling | PR-C2 | auth-service.test.ts rewrite to port mocks, adapter unit tests, factory tests, .env.example additions, AGENTS.md QA updates | ~500 | `pnpm typecheck && pnpm test` — zero @supabase/supabase-js imports in service tests. |
+
+**Parallelism**: B-track and C-track run independently (zero file overlap). C-track is chained (C2 → C1, C3 → C2).
+
+## Migration / Rollout
+
+No data migration required. No feature flags needed. Both tracks are additive — no DB schema or RLS changes.
+
+**Backward compatibility**: auth-service function signatures change (Track C). This is a source-level breaking change for adopter forks. Migration guide documents before/after diffs for all 7 functions and all 6 Server Actions.
+
+**Rollback**: Both tracks fully reversible — remove new files, revert modified files. Neither touches database.
+
+## Open Questions
+
+- [x] All technical questions resolved during exploration and proposal phases
+- [ ] None blocking — design is implementation-ready

--- a/openspec/changes/brand-and-decoupling/proposal.md
+++ b/openspec/changes/brand-and-decoupling/proposal.md
@@ -1,0 +1,114 @@
+# Proposal: Brand Abstraction Layer + Backend Provider Decoupling
+
+## Intent
+
+The template is fully coupled to Supabase and ships a single hardcoded identity. Adopters who need a different auth provider or a second brand must fork and gut — losing upgrade paths. Features #14 (brand) and #16 (decoupling) are orthogonal (zero file overlap), both P1, and unblock the highest-value adopter customization axes: visual identity and backend choice. Bundling them in one SDD change reduces coordination overhead while enabling parallel PR tracks. The roadmap also has a stale status (Notifications #10 shows "Planned" but is Done).
+
+## Scope
+
+### In Scope
+- **A. Roadmap fix**: Update `docs/features/roadmap.md` line 34 — Notifications status "Planned" to "Done"
+- **B. Brand abstraction (#14)**: `BrandConfig` Zod schema in `@enterprise/contracts`, `BrandProvider` + `useBrand()` + `resolveBrand()` in `@enterprise/ui`, brand registry with default "enterprise" brand, `BrandLogo` + `BrandFooter` components, `generateBrandMetadata()` for dynamic Next.js metadata, layout.tsx migration
+- **C. Backend decoupling (#16)**: `AuthPort`, `StoragePort`, `SessionPort` interfaces in `@enterprise/core/services/ports/`, Supabase reference adapters, `createBackendAdapters()` factory, auth-service migration from `SupabaseClient` to `AuthPort`, test rewrite to port mocks, middleware + Server Action updates, `.env.example` additions
+
+### Out of Scope
+- `DatabasePort` / `RealtimePort` abstractions (P1/P2 follow-ups per RFC #16)
+- Runtime brand switching per user session or multi-tenant branding
+- Visual brand editor UI
+- Any changes to `@enterprise/db` Drizzle schemas or RLS policies
+- Brand isolation package (#15) — separate change
+- Deployment provider decoupling (#20) — separate change
+
+## Capabilities
+
+### New Capabilities
+- `brand-config`: BrandConfig Zod schema, brand registry, resolution strategy, default "enterprise" brand
+- `brand-provider`: BrandProvider context, useBrand() hook, BrandLogo/BrandFooter components, generateBrandMetadata()
+- `backend-ports`: AuthPort, StoragePort, SessionPort interfaces in @enterprise/core
+- `backend-adapters`: Supabase reference adapters, createBackendAdapters() factory, env-var-driven selection
+
+### Modified Capabilities
+- None — no existing `openspec/specs/` capabilities are affected (specs dir is empty)
+
+## Approach
+
+Three parallel tracks, sequenced by dependency:
+
+1. **Track A (trivial)**: One-line roadmap edit. Ships in any PR as a drive-by fix.
+2. **Track B (#14 — Brand)**: contracts schema -> ui/brand module (registry, resolve, context, provider) -> layout.tsx migration -> presentational components. ~800-1200 lines. Fits 1-2 PRs within 800-line budget.
+3. **Track C (#16 — Decoupling)**: port interfaces -> Supabase adapters -> factory -> auth-service migration -> action/middleware updates -> test rewrite. ~1500-2200 lines. MUST split into 3 chained PRs.
+
+Tracks B and C have **zero file overlap** and execute in parallel.
+
+### PR Strategy (auto-forecast)
+
+| PR | Track | Content | Est. Lines | Target |
+|----|-------|---------|------------|--------|
+| PR-B1 | B | Contracts schema + brand module + registry + resolve + provider + layout migration | ~600 | main |
+| PR-B2 | B | BrandLogo + BrandFooter + package.json exports + E2E tests + roadmap fix (Track A) | ~400 | main |
+| PR-C1 | C | Port interfaces + Supabase adapters + factory + exports | ~500 | main |
+| PR-C2 | C | auth-service migration + action updates + middleware updates | ~600 | PR-C1 |
+| PR-C3 | C | Test rewrite to port mocks + .env.example + migration docs | ~500 | PR-C2 |
+
+Total: ~2600 lines across 5 PRs. All within 800-line review budget per PR. B-track and C-track run in parallel.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `packages/contracts/src/schemas/` | New | `brand.ts` — BrandConfig Zod schema + types |
+| `packages/contracts/src/index.ts` | Modified | Barrel export for brand schemas |
+| `packages/ui/src/brand/` | New | registry, resolve, context, provider, components |
+| `packages/ui/package.json` | Modified | Add `./brand/*` subpath exports |
+| `packages/ui/src/index.ts` | Modified | Barrel export brand module |
+| `ui/app/layout.tsx` | Modified | Static metadata -> generateMetadata, ThemeProvider -> BrandProvider |
+| `packages/core/src/services/ports/` | New | `auth-port.ts`, `storage-port.ts`, `session-port.ts` |
+| `packages/core/src/services/adapters/` | New | `supabase-auth-adapter.ts`, `supabase-storage-adapter.ts`, `supabase-session-adapter.ts` |
+| `packages/core/src/services/` | New | `backend-adapters.ts` factory |
+| `packages/core/src/services/auth-service.ts` | Modified | 7 functions: SupabaseClient -> AuthPort first param |
+| `packages/core/src/services/__tests__/auth-service.test.ts` | Modified | Full rewrite: SupabaseClient mocks -> AuthPort mocks |
+| `ui/features/auth/actions.ts` | Modified | Inject adapters via createBackendAdapters() factory |
+| `ui/middleware.ts` | Modified | SessionPort for token refresh (keep createMiddlewareClient for DB) |
+| `docs/features/roadmap.md` | Modified | Line 34: Notifications "Planned" -> "Done" |
+| `.env.example` | Modified | Add BRAND_SLUG, BACKEND_AUTH_PROVIDER, BACKEND_STORAGE_PROVIDER docs |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| auth-service signature change breaks adopter forks | High | Document before/after diffs in migration guide. No runtime behavior change for default Supabase path |
+| BrandProvider fails to render ThemeProvider (themeRef validation) | Medium | Startup validation in registry.ts catches invalid themeRef at boot, not render time |
+| createBackendAdapters() module-level call fails in test envs missing env vars | Medium | Fast-fail is intentional. Document required test env setup |
+| resolveBrand() called outside RSC context (headers() crash) | Medium | Type-level: resolveBrand() only exported from server-side module. Docs warn against client import |
+| Chained PRs (C-track) cause merge conflicts between slices | Low | Each PR has autonomous scope. Rebase discipline between slices |
+
+## Rollback Plan
+
+- **Track A**: Revert single line in roadmap.md
+- **Track B**: Remove `packages/ui/src/brand/` directory, revert layout.tsx to static metadata + ThemeProvider, remove brand schema from contracts. No DB changes involved
+- **Track C**: Revert auth-service.ts signatures back to SupabaseClient, remove port/adapter files, revert actions.ts and middleware.ts. The port interfaces have no runtime consumers outside this change. No DB changes involved
+
+Both tracks are fully reversible because neither touches database schemas or RLS policies.
+
+## Dependencies
+
+- Existing ThemeProvider and theme system must remain stable (brand wraps it)
+- Existing payment-adapter-factory.ts pattern guides #16 factory design
+- Node.js `next/headers` API for server-side brand resolution
+
+## Success Criteria
+
+- [ ] `pnpm typecheck` passes with zero errors across all packages
+- [ ] `pnpm test` passes — auth-service tests use AuthPort mocks, zero @supabase/supabase-js imports in test files
+- [ ] `pnpm lint` passes
+- [ ] Default Supabase path works identically — no behavioral regression for adopters who change nothing
+- [ ] `useBrand()` returns resolved BrandConfig in any client component under BrandProvider
+- [ ] `resolveBrand()` correctly resolves "enterprise" brand from env/config in root layout
+- [ ] layout.tsx renders with BrandProvider wrapping children, preserves font classNames and Toaster placement
+- [ ] BrandLogo renders correct logo variant based on theme mode
+- [ ] All 6 auth Server Actions use adapter injection pattern
+- [ ] middleware.ts uses SessionPort for token refresh
+- [ ] createBackendAdapters() returns Supabase adapters by default, respects env var overrides
+- [ ] .env.example documents new optional variables with clear fallback behavior
+- [ ] roadmap.md shows Notifications as "Done"
+- [ ] All PRs under 800-line review budget

--- a/openspec/changes/brand-and-decoupling/spec.md
+++ b/openspec/changes/brand-and-decoupling/spec.md
@@ -1,0 +1,581 @@
+# Specs: brand-and-decoupling
+
+> **Change**: brand-and-decoupling
+> **Type**: New capabilities (openspec/specs/ is empty — full specs, not deltas)
+> **Capabilities**: brand-config, brand-provider, backend-ports, backend-adapters
+
+---
+
+## Domain: brand-config
+
+# Brand Config Specification
+
+## Purpose
+
+Define the data model and validation contract for a brand identity in the Enterprise Platform. `brandConfigSchema` in `@enterprise/contracts` is the single source of truth for what a brand is. Brand configs are static TypeScript files validated at startup — no database, no per-request overhead.
+
+## Requirements
+
+### Requirement: BrandConfig Schema Fields
+
+`brandConfigSchema` MUST be a Zod object schema in `packages/contracts/src/schemas/brand.ts` with the following fields:
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| `slug` | `string` | Yes | Regex `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`; min 1 |
+| `name` | `string` | Yes | min 1 |
+| `displayName` | `string` | Yes | min 1 |
+| `description` | `string` | Yes | min 1 |
+| `logo` | `{ light: LogoVariant, dark: LogoVariant }` | Yes | See brandLogoSchema |
+| `favicon` | `string` | Yes | min 1 |
+| `metadata` | `BrandMetadata` | Yes | See brandMetadataSchema |
+| `legal` | `BrandLegal` | Yes | See brandLegalSchema |
+| `social` | `BrandSocial` | No | optional |
+| `themeRef` | `string` | Yes | min 1 |
+| `features` | `Record<string, boolean>` | No | optional |
+| `isDefault` | `boolean` | No | optional |
+
+Sub-schemas MUST be exported: `brandLogoVariantSchema`, `brandLogoSchema`, `brandMetadataSchema`, `brandLegalSchema`, `brandSocialSchema`.
+
+Type exports MUST be co-located: `BrandConfig`, `BrandLogoVariant`, `BrandLogo`, `BrandMetadata`, `BrandLegal`, `BrandSocial`.
+
+#### Scenario: Valid full brand config passes schema
+
+- GIVEN a brand config object with all required and all optional fields populated
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: true, data: config }`
+
+#### Scenario: Minimal valid config (required fields only)
+
+- GIVEN a brand config with only required fields (no `social`, `features`, `isDefault`)
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: true }` and optional fields are `undefined`
+
+#### Scenario: Invalid slug with spaces or uppercase is rejected
+
+- GIVEN `slug: "My Brand"` or `slug: "Enterprise"`
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: false }` with issue path `["slug"]`
+
+#### Scenario: Missing required nested field is rejected with path
+
+- GIVEN `logo.light.alt: ""` (empty string)
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: false }` with issue path `["logo", "light", "alt"]`
+
+#### Scenario: features record rejects non-boolean value
+
+- GIVEN `features: { showPoweredBy: "yes" }`
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: false }` — `z.boolean()` rejects string
+
+#### Scenario: social.twitter with invalid URL is rejected
+
+- GIVEN `social: { twitter: "not-a-url" }`
+- WHEN `brandConfigSchema.safeParse(config)` is called
+- THEN result is `{ success: false }` with issue path `["social", "twitter"]`
+
+### Requirement: Brand Registry Startup Validation
+
+The registry (`packages/ui/src/brand/registry.ts`) MUST validate every brand config at module initialization using `brandConfigSchema.safeParse()`. It MUST throw before the server serves any request if any config fails.
+
+Duplicate slugs MUST throw: `"[brand] Duplicate brand slug \"${slug}\" detected."`.
+
+`getDefaultBrand()` MUST return the brand with `isDefault: true`, fall back to the `"enterprise"` slug, and throw if neither exists.
+
+#### Scenario: Duplicate slug in registry throws at startup
+
+- GIVEN two brand config files both with `slug: "enterprise"`
+- WHEN the registry module is first imported
+- THEN `buildRegistry()` throws with the duplicate slug in the error message
+- AND the server does not start
+
+#### Scenario: No registered brands throws on getDefaultBrand
+
+- GIVEN no brand config files and no `isDefault` declared
+- WHEN `getDefaultBrand()` is called
+- THEN it throws with a message identifying the missing `"enterprise"` brand
+
+#### Scenario: themeRef validated against existing theme JSONs
+
+- GIVEN a brand config with `themeRef: "nonexistent-theme"`
+- WHEN the registry is built
+- THEN startup throws identifying the invalid `themeRef` before any request is served
+
+### Requirement: Barrel Export in @enterprise/contracts
+
+`packages/contracts/src/index.ts` MUST export all brand schemas and types. Consumers MUST be able to import `brandConfigSchema` and `BrandConfig` from `@enterprise/contracts`.
+
+#### Scenario: Consumer imports BrandConfig from @enterprise/contracts
+
+- GIVEN `import { brandConfigSchema } from "@enterprise/contracts"`
+- WHEN TypeScript compiles the import
+- THEN no type errors; `brandConfigSchema` is a `ZodObject`
+
+---
+
+## Domain: brand-provider
+
+# Brand Provider Specification
+
+## Purpose
+
+Define the runtime API for brand context: `BrandProvider` (context seeder), `useBrand()` (client hook), `resolveBrand()` (server resolver), presentational components (`BrandLogo`, `BrandFooter`), and `generateBrandMetadata()` (metadata helper). These live in `packages/ui/src/brand/`.
+
+## Requirements
+
+### Requirement: resolveBrand() Resolution Strategy
+
+`resolveBrand(): Promise<BrandConfig>` MUST resolve the active brand via a strict priority chain:
+
+1. `BRAND_SLUG` env var — if set, MUST match a registered slug or throw with available slugs listed
+2. Subdomain matching — first segment of `Host` header, only if `host.split(".").length > 2`
+3. Path prefix matching — first segment of request pathname (skip if contains `.`)
+4. Default brand — `getDefaultBrand()` from registry
+
+On unrecognized subdomain or path prefix: MUST emit `console.warn` and fall through to default. MUST NOT throw.
+
+`resolveBrand()` MUST be server-only (imports `next/headers`). MUST NOT be called in Client Components.
+
+#### Scenario: BRAND_SLUG env var forces single brand
+
+- GIVEN `BRAND_SLUG=enterprise` is set and the `"enterprise"` brand is registered
+- WHEN `resolveBrand()` is called from any request context
+- THEN returns the `"enterprise"` brand regardless of subdomain or path
+
+#### Scenario: BRAND_SLUG env var with unknown slug throws
+
+- GIVEN `BRAND_SLUG=unknown-brand` and no brand with that slug is registered
+- WHEN `resolveBrand()` is called
+- THEN throws with message containing `"unknown-brand"` and the list of available slugs
+
+#### Scenario: Subdomain resolves to matching brand
+
+- GIVEN `Host: acme.platform.com` and `"acme"` brand is registered
+- WHEN `resolveBrand()` is called
+- THEN returns the `"acme"` brand
+
+#### Scenario: Unrecognized subdomain falls back to default
+
+- GIVEN `Host: unknown.platform.com` and no `"unknown"` brand
+- WHEN `resolveBrand()` is called
+- THEN emits `console.warn` with the slug
+- AND returns the default brand (no error page)
+
+#### Scenario: Path prefix resolves to matching brand
+
+- GIVEN request path `/acme/dashboard` and `"acme"` brand is registered
+- WHEN `resolveBrand()` is called
+- THEN returns the `"acme"` brand
+
+#### Scenario: Static asset paths do not emit spurious brand warnings
+
+- GIVEN request path `/favicon.ico`
+- WHEN `resolveBrand()` evaluates path prefix
+- THEN does NOT emit `console.warn` (segment contains `.`)
+- AND falls through to default brand
+
+### Requirement: BrandProvider and useBrand() Context
+
+`BrandProvider` MUST be a `"use client"` component. It MUST:
+- Accept `brand: BrandConfig` and `children: React.ReactNode` as props
+- Seed `BrandContext` with `{ brand }`
+- Render `ThemeProvider` internally, deriving `defaultMode` from `themeRef` (ends with `"light"` → `"light"`, otherwise `"dark"`)
+
+`useBrand()` MUST return `BrandConfig` from `BrandContext`. MUST throw with a descriptive error if called outside a `BrandProvider`.
+
+`BrandContext` MUST be `createContext<BrandContextValue | null>(null)`.
+
+#### Scenario: useBrand() returns brand config inside provider
+
+- GIVEN a component tree wrapped in `<BrandProvider brand={enterpriseBrand}>`
+- WHEN a client component calls `useBrand()`
+- THEN returns the `enterpriseBrand` config without errors
+
+#### Scenario: useBrand() throws outside BrandProvider
+
+- GIVEN a client component NOT wrapped in `BrandProvider`
+- WHEN it calls `useBrand()`
+- THEN throws with message containing `"<BrandProvider>"` and guidance
+
+#### Scenario: BrandProvider renders ThemeProvider with derived mode
+
+- GIVEN `brand.themeRef = "acme-light"`
+- WHEN `BrandProvider` renders
+- THEN `ThemeProvider` receives `defaultMode="light"`
+
+### Requirement: Root Layout Integration
+
+`ui/app/layout.tsx` MUST be migrated from static `export const metadata` to `export async function generateMetadata()`. It MUST call `resolveBrand()` and pass the result to `generateBrandMetadata()`. The layout MUST wrap children with `BrandProvider`. Font `className` on `<html>` and `Toaster` at body level MUST be preserved.
+
+#### Scenario: generateMetadata uses resolved brand
+
+- GIVEN the enterprise brand with `metadata.titleTemplate = "%s | Enterprise Platform"`
+- WHEN Next.js calls `generateMetadata()` for the root layout
+- THEN returns `{ title: { template: "%s | Enterprise Platform", default: "Enterprise Platform" }, ... }`
+
+#### Scenario: BrandProvider wraps children at root layout level
+
+- GIVEN `resolveBrand()` returns the enterprise brand
+- WHEN the root layout renders
+- THEN all pages have access to `BrandContext` via `useBrand()`
+
+### Requirement: BrandLogo Component
+
+`BrandLogo` MUST be a `"use client"` component that:
+- Reads `useBrand().logo` and `useTheme().mode`
+- Renders `<img>` with the `light` or `dark` variant `src` and `alt` based on mode
+- Falls back to `<span>` with `brand.displayName` text when `src` is empty/falsy
+- Forwards optional `className` prop to the root element
+
+#### Scenario: Logo renders correct variant for active theme mode
+
+- GIVEN mode is `"dark"` and `brand.logo.dark.src = "/logo-dark.svg"`
+- WHEN `BrandLogo` renders
+- THEN `<img src="/logo-dark.svg">` is rendered with `alt` from `logo.dark.alt`
+
+#### Scenario: Empty src renders displayName text fallback
+
+- GIVEN `brand.logo.light.src = ""`
+- WHEN `BrandLogo` renders in light mode
+- THEN a `<span>` containing `brand.displayName` is rendered — no `<img>` tag
+
+### Requirement: BrandFooter Component
+
+`BrandFooter` MUST be a `"use client"` component that:
+- Renders `© {year} {brand.displayName}`
+- Renders `<a>` links for `legal.privacyUrl` and `legal.termsUrl` — omits links when value is empty string
+- Renders social links from `brand.social` when present
+- Renders "Powered by Enterprise Platform" when `brand.features?.["showPoweredBy"] === true`
+
+#### Scenario: Footer renders legal links when URLs are non-empty
+
+- GIVEN `brand.legal.privacyUrl = "https://example.com/privacy"`
+- WHEN `BrandFooter` renders
+- THEN `<a href="https://example.com/privacy">Privacy Policy</a>` is present in the DOM
+
+#### Scenario: Footer omits legal links when URLs are empty string
+
+- GIVEN `brand.legal.privacyUrl = ""`
+- WHEN `BrandFooter` renders
+- THEN no `<a>` element with `href=""` is rendered for privacy
+
+### Requirement: generateBrandMetadata() Helper
+
+`generateBrandMetadata(brand: BrandConfig): Metadata` MUST return a Next.js `Metadata` object with:
+- `title.template` = `brand.metadata.titleTemplate`
+- `title.default` = `brand.metadata.defaultTitle`
+- `description` = `brand.metadata.description`
+- `icons.icon` = `brand.favicon`
+- `openGraph.images` = `[brand.metadata.ogImage]` (empty array if `ogImage` is falsy)
+
+#### Scenario: generateBrandMetadata maps all brand metadata fields
+
+- GIVEN a valid `BrandConfig` with all metadata fields populated
+- WHEN `generateBrandMetadata(brand)` is called
+- THEN returns a `Metadata` object with all fields mapped correctly
+
+### Requirement: Subpath Exports in packages/ui
+
+`packages/ui/package.json` MUST include subpath exports for all brand modules. `packages/ui/src/index.ts` MUST barrel-export `BrandProvider`, `useBrand`, `BrandLogo`, `BrandFooter`, `BrandContext`.
+
+#### Scenario: Consumer imports BrandProvider from subpath
+
+- GIVEN `import { BrandProvider } from "@enterprise/ui/brand/provider"`
+- WHEN TypeScript resolves the import
+- THEN no type errors; `BrandProvider` is a React component
+
+---
+
+## Domain: backend-ports
+
+# Backend Ports Specification
+
+## Purpose
+
+Define the three provider-agnostic port interfaces in `packages/core/src/services/ports/`: `AuthPort`, `StoragePort`, `SessionPort`. These are plain TypeScript interfaces — no abstract classes, no SDK imports. Any object satisfying the interface is a valid adapter.
+
+## Requirements
+
+### Requirement: AuthPort Interface
+
+`AuthPort` MUST be a plain TypeScript interface at `packages/core/src/services/ports/auth-port.ts` with these 7 methods:
+
+| Method | Signature | Return |
+|--------|-----------|--------|
+| `signInWithPassword` | `(input: SignInServiceInput)` | `Promise<ServiceResult<SignInServiceData>>` |
+| `signUp` | `(input: SignUpServiceInput)` | `Promise<ServiceResult<SignUpServiceData>>` |
+| `signOut` | `()` | `Promise<ServiceResult<null>>` |
+| `getUser` | `()` | `Promise<ServiceResult<PlatformUser \| null>>` |
+| `getUserRole` | `(userId: string)` | `Promise<ServiceResult<UserRoleServiceData>>` |
+| `requestPasswordReset` | `(input: PasswordResetServiceInput)` | `Promise<ServiceResult<null>>` |
+| `updatePassword` | `(input: UpdatePasswordServiceInput)` | `Promise<ServiceResult<null>>` |
+
+`AuthPort` MUST NOT import any SDK (`@supabase/supabase-js`, `firebase`, etc.). All types MUST come from `@enterprise/contracts` or `../auth-service`.
+
+Adapters MUST return `ServiceResult` (never throw). On failure: `{ success: false, error: string, code: string }`.
+
+#### Scenario: AuthPort mock satisfies the interface without SDK imports
+
+- GIVEN a test file that creates `const mock: AuthPort = { signInWithPassword: vi.fn(), ... }`
+- WHEN TypeScript compiles the file
+- THEN no errors — no `@supabase/supabase-js` import required
+- AND the mock can be passed to any service accepting `AuthPort`
+
+#### Scenario: getUser returns null for anonymous visitor (not an error)
+
+- GIVEN an `AuthPort` implementation where no session exists
+- WHEN `getUser()` is called
+- THEN returns `{ success: true, data: null }` — NOT `{ success: false }`
+
+### Requirement: StoragePort Interface
+
+`StoragePort` MUST be a plain TypeScript interface at `packages/core/src/services/ports/storage-port.ts` with 6 methods:
+
+| Method | Key Parameters | Return |
+|--------|---------------|--------|
+| `upload` | `bucket, path, file: Blob\|File\|ArrayBuffer, options?` | `Promise<ServiceResult<StorageUploadResult>>` |
+| `download` | `bucket, path` | `Promise<ServiceResult<Blob>>` |
+| `delete` | `bucket, paths: string[]` | `Promise<ServiceResult<null>>` |
+| `getSignedUrl` | `bucket, path, expiresIn: number` | `Promise<ServiceResult<StorageSignedUrlResult>>` |
+| `getPublicUrl` | `bucket, path` | `Promise<ServiceResult<StoragePublicUrlResult>>` |
+| `listFiles` | `bucket, prefix?, limit?, offset?` | `Promise<ServiceResult<StorageFileEntry[]>>` |
+
+Supporting types MUST be exported: `StorageUploadOptions`, `StorageUploadResult`, `StorageSignedUrlResult`, `StoragePublicUrlResult`, `StorageFileEntry`.
+
+#### Scenario: StoragePort mock satisfies interface without SDK imports
+
+- GIVEN `const mock: StoragePort = { upload: vi.fn(), download: vi.fn(), ... }`
+- WHEN TypeScript compiles
+- THEN no errors — no `@supabase/supabase-js` needed
+
+#### Scenario: delete accepts multiple paths
+
+- GIVEN `paths: ["avatars/user-1.webp", "avatars/user-2.webp"]`
+- WHEN `storage.delete(bucket, paths)` is called
+- THEN both paths are removed in a single operation
+
+### Requirement: SessionPort Interface
+
+`SessionPort` MUST be a plain TypeScript interface at `packages/core/src/services/ports/session-port.ts` with a single method:
+
+`refreshSession(request: NextRequest): Promise<NextResponse>`
+
+`SessionPort` is intentionally Next.js-scoped. The method MUST refresh the session cookie and return a `NextResponse` with updated `Set-Cookie` headers. It MUST return a pass-through response when no session exists.
+
+#### Scenario: refreshSession returns NextResponse with refreshed cookies
+
+- GIVEN an authenticated request with a valid but near-expiry session cookie
+- WHEN `sessionPort.refreshSession(request)` is called
+- THEN returns a `NextResponse` with updated `Set-Cookie` headers containing the refreshed token
+
+#### Scenario: refreshSession returns pass-through for anonymous request
+
+- GIVEN a request with no session cookie
+- WHEN `sessionPort.refreshSession(request)` is called
+- THEN returns a `NextResponse` without modifying cookies (no error thrown)
+
+### Requirement: Ports Exported from @enterprise/core Public API
+
+All three port interfaces MUST be exported from the `@enterprise/core` public API (subpath or barrel). Consumers MUST be able to import `AuthPort`, `StoragePort`, `SessionPort` from `@enterprise/core/services`.
+
+#### Scenario: Consumer imports AuthPort from @enterprise/core/services
+
+- GIVEN `import type { AuthPort } from "@enterprise/core/services"`
+- WHEN TypeScript resolves the import
+- THEN no errors; `AuthPort` is a TypeScript interface with 7 methods
+
+---
+
+## Domain: backend-adapters
+
+# Backend Adapters Specification
+
+## Purpose
+
+Define the Supabase reference adapter implementations, the `createBackendAdapters()` factory, the auth-service migration contract, middleware and Server Action wiring, and the port-mock test pattern.
+
+## Requirements
+
+### Requirement: SupabaseAuthAdapter Implements AuthPort
+
+`SupabaseAuthAdapter` MUST be a class in `packages/core/src/services/adapters/supabase-auth-adapter.ts` implementing `AuthPort`. Constructor: `constructor(private readonly client: SupabaseClient)`.
+
+Each method MUST map 1:1 to the pre-refactor `auth-service.ts` logic with identical `ServiceResult` error codes:
+
+| Method | Error codes |
+|--------|-------------|
+| `signInWithPassword` | `INVALID_CREDENTIALS`, `USER_NOT_FOUND`, `ROLE_LOOKUP_FAILED` |
+| `signUp` | `SIGN_UP_FAILED`, `USER_NOT_CREATED` |
+| `signOut` | `SIGN_OUT_FAILED` |
+| `getUser` | `AUTH_USER_LOOKUP_FAILED` |
+| `getUserRole` | `ROLE_LOOKUP_FAILED`; PGRST116 (row not found) MUST return `{ role: "guest" }`, not an error |
+| `requestPasswordReset` | `PASSWORD_RESET_REQUEST_FAILED` |
+| `updatePassword` | `PASSWORD_UPDATE_FAILED` |
+
+#### Scenario: SupabaseAuthAdapter.signInWithPassword maps Supabase error to ServiceResult
+
+- GIVEN `client.auth.signInWithPassword()` returns an error
+- WHEN `adapter.signInWithPassword(input)` is called
+- THEN returns `{ success: false, error: "Invalid credentials", code: "INVALID_CREDENTIALS" }`
+- AND does not throw
+
+#### Scenario: getUserRole ignores PGRST116 and defaults to guest
+
+- GIVEN `client.from("profiles").select("role")` returns `error.code = "PGRST116"` (no row)
+- WHEN `adapter.getUserRole(userId)` is called
+- THEN returns `{ success: true, data: { role: "guest" } }`
+
+### Requirement: SupabaseStorageAdapter Implements StoragePort
+
+`SupabaseStorageAdapter` MUST be a class implementing `StoragePort`. Constructor: `constructor(private readonly client: SupabaseClient)`. It MUST use `STORAGE_BUCKETS` and `STORAGE_PATHS` constants as naming conventions (not embedded in the adapter interface). `getPublicUrl` MUST always return `{ success: true }` — Supabase never errors on public URL construction.
+
+#### Scenario: upload wraps Supabase storage upload
+
+- GIVEN `client.storage.from(bucket).upload(path, file)` succeeds
+- WHEN `adapter.upload(bucket, path, file)` is called
+- THEN returns `{ success: true, data: { path, fullPath } }`
+
+#### Scenario: getPublicUrl always succeeds
+
+- GIVEN any bucket and path
+- WHEN `adapter.getPublicUrl(bucket, path)` is called
+- THEN returns `{ success: true, data: { publicUrl: "..." } }` — no error possible
+
+### Requirement: SupabaseSessionAdapter Implements SessionPort
+
+`SupabaseSessionAdapter` MUST be a class implementing `SessionPort`. Constructor: `constructor(supabaseUrl: string, supabaseAnonKey: string)`. It MUST delegate `refreshSession()` to the existing `updateSession()` function from `packages/core/src/supabase/middleware.ts`. No new logic is introduced.
+
+#### Scenario: refreshSession delegates to updateSession
+
+- GIVEN a valid `NextRequest` with session cookies
+- WHEN `adapter.refreshSession(request)` is called
+- THEN calls `updateSession(request, { supabaseUrl, supabaseAnonKey })`
+- AND returns the resulting `NextResponse`
+
+### Requirement: createBackendAdapters() Factory
+
+`createBackendAdapters()` MUST be at `packages/core/src/services/backend-adapters.ts`. Return type:
+
+```
+{
+  auth: (client: SupabaseClient) => AuthPort;
+  storage: (client: SupabaseClient) => StoragePort;
+  session: SessionPort;
+}
+```
+
+Selection env vars:
+- `BACKEND_AUTH_PROVIDER`: `"supabase"` (default) | `"custom"` (throws with guidance)
+- `BACKEND_STORAGE_PROVIDER`: `"supabase"` (default) | `"custom"` (throws with guidance)
+
+Session adapter: always `SupabaseSessionAdapter`. Requires `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — MUST throw if missing.
+
+`auth` and `storage` MUST be factory functions `(client) => Adapter` (NOT fully-constructed instances) because `SupabaseClient` is request-scoped.
+
+#### Scenario: Default factory (no env vars) returns Supabase adapters
+
+- GIVEN no `BACKEND_AUTH_PROVIDER` or `BACKEND_STORAGE_PROVIDER` set
+- WHEN `createBackendAdapters()` is called
+- THEN returns `{ auth: fn, storage: fn, session: SupabaseSessionAdapter }`
+- AND `auth(client)` returns a `SupabaseAuthAdapter`
+
+#### Scenario: Unknown BACKEND_AUTH_PROVIDER throws at call time
+
+- GIVEN `BACKEND_AUTH_PROVIDER=firebase` (unsupported in MVP)
+- WHEN `createBackendAdapters()` is called
+- THEN throws with message containing `"firebase"` and `"Supported values: \"supabase\""`
+
+#### Scenario: Missing Supabase URL throws descriptive error
+
+- GIVEN `NEXT_PUBLIC_SUPABASE_URL` is not set
+- WHEN `createBackendAdapters()` is called
+- THEN throws `"Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY"`
+
+### Requirement: auth-service.ts Migration (7 Function Signatures)
+
+All 7 functions in `packages/core/src/services/auth-service.ts` MUST change their first parameter from `SupabaseClient` to `AuthPort`. Function bodies become thin delegations to the adapter:
+
+| Function | Before | After |
+|----------|--------|-------|
+| `signInWithPasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signUpService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `signOutService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getCurrentPlatformUserService` | `(client: SupabaseClient)` | `(auth: AuthPort)` |
+| `getUserRoleService` | `(client: SupabaseClient, userId)` | `(auth: AuthPort, userId)` |
+| `requestPasswordResetService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+| `updatePasswordService` | `(client: SupabaseClient, input)` | `(auth: AuthPort, input)` |
+
+Service bodies MUST delegate to the adapter (e.g., `return auth.signInWithPassword(input)`). No Supabase SDK calls remain in service functions.
+
+#### Scenario: signInWithPasswordService delegates to AuthPort
+
+- GIVEN `auth.signInWithPassword` is a `vi.fn()` returning `{ success: true, data: { role: "admin" } }`
+- WHEN `signInWithPasswordService(auth, input)` is called
+- THEN calls `auth.signInWithPassword(input)` exactly once
+- AND returns `{ success: true, data: { role: "admin" } }`
+
+#### Scenario: No @supabase/supabase-js imports remain in service tests
+
+- GIVEN the rewritten `auth-service.test.ts`
+- WHEN linting checks imports
+- THEN no `@supabase/supabase-js` import exists in the test file
+
+### Requirement: Middleware Migration to SessionPort
+
+`ui/middleware.ts` MUST be updated to:
+1. Import `createBackendAdapters` from `@enterprise/core/services/backend-adapters`
+2. Call `createBackendAdapters()` at module level: `const { session: sessionPort } = createBackendAdapters()`
+3. Replace `updateSession(request, config)` with `sessionPort.refreshSession(request)`
+4. RETAIN `createMiddlewareClient` import for role resolution (DB query — not yet covered by a port)
+5. Include a comment: `// Role resolution still uses SupabaseClient for DB query. Removed when DatabasePort lands.`
+
+#### Scenario: Middleware uses SessionPort for session refresh
+
+- GIVEN `sessionPort.refreshSession` is a `vi.fn()` returning a `NextResponse`
+- WHEN `middleware(request)` is called
+- THEN `sessionPort.refreshSession(request)` is called before route guards
+- AND the existing role-based redirect logic remains functional
+
+### Requirement: Server Action Adapter Injection
+
+All 6 auth Server Actions in `ui/features/auth/actions.ts` MUST inject the adapter:
+1. Call `createBackendAdapters()` at module level: `const { auth: authFactory } = createBackendAdapters()`
+2. Per-request: `const client = await getServerClient(); const auth = authFactory(client)`
+3. Pass `auth` (not `client`) to each service function
+
+Actions covered: `signInAction`, the `signIn` helper, `signUpAction`, `signOutAction`, `forgotPasswordAction`, `updatePasswordAction`.
+
+#### Scenario: signInAction uses injected AuthPort
+
+- GIVEN `authFactory` returns a mock `AuthPort`
+- WHEN `signInAction(input)` is called
+- THEN calls `signInWithPasswordService(auth, input)` with the mock port — NOT with `SupabaseClient`
+
+### Requirement: Port-Mock Test Pattern
+
+The canonical port-mock helpers MUST be defined in the test files. No `@supabase/supabase-js` imports in service test files after migration.
+
+`createMockAuthPort()` returns an object with all 7 `AuthPort` methods as `vi.fn()`.
+`createMockStoragePort()` returns an object with all 6 `StoragePort` methods as `vi.fn()`.
+
+#### Scenario: createMockAuthPort used in auth-service tests
+
+- GIVEN `const auth = createMockAuthPort()`
+- WHEN `auth.signInWithPassword.mockResolvedValue({ success: true, data: { role: "admin" } })`
+- THEN `signInWithPasswordService(auth, input)` returns `{ success: true, data: { role: "admin" } }`
+- AND no Supabase SDK is imported in the test file
+
+---
+
+## Roadmap Fix
+
+### Requirement: Notifications Marked Done in Roadmap
+
+`docs/features/roadmap.md` MUST have Notifications (#10) status changed from `"Planned"` to `"Done"`.
+
+#### Scenario: Roadmap reflects Notifications as Done
+
+- GIVEN the updated `roadmap.md`
+- WHEN the file is read
+- THEN the row for feature #10 (Notifications) shows status `"Done"`

--- a/openspec/changes/brand-and-decoupling/tasks.md
+++ b/openspec/changes/brand-and-decoupling/tasks.md
@@ -31,12 +31,31 @@ B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
 
 ---
 
+## Reconciliation Status (2026-06-08)
+
+> The checkboxes below were desynced from the codebase. This block records ground
+> truth verified against `main` (commit `8bbbca8`). Checkboxes have been corrected
+> to match.
+
+| Track | Real status | Evidence |
+|-------|-------------|----------|
+| **PR-A** Roadmap fix | ✅ Done | `docs/features/roadmap.md` shows Notifications (#10) = "Done" |
+| **PR-C1** Ports + adapters + factory | ✅ Done (merged PR #116) | `packages/core/src/services/ports/*`, `adapters/*`, `backend-adapters.ts`, barrel exports in `services/index.ts` |
+| **PR-C2** Service + actions + middleware migration | ✅ Done | `auth-service.ts` uses `AuthPort` (7 fns); `ui/features/auth/actions.ts` + `ui/middleware.ts` use `createBackendAdapters()` |
+| **PR-C3** Test rewrite + env docs + migration guide | 🟡 Partial | Tests rewritten to `createMockAuthPort()` ✅. **Pending:** `.env.example` docs (verify), `docs/migrations/brand-and-decoupling-migration-guide.md` (missing) |
+| **PR-B1** Brand contracts + module + provider + layout | ❌ Not started | No `packages/ui/src/brand/` or `packages/ui/src/brands/` exists |
+| **PR-B2** BrandLogo + BrandFooter + E2E | ❌ Not started | — |
+
+**Remaining work in this change: Track B (Brand #14) + the C3 documentation tail.**
+
+---
+
 ## PR-A: Roadmap Fix
 
 ### Phase 1: Roadmap Update
 
-- [ ] A.1.1 Edit `docs/features/roadmap.md`: change Notifications (#10) status from `"Planned"` to `"Done"`
-- [ ] A.1.2 Verify: grep roadmap.md confirms `"Done"` on the Notifications row
+- [x] A.1.1 Edit `docs/features/roadmap.md`: change Notifications (#10) status from `"Planned"` to `"Done"`
+- [x] A.1.2 Verify: grep roadmap.md confirms `"Done"` on the Notifications row
 
 ---
 
@@ -44,49 +63,49 @@ B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
 
 ### Phase 1: Schema (RED → GREEN)
 
-- [x] B1.1.1 RED: Write `packages/contracts/src/schemas/__tests__/brand.test.ts` — 6 scenarios: valid full config passes, minimal config passes, invalid slug rejected at path `["slug"]`, missing nested field rejected, features non-boolean rejected, social.twitter invalid URL rejected
-- [x] B1.1.2 GREEN: Create `packages/contracts/src/schemas/brand.ts` — `brandLogoVariantSchema`, `brandLogoSchema`, `brandMetadataSchema`, `brandLegalSchema`, `brandSocialSchema`, `brandConfigSchema`; export types `BrandConfig`, `BrandLogoVariant`, `BrandLogo`, `BrandMetadata`, `BrandLegal`, `BrandSocial`
-- [x] B1.1.3 Export all brand schemas + types from `packages/contracts/src/index.ts`
-- [x] B1.1.4 Run vitest — all schema tests GREEN
+- [ ] B1.1.1 RED: Write `packages/contracts/src/schemas/__tests__/brand.test.ts` — 6 scenarios: valid full config passes, minimal config passes, invalid slug rejected at path `["slug"]`, missing nested field rejected, features non-boolean rejected, social.twitter invalid URL rejected
+- [ ] B1.1.2 GREEN: Create `packages/contracts/src/schemas/brand.ts` — `brandLogoVariantSchema`, `brandLogoSchema`, `brandMetadataSchema`, `brandLegalSchema`, `brandSocialSchema`, `brandConfigSchema`; export types `BrandConfig`, `BrandLogoVariant`, `BrandLogo`, `BrandMetadata`, `BrandLegal`, `BrandSocial`
+- [ ] B1.1.3 Export all brand schemas + types from `packages/contracts/src/index.ts`
+- [ ] B1.1.4 Run vitest — all schema tests GREEN
 
 ### Phase 2: Brand Registry (RED → GREEN)
 
-- [x] B1.2.1 RED: Write `packages/ui/src/brand/__tests__/registry.test.ts` — scenarios: duplicate slug throws, no brands throws on `getDefaultBrand()`, `getDefaultBrand()` returns `isDefault=true` brand, falls back to `"enterprise"` slug
-- [x] B1.2.2 GREEN: Create `packages/ui/src/brands/enterprise.brand.ts` — default enterprise brand config satisfying `brandConfigSchema`
-- [x] B1.2.3 GREEN: Create `packages/ui/src/brand/registry.ts` — `buildRegistry()`, `getAllBrands()`, `getBrandBySlug()`, `getDefaultBrand()`; pure helpers + lazy singleton; throws on duplicate slug or missing default
-- [x] B1.2.4 Run vitest — all registry tests GREEN
+- [ ] B1.2.1 RED: Write `packages/ui/src/brand/__tests__/registry.test.ts` — scenarios: duplicate slug throws, no brands throws on `getDefaultBrand()`, `getDefaultBrand()` returns `isDefault=true` brand, falls back to `"enterprise"` slug
+- [ ] B1.2.2 GREEN: Create `packages/ui/src/brands/enterprise.brand.ts` — default enterprise brand config satisfying `brandConfigSchema`
+- [ ] B1.2.3 GREEN: Create `packages/ui/src/brand/registry.ts` — `buildRegistry()`, `getAllBrands()`, `getBrandBySlug()`, `getDefaultBrand()`; pure helpers + lazy singleton; throws on duplicate slug or missing default
+- [ ] B1.2.4 Run vitest — all registry tests GREEN
 
 ### Phase 3: Brand Resolution (RED → GREEN)
 
-- [x] B1.3.1 RED: Write `packages/ui/src/brand/__tests__/resolve.test.ts` — scenarios: `BRAND_SLUG` forces brand, unknown `BRAND_SLUG` throws with available slugs, subdomain resolves, unrecognized subdomain warns+falls back, path prefix resolves, static asset paths produce no spurious warn
-- [x] B1.3.2 GREEN: Create `packages/ui/src/brand/resolve.ts` — `resolveBrand()` server-only function + `resolveBrandFromRegistry()` pure testable variant; priority chain: env → subdomain → path prefix → `getDefaultBrand()`; `console.warn` on unrecognized fallback
-- [x] B1.3.3 Run vitest — all resolve tests GREEN
+- [ ] B1.3.1 RED: Write `packages/ui/src/brand/__tests__/resolve.test.ts` — scenarios: `BRAND_SLUG` forces brand, unknown `BRAND_SLUG` throws with available slugs, subdomain resolves, unrecognized subdomain warns+falls back, path prefix resolves, static asset paths produce no spurious warn
+- [ ] B1.3.2 GREEN: Create `packages/ui/src/brand/resolve.ts` — `resolveBrand()` server-only function + `resolveBrandFromRegistry()` pure testable variant; priority chain: env → subdomain → path prefix → `getDefaultBrand()`; `console.warn` on unrecognized fallback
+- [ ] B1.3.3 Run vitest — all resolve tests GREEN
 
 ### Phase 4: BrandProvider + useBrand() (RED → GREEN)
 
-- [x] B1.4.1 RED: Write `packages/ui/src/brand/__tests__/provider.test.ts` — scenarios: `useBrand()` returns brand inside provider, `useBrand()` throws outside provider with `<BrandProvider>` guidance, ThemeProvider receives derived `defaultMode` from `themeRef`
-- [x] B1.4.2 GREEN: Create `packages/ui/src/brand/context.ts` — `BrandContext = createContext<BrandContextValue | null>(null)`
-- [x] B1.4.3 GREEN: Create `packages/ui/src/brand/provider.tsx` — `"use client"`, `BrandProvider` wraps `ThemeProvider` deriving mode from `themeRef`, `useBrand()` hook
-- [x] B1.4.4 Run vitest — all provider tests GREEN
+- [ ] B1.4.1 RED: Write `packages/ui/src/brand/__tests__/provider.test.ts` — scenarios: `useBrand()` returns brand inside provider, `useBrand()` throws outside provider with `<BrandProvider>` guidance, ThemeProvider receives derived `defaultMode` from `themeRef`
+- [ ] B1.4.2 GREEN: Create `packages/ui/src/brand/context.ts` — `BrandContext = createContext<BrandContextValue | null>(null)`
+- [ ] B1.4.3 GREEN: Create `packages/ui/src/brand/provider.tsx` — `"use client"`, `BrandProvider` wraps `ThemeProvider` deriving mode from `themeRef`, `useBrand()` hook
+- [ ] B1.4.4 Run vitest — all provider tests GREEN
 
 ### Phase 5: generateBrandMetadata() (RED → GREEN)
 
-- [x] B1.5.1 RED: Write `packages/ui/src/brand/__tests__/metadata.test.ts` — scenario: all fields mapped correctly; `openGraph.images = []` when `ogImage` falsy
-- [x] B1.5.2 GREEN: Create `packages/ui/src/brand/metadata.ts` — `generateBrandMetadata(brand: BrandConfig): Metadata`; returns `title.template`, `title.default`, `description`, `icons.icon`, `openGraph.images`
-- [x] B1.5.3 Run vitest — metadata test GREEN
+- [ ] B1.5.1 RED: Write `packages/ui/src/brand/__tests__/metadata.test.ts` — scenario: all fields mapped correctly; `openGraph.images = []` when `ogImage` falsy
+- [ ] B1.5.2 GREEN: Create `packages/ui/src/brand/metadata.ts` — `generateBrandMetadata(brand: BrandConfig): Metadata`; returns `title.template`, `title.default`, `description`, `icons.icon`, `openGraph.images`
+- [ ] B1.5.3 Run vitest — metadata test GREEN
 
 ### Phase 6: Layout Integration
 
-- [x] B1.6.1 Modify `ui/app/layout.tsx`: convert static `metadata` export to `async generateMetadata()` calling `resolveBrand()` + `generateBrandMetadata()`
-- [x] B1.6.2 Wrap `children` with `<BrandProvider brand={brand}>` in `RootLayout`; preserve font `className` on `<html>`, preserve `<Toaster>` as sibling (not inside BrandProvider)
-- [x] B1.6.3 Run `pnpm typecheck` from root — no errors
+- [ ] B1.6.1 Modify `ui/app/layout.tsx`: convert static `metadata` export to `async generateMetadata()` calling `resolveBrand()` + `generateBrandMetadata()`
+- [ ] B1.6.2 Wrap `children` with `<BrandProvider brand={brand}>` in `RootLayout`; preserve font `className` on `<html>`, preserve `<Toaster>` as sibling (not inside BrandProvider)
+- [ ] B1.6.3 Run `pnpm typecheck` from root — no errors
 
 ### Phase 7: Barrel Export (packages/ui)
 
-- [x] B1.7.1 Create `packages/ui/src/brand/index.ts` — re-exports `BrandProvider`, `useBrand`, `BrandContext`
-- [x] B1.7.2 Add subpath exports to `packages/ui/package.json`: `"./brand/provider"`, `"./brand/context"`, `"./brand/resolve"`, `"./brand/registry"`, `"./brand/metadata"`
-- [x] B1.7.3 Add brand barrel to `packages/ui/src/index.ts` (or existing barrel entry point)
-- [x] B1.7.4 Run `pnpm typecheck` + `pnpm lint` — clean
+- [ ] B1.7.1 Create `packages/ui/src/brand/index.ts` — re-exports `BrandProvider`, `useBrand`, `BrandContext`
+- [ ] B1.7.2 Add subpath exports to `packages/ui/package.json`: `"./brand/provider"`, `"./brand/context"`, `"./brand/resolve"`, `"./brand/registry"`, `"./brand/metadata"`
+- [ ] B1.7.3 Add brand barrel to `packages/ui/src/index.ts` (or existing barrel entry point)
+- [ ] B1.7.4 Run `pnpm typecheck` + `pnpm lint` — clean
 
 ---
 
@@ -121,33 +140,33 @@ B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
 
 ### Phase 1: Port Interfaces (RED → GREEN)
 
-- [ ] C1.1.1 RED: Write `packages/core/src/services/ports/__tests__/auth-port.test.ts` — scenarios: mock satisfies `AuthPort` interface without SDK import; `getUser` mock returns `null` (not error) for anonymous
-- [ ] C1.1.2 GREEN: Create `packages/core/src/services/ports/auth-port.ts` — `AuthPort` interface; 7 methods with correct `ServiceResult<T>` return types; no SDK imports
-- [ ] C1.1.3 RED: Write `packages/core/src/services/ports/__tests__/storage-port.test.ts` — scenarios: mock satisfies `StoragePort` interface; delete accepts multiple paths
-- [ ] C1.1.4 GREEN: Create `packages/core/src/services/ports/storage-port.ts` — `StoragePort` interface; 6 methods + supporting types exported (`StorageUploadResult`, `StorageSignedUrlResult`, `StoragePublicUrlResult`, `StorageFileEntry`)
-- [ ] C1.1.5 GREEN: Create `packages/core/src/services/ports/session-port.ts` — `SessionPort` interface; single `refreshSession(request: NextRequest): Promise<NextResponse>`
-- [ ] C1.1.6 Run vitest — all port tests GREEN
+- [x] C1.1.1 RED: Write `packages/core/src/services/ports/__tests__/auth-port.test.ts` — scenarios: mock satisfies `AuthPort` interface without SDK import; `getUser` mock returns `null` (not error) for anonymous
+- [x] C1.1.2 GREEN: Create `packages/core/src/services/ports/auth-port.ts` — `AuthPort` interface; 7 methods with correct `ServiceResult<T>` return types; no SDK imports
+- [x] C1.1.3 RED: Write `packages/core/src/services/ports/__tests__/storage-port.test.ts` — scenarios: mock satisfies `StoragePort` interface; delete accepts multiple paths
+- [x] C1.1.4 GREEN: Create `packages/core/src/services/ports/storage-port.ts` — `StoragePort` interface; 6 methods + supporting types exported (`StorageUploadResult`, `StorageSignedUrlResult`, `StoragePublicUrlResult`, `StorageFileEntry`)
+- [x] C1.1.5 GREEN: Create `packages/core/src/services/ports/session-port.ts` — `SessionPort` interface; single `refreshSession(request: NextRequest): Promise<NextResponse>`
+- [x] C1.1.6 Run vitest — all port tests GREEN
 
 ### Phase 2: Supabase Adapters (RED → GREEN)
 
-- [ ] C1.2.1 RED: Write `packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts` — scenarios: `signInWithPassword` maps Supabase error to `INVALID_CREDENTIALS`; `getUserRole` ignores `PGRST116` and returns `{ role: "guest" }`
-- [ ] C1.2.2 GREEN: Create `packages/core/src/services/adapters/supabase-auth-adapter.ts` — `SupabaseAuthAdapter implements AuthPort`; constructor `(client: SupabaseClient)`; maps all 7 methods; all error codes listed in spec
-- [ ] C1.2.3 RED: Write `packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts` — scenarios: `upload` returns `path+fullPath`; `getPublicUrl` always succeeds (no error path)
-- [ ] C1.2.4 GREEN: Create `packages/core/src/services/adapters/supabase-storage-adapter.ts` — `SupabaseStorageAdapter implements StoragePort`; constructor `(client: SupabaseClient)`
-- [ ] C1.2.5 GREEN: Create `packages/core/src/services/adapters/supabase-session-adapter.ts` — `SupabaseSessionAdapter implements SessionPort`; delegates `refreshSession()` to `updateSession()`; constructor `(supabaseUrl, supabaseAnonKey)`
-- [ ] C1.2.6 Run vitest — all adapter tests GREEN
+- [x] C1.2.1 RED: Write `packages/core/src/services/adapters/__tests__/supabase-auth-adapter.test.ts` — scenarios: `signInWithPassword` maps Supabase error to `INVALID_CREDENTIALS`; `getUserRole` ignores `PGRST116` and returns `{ role: "guest" }`
+- [x] C1.2.2 GREEN: Create `packages/core/src/services/adapters/supabase-auth-adapter.ts` — `SupabaseAuthAdapter implements AuthPort`; constructor `(client: SupabaseClient)`; maps all 7 methods; all error codes listed in spec
+- [x] C1.2.3 RED: Write `packages/core/src/services/adapters/__tests__/supabase-storage-adapter.test.ts` — scenarios: `upload` returns `path+fullPath`; `getPublicUrl` always succeeds (no error path)
+- [x] C1.2.4 GREEN: Create `packages/core/src/services/adapters/supabase-storage-adapter.ts` — `SupabaseStorageAdapter implements StoragePort`; constructor `(client: SupabaseClient)`
+- [x] C1.2.5 GREEN: Create `packages/core/src/services/adapters/supabase-session-adapter.ts` — `SupabaseSessionAdapter implements SessionPort`; delegates `refreshSession()` to `updateSession()`; constructor `(supabaseUrl, supabaseAnonKey)`
+- [x] C1.2.6 Run vitest — all adapter tests GREEN
 
 ### Phase 3: Factory (RED → GREEN)
 
-- [ ] C1.3.1 RED: Write `packages/core/src/services/__tests__/backend-adapters.test.ts` — scenarios: default returns Supabase adapters; unknown provider throws with guidance; missing `NEXT_PUBLIC_SUPABASE_URL` throws descriptive error
-- [ ] C1.3.2 GREEN: Create `packages/core/src/services/backend-adapters.ts` — `createBackendAdapters()` returning `{ auth: (client) => AuthPort, storage: (client) => StoragePort, session: SessionPort }`; reads `BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- [ ] C1.3.3 Run vitest — factory tests GREEN
+- [x] C1.3.1 RED: Write `packages/core/src/services/__tests__/backend-adapters.test.ts` — scenarios: default returns Supabase adapters; unknown provider throws with guidance; missing `NEXT_PUBLIC_SUPABASE_URL` throws descriptive error
+- [x] C1.3.2 GREEN: Create `packages/core/src/services/backend-adapters.ts` — `createBackendAdapters()` returning `{ auth: (client) => AuthPort, storage: (client) => StoragePort, session: SessionPort }`; reads `BACKEND_AUTH_PROVIDER`, `BACKEND_STORAGE_PROVIDER`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- [x] C1.3.3 Run vitest — factory tests GREEN
 
 ### Phase 4: Exports
 
-- [ ] C1.4.1 Export `AuthPort`, `StoragePort`, `SessionPort` from `packages/core/src/services/index.ts` (subpath export)
-- [ ] C1.4.2 Export `createBackendAdapters` from `packages/core/src/services/index.ts`
-- [ ] C1.4.3 Run `pnpm typecheck` + `pnpm lint` — clean
+- [x] C1.4.1 Export `AuthPort`, `StoragePort`, `SessionPort` from `packages/core/src/services/index.ts` (subpath export)
+- [x] C1.4.2 Export `createBackendAdapters` from `packages/core/src/services/index.ts`
+- [x] C1.4.3 Run `pnpm typecheck` + `pnpm lint` — clean
 
 ---
 
@@ -155,23 +174,23 @@ B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
 
 ### Phase 1: auth-service Migration
 
-- [ ] C2.1.1 Modify `packages/core/src/services/auth-service.ts`: change all 7 function signatures — first param `SupabaseClient` → `AuthPort`; bodies become thin delegations `return auth.method(input)`; remove all `@supabase/supabase-js` SDK calls from service functions
-- [ ] C2.1.2 Run `pnpm typecheck` — verify no SDK imports remain in service functions
+- [x] C2.1.1 Modify `packages/core/src/services/auth-service.ts`: change all 7 function signatures — first param `SupabaseClient` → `AuthPort`; bodies become thin delegations `return auth.method(input)`; remove all `@supabase/supabase-js` SDK calls from service functions
+- [x] C2.1.2 Run `pnpm typecheck` — verify no SDK imports remain in service functions
 
 ### Phase 2: Server Actions Migration
 
-- [ ] C2.2.1 Modify `ui/features/auth/actions.ts`: add `createBackendAdapters()` at module level; add per-request `authFactory(client)` call inside each action; replace `client` → `auth` (AuthPort) in service function calls for all 6 Server Actions
-- [ ] C2.2.2 Run `pnpm typecheck` — actions file clean
+- [x] C2.2.1 Modify `ui/features/auth/actions.ts`: add `createBackendAdapters()` at module level; add per-request `authFactory(client)` call inside each action; replace `client` → `auth` (AuthPort) in service function calls for all 6 Server Actions
+- [x] C2.2.2 Run `pnpm typecheck` — actions file clean
 
 ### Phase 3: Middleware Migration
 
-- [ ] C2.3.1 Modify `ui/middleware.ts`: import `createBackendAdapters`; call at module level to get `sessionPort`; replace `updateSession(request)` call with `sessionPort.refreshSession(request)`; retain `createMiddlewareClient` for `getUserRoleService` DB query; add comment `// TODO: DatabasePort — see brand-and-decoupling migration guide`
-- [ ] C2.3.2 Run `pnpm typecheck` + `pnpm lint` — middleware clean
+- [x] C2.3.1 Modify `ui/middleware.ts`: import `createBackendAdapters`; call at module level to get `sessionPort`; replace `updateSession(request)` call with `sessionPort.refreshSession(request)`; retain `createMiddlewareClient` for `getUserRoleService` DB query; add comment `// TODO: DatabasePort — see brand-and-decoupling migration guide`
+- [x] C2.3.2 Run `pnpm typecheck` + `pnpm lint` — middleware clean
 
 ### Phase 4: Integration Verify
 
-- [ ] C2.4.1 Run full `pnpm test` — all existing auth tests pass (may be failing until C3 rewrite — acceptable at this PR stage; document in PR description)
-- [ ] C2.4.2 Run `pnpm typecheck` from root — zero errors
+- [x] C2.4.1 Run full `pnpm test` — all existing auth tests pass (may be failing until C3 rewrite — acceptable at this PR stage; document in PR description)
+- [x] C2.4.2 Run `pnpm typecheck` from root — zero errors
 
 ---
 
@@ -179,13 +198,13 @@ B-track (B1→B2) and C-track (C1→C2→C3) run in parallel after PR-A merges.
 
 ### Phase 1: Port Mock Helpers (RED → GREEN)
 
-- [ ] C3.1.1 Create `packages/core/src/services/__tests__/mocks/auth-port.mock.ts` — `createMockAuthPort()` returning object with 7 `vi.fn()` stubs; zero `@supabase/supabase-js` imports
-- [ ] C3.1.2 Create `packages/core/src/services/__tests__/mocks/storage-port.mock.ts` — `createMockStoragePort()` returning object with 6 `vi.fn()` stubs
+- [x] C3.1.1 Create `packages/core/src/services/__tests__/mocks/auth-port.mock.ts` — `createMockAuthPort()` returning object with 7 `vi.fn()` stubs; zero `@supabase/supabase-js` imports
+- [x] C3.1.2 Create `packages/core/src/services/__tests__/mocks/storage-port.mock.ts` — `createMockStoragePort()` returning object with 6 `vi.fn()` stubs
 
 ### Phase 2: auth-service Test Rewrite (RED → GREEN)
 
-- [ ] C3.2.1 Rewrite `packages/core/src/services/__tests__/auth-service.test.ts`: use `createMockAuthPort()` in all test cases; no `@supabase/supabase-js` import in test file; verify `signInWithPasswordService` delegates to `auth.signInWithPassword`; verify all 7 functions delegate correctly
-- [ ] C3.2.2 Run vitest — all auth-service tests GREEN
+- [x] C3.2.1 Rewrite `packages/core/src/services/__tests__/auth-service.test.ts`: use `createMockAuthPort()` in all test cases; no `@supabase/supabase-js` import in test file; verify `signInWithPasswordService` delegates to `auth.signInWithPassword`; verify all 7 functions delegate correctly
+- [x] C3.2.2 Run vitest — all auth-service tests GREEN
 
 ### Phase 3: Env Docs
 


### PR DESCRIPTION
## Summary

- Brings the OpenSpec change folder in line with what is actually on `main`. The tracked `brand-and-decoupling/tasks.md` had **inverted** checkboxes (claimed Brand done / decoupling pending — the reverse of reality), and the `notifications` change had shipped long ago but was never archived.
- Docs-only. No code changes.

## Changes

| File | Change |
|------|--------|
| `openspec/changes/archive/2026-06-08-notifications/**` | Archive the shipped Notifications change (moved from `changes/notifications/`) + add `archive-report.md` |
| `openspec/changes/brand-and-decoupling/{proposal,design,spec}.md` | Commit planning docs that were never tracked |
| `openspec/changes/brand-and-decoupling/tasks.md` | Correct checkboxes to ground truth + add Reconciliation Status block |

## Ground truth recorded

- **Track A** (roadmap fix): ✅ Done — roadmap shows Notifications = "Done"
- **Track C** (#16 decoupling): ✅ Done & merged (PR #116) — ports, adapters, factory, `auth-service` on `AuthPort`, actions/middleware on `createBackendAdapters()`, tests on `createMockAuthPort()`
- **Track B** (#14 brand): ❌ Not started — no `packages/ui/src/brand/` exists. This is the remaining work.
- **C3 docs tail**: 🟡 `.env.example` docs (verify) + migration guide (missing)

## Verification

- [x] Docs/OpenSpec-only diff — no source, build, or dependency changes
- [x] `git diff main...HEAD --stat` scoped to `openspec/` only
- [ ] N/A `pnpm install --frozen-lockfile` / `typecheck` / `lint` / `test` — no code touched